### PR TITLE
Fix open project and sequence clip issues

### DIFF
--- a/cep-plugin/bridge-cep.js
+++ b/cep-plugin/bridge-cep.js
@@ -197,7 +197,21 @@
             }
 
             var fullScript = EXTENDSCRIPT_COMPAT_HELPERS + '\n' + script;
+            var settled = false;
+            var timeoutMs = 45000;
+            var timeoutId = setTimeout(function() {
+                if (settled) return;
+                settled = true;
+                callback(new Error(
+                    'ExtendScript execution timed out after ' + timeoutMs + 'ms. ' +
+                    'Premiere Pro or the CEP scripting host did not return a result.'
+                ));
+            }, timeoutMs);
+
             this.csInterface.evalScript(fullScript, function(result) {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeoutId);
                 self.log('EvalScript result: ' + result, 'info');
 
                 if (result === 'EvalScript error.' || result === 'EvalScript error') {

--- a/src/__tests__/bridge/index.test.ts
+++ b/src/__tests__/bridge/index.test.ts
@@ -105,6 +105,61 @@ describe('PremiereProBridge', () => {
     expect(result.id).toBe('item-123');
   });
 
+  it('creates projects using a concrete .prproj path and verifies activation', async () => {
+    const bridge = new PremiereProBridge();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.access.mockRejectedValue(new Error('Not found'));
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.readFile.mockResolvedValue(JSON.stringify({
+      success: false,
+      error: 'Premiere Pro did not create or activate the requested project',
+      projectPath: '/tmp/projects/Test.prproj'
+    }));
+    mockFs.unlink.mockResolvedValue(undefined);
+
+    await bridge.initialize();
+    const result: any = await bridge.createProject('Test', '/tmp/projects/');
+
+    expect(result.success).toBe(false);
+    expect(result.projectPath).toBe('/tmp/projects/Test.prproj');
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json',
+      expect.stringContaining('app.newProject(projectPath)')
+    );
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json',
+      expect.stringContaining('Premiere Pro did not create or activate the requested project')
+    );
+  });
+
+  it('opens projects only after verifying the requested path became active', async () => {
+    const bridge = new PremiereProBridge();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.access.mockRejectedValue(new Error('Not found'));
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.readFile.mockResolvedValue(JSON.stringify({
+      success: false,
+      error: 'Premiere Pro did not activate the requested project',
+      projectPath: '/tmp/projects/Target.prproj',
+      actualPath: '/tmp/projects/AlreadyOpen.prproj'
+    }));
+    mockFs.unlink.mockResolvedValue(undefined);
+
+    await bridge.initialize();
+    const result: any = await bridge.openProject('/tmp/projects/Target.prproj');
+
+    expect(result.success).toBe(false);
+    expect(result.actualPath).toBe('/tmp/projects/AlreadyOpen.prproj');
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json',
+      expect.stringContaining('app.openDocument(projectPath)')
+    );
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json',
+      expect.stringContaining('Premiere Pro did not activate the requested project')
+    );
+  });
+
   it('does not delete externally managed temp directories during cleanup', async () => {
     const bridge = new PremiereProBridge();
     mockFs.mkdir.mockResolvedValue(undefined);

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -70,6 +70,40 @@ describe('PremiereProTools', () => {
   });
 
   describe('bridge-backed wrappers', () => {
+    it('surfaces create_project bridge failures instead of claiming success', async () => {
+      mockBridge.createProject = jest.fn().mockResolvedValue({
+        success: false,
+        error: 'Premiere Pro did not create or activate the requested project',
+        projectPath: '/tmp/Test.prproj'
+      } as any);
+
+      const result = await tools.executeTool('create_project', {
+        name: 'Test',
+        location: '/tmp'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('did not create');
+      expect(result.projectPath).toBe('/tmp/Test.prproj');
+    });
+
+    it('surfaces open_project bridge failures instead of claiming success', async () => {
+      mockBridge.openProject = jest.fn().mockResolvedValue({
+        success: false,
+        error: 'Premiere Pro did not activate the requested project',
+        projectPath: '/tmp/Target.prproj',
+        actualPath: '/tmp/AlreadyOpen.prproj'
+      } as any);
+
+      const result = await tools.executeTool('open_project', {
+        path: '/tmp/Target.prproj'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('did not activate');
+      expect(result.actualPath).toBe('/tmp/AlreadyOpen.prproj');
+    });
+
     it('passes through successful imports', async () => {
       mockBridge.importMedia = jest.fn().mockResolvedValue({
         success: true,
@@ -207,6 +241,32 @@ describe('PremiereProTools', () => {
 
       expect(mockBridge.executeScript).toHaveBeenCalled();
       expect(result.success).toBe(true);
+    });
+
+    it('looks up clip properties in the requested sequence', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true, properties: {} });
+
+      const result = await tools.executeTool('get_clip_properties', {
+        clipId: 'clip-123',
+        sequenceId: 'seq-456'
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockBridge.executeScript).toHaveBeenCalledWith(expect.stringContaining('__findClip("clip-123", "seq-456")'));
+    });
+
+    it('removes clips from the requested sequence', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true, clipId: 'clip-123' });
+
+      const result = await tools.executeTool('remove_from_timeline', {
+        clipId: 'clip-123',
+        sequenceId: 'seq-456',
+        deleteMode: 'lift'
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockBridge.executeScript).toHaveBeenCalledWith(expect.stringContaining('__findClip("clip-123", "seq-456")'));
+      expect(mockBridge.executeScript).toHaveBeenCalledWith(expect.stringContaining('var isRipple = "lift" === "ripple";'));
     });
   });
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -49,31 +49,52 @@ function __mcpStringify(value) {
 if (typeof JSON === 'undefined') { JSON = {}; }
 if (typeof JSON.stringify !== 'function') { JSON.stringify = __mcpStringify; }
 function __findSequence(id) {
+  if (!app.project || !app.project.sequences) return null;
   for (var i = 0; i < app.project.sequences.numSequences; i++) {
     if (app.project.sequences[i].sequenceID === id) return app.project.sequences[i];
   }
   return null;
 }
-function __findClip(nodeId) {
-  var seq = app.project.activeSequence;
+function __findClipInSequence(seq, nodeId) {
   if (!seq) return null;
   for (var t = 0; t < seq.videoTracks.numTracks; t++) {
     var track = seq.videoTracks[t];
     for (var c = 0; c < track.clips.numItems; c++) {
       if (track.clips[c].nodeId === nodeId)
-        return { clip: track.clips[c], track: track, trackIndex: t, clipIndex: c, trackType: 'video' };
+        return { clip: track.clips[c], track: track, trackIndex: t, clipIndex: c, trackType: 'video', sequence: seq, sequenceId: seq.sequenceID, sequenceName: seq.name };
     }
   }
   for (var t = 0; t < seq.audioTracks.numTracks; t++) {
     var track = seq.audioTracks[t];
     for (var c = 0; c < track.clips.numItems; c++) {
       if (track.clips[c].nodeId === nodeId)
-        return { clip: track.clips[c], track: track, trackIndex: t, clipIndex: c, trackType: 'audio' };
+        return { clip: track.clips[c], track: track, trackIndex: t, clipIndex: c, trackType: 'audio', sequence: seq, sequenceId: seq.sequenceID, sequenceName: seq.name };
     }
   }
   return null;
 }
+function __findClip(nodeId, sequenceId) {
+  if (!app.project) return null;
+  if (sequenceId) return __findClipInSequence(__findSequence(sequenceId), nodeId);
+
+  var found = __findClipInSequence(app.project.activeSequence, nodeId);
+  if (found) return found;
+
+  if (!app.project.sequences) return null;
+  for (var i = 0; i < app.project.sequences.numSequences; i++) {
+    found = __findClipInSequence(app.project.sequences[i], nodeId);
+    if (found) return found;
+  }
+  return null;
+}
+function __samePath(a, b) {
+  function normalize(value) {
+    return String(value || '').replace(/\\\\/g, '/').replace(/\\/+$/g, '');
+  }
+  return normalize(a) === normalize(b);
+}
 function __findProjectItem(nodeId) {
+  if (!app.project || !app.project.rootItem) return null;
   function walk(item) {
     if (item.nodeId === nodeId) return item;
     if (item.children) {
@@ -284,13 +305,45 @@ export class PremiereProBridge implements PremiereProTransport {
 
   // Project Management
   async createProject(name: string, location: string): Promise<PremiereProProject> {
+    const normalizedLocation = location.replace(/[\\/]+$/, '');
+    const projectFileName = name.endsWith('.prproj') ? name : `${name}.prproj`;
+    const projectPath = `${normalizedLocation}/${projectFileName}`;
     const script = `
-      // Create new project
-      app.newProject("${name}", "${location}");
+      var projectPath = ${JSON.stringify(projectPath)};
+      var projectFolder = new Folder(${JSON.stringify(normalizedLocation)});
+
+      if (!projectFolder.exists && !projectFolder.create()) {
+        return JSON.stringify({
+          success: false,
+          error: "Could not create project folder",
+          projectPath: projectPath
+        });
+      }
+
+      var createdResult = app.newProject(projectPath);
+      var projectFile = new File(projectPath);
+
+      if (!projectFile.exists && app.project && app.project.saveAs) {
+        try {
+          app.project.saveAs(projectPath);
+        } catch (saveError) {}
+      }
+
       var project = app.project;
-      
-      // Return project info
+      var actualPath = project && project.path ? String(project.path) : "";
+
+      if (!projectFile.exists || !__samePath(actualPath, projectPath)) {
+        return JSON.stringify({
+          success: false,
+          error: "Premiere Pro did not create or activate the requested project",
+          projectPath: projectPath,
+          actualPath: actualPath,
+          createdResult: createdResult
+        });
+      }
+
       return JSON.stringify({
+        success: true,
         id: project.documentID,
         name: project.name,
         path: project.path,
@@ -305,12 +358,33 @@ export class PremiereProBridge implements PremiereProTransport {
 
   async openProject(path: string): Promise<PremiereProProject> {
     const script = `
-      // Open existing project
-      app.openDocument("${path}");
+      var projectPath = ${JSON.stringify(path)};
+      var projectFile = new File(projectPath);
+
+      if (!projectFile.exists) {
+        return JSON.stringify({
+          success: false,
+          error: "Project file does not exist",
+          projectPath: projectPath
+        });
+      }
+
+      var openResult = app.openDocument(projectPath);
       var project = app.project;
-      
-      // Return project info
+      var actualPath = project && project.path ? String(project.path) : "";
+
+      if (!project || !__samePath(actualPath, projectPath)) {
+        return JSON.stringify({
+          success: false,
+          error: "Premiere Pro did not activate the requested project",
+          projectPath: projectPath,
+          actualPath: actualPath,
+          openResult: openResult
+        });
+      }
+
       return JSON.stringify({
+        success: true,
         id: project.documentID,
         name: project.name,
         path: project.path,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -311,9 +311,10 @@ export class PremiereProTools {
       },
       {
         name: 'remove_from_timeline',
-        description: 'Removes a clip from the timeline.',
+        description: 'Removes a clip from the timeline. Pass sequenceId when the clip ID came from list_sequence_tracks for a non-active sequence.',
         inputSchema: z.object({
           clipId: z.string().describe('The ID of the clip on the timeline to remove'),
+          sequenceId: z.string().optional().describe('Optional sequence ID to search. If omitted, searches the active sequence first, then all sequences.'),
           deleteMode: z.enum(['ripple', 'lift']).optional().describe('Whether to ripple delete (close gap) or lift (leave gap)')
         })
       },
@@ -680,9 +681,10 @@ export class PremiereProTools {
       },
       {
         name: 'get_clip_properties',
-        description: 'Gets detailed properties of a clip.',
+        description: 'Gets detailed properties of a clip. Pass sequenceId when the clip ID came from list_sequence_tracks for a non-active sequence.',
         inputSchema: z.object({
-          clipId: z.string().describe('The ID of the clip')
+          clipId: z.string().describe('The ID of the clip'),
+          sequenceId: z.string().optional().describe('Optional sequence ID to search. If omitted, searches the active sequence first, then all sequences.')
         })
       },
       {
@@ -1202,7 +1204,7 @@ export class PremiereProTools {
         case 'add_to_timeline':
           return await this.addToTimeline(args.sequenceId, args.projectItemId, args.trackIndex, args.time, args.insertMode, args.linkAudio);
         case 'remove_from_timeline':
-          return await this.removeFromTimeline(args.clipId, args.deleteMode);
+          return await this.removeFromTimeline(args.clipId, args.sequenceId, args.deleteMode);
         case 'move_clip':
           return await this.moveClip(args.clipId, args.newTime, args.newTrackIndex);
         case 'trim_clip':
@@ -1304,7 +1306,7 @@ export class PremiereProTools {
         case 'set_sequence_settings':
           return await this.setSequenceSettings(args.sequenceId, args.settings);
         case 'get_clip_properties':
-          return await this.getClipProperties(args.clipId);
+          return await this.getClipProperties(args.clipId, args.sequenceId);
         case 'set_clip_properties':
           return await this.setClipProperties(args.clipId, args.properties);
 
@@ -2002,11 +2004,19 @@ export class PremiereProTools {
   // Project Management Implementation
   private async createProject(name: string, location: string): Promise<any> {
     try {
-      const result = await this.bridge.createProject(name, location);
+      const result: any = await this.bridge.createProject(name, location);
+      const projectPath = `${location.replace(/[\\/]+$/, '')}/${name.endsWith('.prproj') ? name : `${name}.prproj`}`;
+      if (result?.success === false) {
+        return {
+          ...result,
+          projectPath: result.projectPath || projectPath
+        };
+      }
+
       return {
         success: true,
         message: `Project "${name}" created successfully`,
-        projectPath: `${location}/${name}.prproj`,
+        projectPath,
         ...result
       };
     } catch (error) {
@@ -2019,7 +2029,14 @@ export class PremiereProTools {
 
   private async openProject(path: string): Promise<any> {
     try {
-      const result = await this.bridge.openProject(path);
+      const result: any = await this.bridge.openProject(path);
+      if (result?.success === false) {
+        return {
+          ...result,
+          projectPath: result.projectPath || path
+        };
+      }
+
       return {
         success: true,
         message: `Project opened successfully`,
@@ -2538,21 +2555,23 @@ export class PremiereProTools {
     }
   }
 
-  private async removeFromTimeline(clipId: string, deleteMode = 'ripple'): Promise<any> {
+  private async removeFromTimeline(clipId: string, sequenceId?: string, deleteMode = 'ripple'): Promise<any> {
     const script = `
       try {
-        var info = __findClip("${clipId}");
-        if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
+        var info = __findClip(${JSON.stringify(clipId)}, ${sequenceId ? JSON.stringify(sequenceId) : 'null'});
+        if (!info) return JSON.stringify({ success: false, error: ${sequenceId ? JSON.stringify(`Clip not found in sequence: ${sequenceId}`) : '"Clip not found"'} });
         var clip = info.clip;
         var clipName = clip.name;
-        var isRipple = "${deleteMode}" === "ripple";
+        var isRipple = ${JSON.stringify(deleteMode)} === "ripple";
         clip.remove(isRipple, true);
         return JSON.stringify({
           success: true,
           message: "Clip removed from timeline",
-          clipId: "${clipId}",
+          clipId: ${JSON.stringify(clipId)},
           clipName: clipName,
-          deleteMode: "${deleteMode}"
+          sequenceId: info.sequenceId,
+          sequenceName: info.sequenceName,
+          deleteMode: ${JSON.stringify(deleteMode)}
         });
       } catch (e) {
         return JSON.stringify({
@@ -4359,11 +4378,11 @@ export class PremiereProTools {
     };
   }
 
-  private async getClipProperties(clipId: string): Promise<any> {
+  private async getClipProperties(clipId: string, sequenceId?: string): Promise<any> {
     const script = `
       try {
-        var info = __findClip(${JSON.stringify(clipId)});
-        if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
+        var info = __findClip(${JSON.stringify(clipId)}, ${sequenceId ? JSON.stringify(sequenceId) : 'null'});
+        if (!info) return JSON.stringify({ success: false, error: ${sequenceId ? JSON.stringify(`Clip not found in sequence: ${sequenceId}`) : '"Clip not found"'} });
         var clip = info.clip;
         return JSON.stringify({
           success: true,
@@ -4377,6 +4396,8 @@ export class PremiereProTools {
             enabled: !clip.disabled,
             trackIndex: info.trackIndex,
             trackType: info.trackType,
+            sequenceId: info.sequenceId,
+            sequenceName: info.sequenceName,
             speed: clip.getSpeed()
           }
         });


### PR DESCRIPTION
Fixes the current open issue cluster around project activation, sequence-scoped clip operations, and CEP bridge hangs.

Changes:
- create_project now creates a concrete .prproj path, verifies the file exists, and verifies Premiere activates that exact project before returning success.
- open_project now verifies the target file exists and that Premiere activates the requested project instead of returning stale active project data.
- clip lookup can now search a requested sequence, and falls back from active sequence to all sequences when sequenceId is omitted.
- get_clip_properties and remove_from_timeline accept optional sequenceId for clip IDs returned by list_sequence_tracks.
- tool wrappers preserve bridge { success: false } responses instead of overwriting them with success messages.
- CEP evalScript execution now has a 45s timeout so the panel writes a structured error response instead of leaving the MCP server to hit its 60s bridge timeout.
- adds regression tests for project false-success handling and sequence-scoped clip operations.

Closes #18
Closes #19
Closes #20
Closes #21
Closes #22

Verification:
- npm run build
- npm test -- --runInBand