### PR TITLE
feat: read_sequence_captions, rename_project_item; fix duplicate_sequence rename (#15)

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -867,6 +867,21 @@ export class PremiereProTools {
           captionFormat: z.string().optional().describe('Caption format (e.g., "Subtitle Default")')
         })
       },
+      {
+        name: 'read_sequence_captions',
+        description: 'Reads all caption tracks of a sequence and returns each caption clip as { start, end, text }, with timestamps in seconds. Use this to find the timecodes of specific spoken phrases.',
+        inputSchema: z.object({
+          sequenceId: z.string().optional().describe('Optional sequence ID. Defaults to the active sequence.')
+        })
+      },
+      {
+        name: 'rename_project_item',
+        description: 'Renames a project item (sequence, bin, clip) by setting its name. Use this when duplicate_sequence does not propagate the new name to the project panel.',
+        inputSchema: z.object({
+          projectItemId: z.string().describe('The ID of the project item to rename'),
+          newName: z.string().describe('The new name for the project item')
+        })
+      },
 
       // Subclip
       {
@@ -1114,6 +1129,10 @@ export class PremiereProTools {
           return await this.duplicateSequence(args.sequenceId, args.newName);
         case 'delete_sequence':
           return await this.deleteSequence(args.sequenceId);
+        case 'read_sequence_captions':
+          return await this.readSequenceCaptions(args.sequenceId);
+        case 'rename_project_item':
+          return await this.renameProjectItem(args.projectItemId, args.newName);
 
         // Timeline Operations
         case 'add_to_timeline':
@@ -2107,23 +2126,167 @@ export class PremiereProTools {
   }
 
   private async duplicateSequence(sequenceId: string, newName: string): Promise<any> {
+    const safeName = JSON.stringify(newName);
     const script = `
       try {
-        var originalSeq = __findSequence("${sequenceId}");
+        var originalSeq = __findSequence(${JSON.stringify(sequenceId)});
         if (!originalSeq) return JSON.stringify({ success: false, error: "Sequence not found" });
+
         var newSeq = originalSeq.clone();
-        newSeq.name = "${newName}";
+        newSeq.name = ${safeName};
+
+        // Sequence.name does NOT propagate to the project panel — find and rename
+        // the matching ProjectItem so the rename is visible to the user and to
+        // future MCP calls.
+        function __findItemForSequence(parent, seqId) {
+          if (!parent || !parent.children) return null;
+          for (var i = 0; i < parent.children.numItems; i++) {
+            var item = parent.children[i];
+            if (!item) continue;
+            try {
+              var seq = item.getSequence && item.getSequence();
+              if (seq && seq.sequenceID === seqId) return item;
+            } catch (_) { /* not a sequence-bearing item */ }
+            if (item.type === 2 /* BIN */) {
+              var nested = __findItemForSequence(item, seqId);
+              if (nested) return nested;
+            }
+          }
+          return null;
+        }
+
+        var renamedAtItem = false;
+        var newItem = __findItemForSequence(app.project.rootItem, newSeq.sequenceID);
+        if (newItem) {
+          try {
+            newItem.name = ${safeName};
+            renamedAtItem = true;
+          } catch (_) { /* fall through */ }
+        }
+
         return JSON.stringify({
           success: true,
-          originalSequenceId: "${sequenceId}",
+          originalSequenceId: ${JSON.stringify(sequenceId)},
           newSequenceId: newSeq.sequenceID,
-          newName: "${newName}"
+          newName: ${safeName},
+          newProjectItemId: newItem ? newItem.nodeId : null,
+          renamedAtProjectItem: renamedAtItem
         });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
       }
     `;
 
+    return await this.bridge.executeScript(script);
+  }
+
+  private async renameProjectItem(projectItemId: string, newName: string): Promise<any> {
+    const safeName = JSON.stringify(newName);
+    const script = `
+      try {
+        var item = __findProjectItem(${JSON.stringify(projectItemId)});
+        if (!item) return JSON.stringify({ success: false, error: "Project item not found" });
+        var oldName = item.name;
+        item.name = ${safeName};
+        return JSON.stringify({
+          success: true,
+          projectItemId: ${JSON.stringify(projectItemId)},
+          oldName: oldName,
+          newName: ${safeName}
+        });
+      } catch (e) {
+        return JSON.stringify({ success: false, error: e.toString() });
+      }
+    `;
+    return await this.bridge.executeScript(script);
+  }
+
+  private async readSequenceCaptions(sequenceId?: string): Promise<any> {
+    const seqArg = sequenceId ? JSON.stringify(sequenceId) : 'null';
+    const script = `
+      try {
+        var sequence = ${seqArg} ? __findSequence(${seqArg}) : null;
+        if (!sequence) sequence = app.project.activeSequence;
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found" });
+
+        // Premiere caption tracks live alongside video/audio tracks. Different
+        // Premiere versions expose them differently:
+        //   - sequence.getCaptionTracks() (newer)
+        //   - sequence.captionTracks (some builds)
+        //   - sequence.videoTracks[i] with isCaptioning style flag
+        // Try in that order, return whatever yields {start, end, text} clips.
+
+        var tracks = [];
+        try {
+          if (sequence.getCaptionTracks) {
+            tracks = sequence.getCaptionTracks();
+          } else if (sequence.captionTracks) {
+            tracks = sequence.captionTracks;
+          }
+        } catch (_) { /* fall through to track scan */ }
+
+        // Fallback: scan video tracks for caption clip data
+        if ((!tracks || tracks.length === 0) && sequence.videoTracks) {
+          for (var v = 0; v < sequence.videoTracks.numTracks; v++) {
+            var t = sequence.videoTracks[v];
+            if (t && (t.isCaption || t.captionTrack || (t.name && /caption/i.test(t.name)))) {
+              tracks.push(t);
+            }
+          }
+        }
+
+        var trackCount = tracks ? tracks.length : 0;
+        var output = [];
+
+        for (var i = 0; i < trackCount; i++) {
+          var trk = tracks[i];
+          if (!trk) continue;
+          var clips = trk.clips || trk.captions || [];
+          var clipCount = clips.numItems !== undefined ? clips.numItems : (clips.length || 0);
+          for (var c = 0; c < clipCount; c++) {
+            var clip = clips[c];
+            if (!clip) continue;
+            var startSec = null;
+            var endSec = null;
+            try {
+              if (clip.start && clip.start.seconds !== undefined) startSec = clip.start.seconds;
+              else if (clip.start && clip.start.ticks) startSec = parseFloat(clip.start.ticks) / 254016000000.0;
+              else if (typeof clip.startTime === 'number') startSec = clip.startTime;
+            } catch (_) {}
+            try {
+              if (clip.end && clip.end.seconds !== undefined) endSec = clip.end.seconds;
+              else if (clip.end && clip.end.ticks) endSec = parseFloat(clip.end.ticks) / 254016000000.0;
+              else if (typeof clip.endTime === 'number') endSec = clip.endTime;
+            } catch (_) {}
+
+            var text = "";
+            try {
+              if (typeof clip.text === 'string') text = clip.text;
+              else if (clip.captionText) text = clip.captionText;
+              else if (clip.name) text = clip.name;
+            } catch (_) {}
+
+            output.push({
+              trackIndex: i,
+              start: startSec,
+              end: endSec,
+              text: text
+            });
+          }
+        }
+
+        return JSON.stringify({
+          success: true,
+          sequenceId: sequence.sequenceID,
+          sequenceName: sequence.name,
+          trackCount: trackCount,
+          captionCount: output.length,
+          captions: output
+        });
+      } catch (e) {
+        return JSON.stringify({ success: false, error: e.toString() });
+      }
+    `;
     return await this.bridge.executeScript(script);
   }
 


### PR DESCRIPTION
## Summary

- Adds `read_sequence_captions` so MCP callers can find timecodes of spoken phrases directly from a sequence's caption tracks (no Whisper / manual SRT exports needed).
- Adds `rename_project_item` so callers can rename any project item (sequence, bin, clip) standalone — useful as a recovery path when a duplicate lands with the wrong name.
- Patches `duplicate_sequence` to also rename the matching `ProjectItem` after `clone()`, which is what the project panel actually surfaces. Closes #15.

## Why

I'm using the MCP server to assemble 15-second ad cuts from a finished credibility-clips project. Two things bit me:

1. **Rename doesn't reach the project panel.** `Sequence.name` assignment after `clone()` only renames the in-memory Sequence object. The new project item retains the auto-suffixed `<original> Copy` name, so `list_sequences`, `move_item_to_bin`, and any human looking at the bin all see the wrong name. (Issue #15.)

2. **No way to read existing captions** off a sequence. The server can `create_caption_track` (write) but offers no read path, so callers can't use the captions Premiere already has (e.g., from a real captions track populated via Speech-to-Text or an imported SRT) to find a target phrase's in/out timecodes.

## Changes

### `read_sequence_captions`

```ts
{
  name: 'read_sequence_captions',
  description: 'Reads all caption tracks of a sequence and returns each caption clip as { start, end, text }, with timestamps in seconds.',
  inputSchema: z.object({
    sequenceId: z.string().optional()  // defaults to active sequence
  })
}
```

Implementation handles three places different Premiere builds expose caption tracks (`sequence.getCaptionTracks()`, `sequence.captionTracks`, plus a `videoTracks` scan fallback for older builds where caption tracks appear as a video-track variant) and the two ways caption clips encode time (`seconds` property vs `ticks`). Returns:

```json
{
  "success": true,
  "sequenceId": "...",
  "sequenceName": "...",
  "trackCount": 1,
  "captionCount": 47,
  "captions": [
    { "trackIndex": 0, "start": 0.0, "end": 0.34, "text": "I think it comes down" },
    ...
  ]
}
```

### Scope: what `read_sequence_captions` does NOT cover

The tool reads **real Premiere caption tracks** via the documented APIs. It does **not** read text rendered onto video tracks via Motion Graphics Templates (MOGRTs) — for example sequences edited with Captioneer or "9•16 Typewriter Subtitles" style MOGRTs, where the on-screen captions are baked into video clips on V3/V4/V5 rather than living in a Premiere captions track.

If a sequence shows on-screen subtitles but `read_sequence_captions` returns `trackCount: 0`, the captions are MOGRT-rendered text overlays, not a queryable caption track. To use the API path, the sequence needs a real captions track (Window > Text > Captions, then Transcribe Sequence or import SRT). For MOGRT-only content, callers fall back to Whisper / a manual SRT export from Premiere.

This is a Premiere ExtendScript surface limitation, not the tool's behaviour — MOGRT text layers aren't exposed as caption clips. Worth knowing for documentation.

### `rename_project_item`

Calls `projectItem.name = newName` on a resolved `ProjectItem`. Returns old + new name.

### `duplicate_sequence` rename fix

After `originalSeq.clone()`, walks `app.project.rootItem` recursively to find the project item whose `getSequence().sequenceID` matches the new sequence, then renames via `item.name = newName`. Returns `renamedAtProjectItem: true|false` so callers can detect a fallback. Falls back to the old `newSeq.name = newName` write if no matching item is found.

## Compatibility

- Purely additive aside from `duplicateSequence`, which preserves the previous behaviour as a fallback.
- All new ExtendScript wrapped in try/catch with success/error JSON.
- No new dependencies.
- Tested against Premiere Pro 26.0 (Beta) on macOS with a real working project. `npm run build` passes.

## Tested

- `duplicate_sequence` on a finished sequence: project panel now shows the requested `newName`, not `<original> Copy`. `list_sequences` returns the correct name. ✓
- `rename_project_item` on existing `<original> Copy` items: rename takes immediately, visible in project panel. ✓
- `read_sequence_captions` on a sequence with a real caption track: returns word-level captions with `start` / `end` in seconds matching the visible captions to the frame. ✓
- `read_sequence_captions` on a sequence with **only** MOGRT-rendered captions (no caption track): correctly returns `trackCount: 0, captionCount: 0` — the captions live on video tracks, not a caption track, so there's nothing for the API to read. Documented this in the scope note above. ✓

## Closes

Closes #15.