### PR TITLE
Fix create_sequence false-negative recovery

### DIFF
--- a/cep-plugin/bridge-cep.js
+++ b/cep-plugin/bridge-cep.js
@@ -62,6 +62,30 @@
         return resolvedPath;
     }
 
+    function sanitizeTempDirectoryInput(value) {
+        if (!value || typeof value !== 'string') return '';
+        var trimmed = value.trim();
+
+        try {
+            if (trimmed.charAt(0) === '{') {
+                var parsed = JSON.parse(trimmed);
+                if (parsed && typeof parsed.PREMIERE_TEMP_DIR === 'string') {
+                    return parsed.PREMIERE_TEMP_DIR.trim();
+                }
+                if (parsed && typeof parsed.tempDirectory === 'string') {
+                    return parsed.tempDirectory.trim();
+                }
+            }
+        } catch (e) {}
+
+        var envMatch = trimmed.match(/["']?PREMIERE_TEMP_DIR["']?\s*:\s*["']([^"']+)["']/);
+        if (envMatch && envMatch[1]) {
+            return envMatch[1].trim();
+        }
+
+        return trimmed.replace(/^["']|["']$/g, '');
+    }
+
     function MCPPremiereBridge() {
         this.isConnected = false;
         this.tempDirectory = '';
@@ -310,7 +334,7 @@
                 var configPath = path.join(defaultPath, 'config.json');
                 if (fs.existsSync(configPath)) {
                     var config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-                    if (config.tempDirectory) this.tempDirectory = config.tempDirectory;
+                    if (config.tempDirectory) this.tempDirectory = sanitizeTempDirectoryInput(config.tempDirectory);
                 }
             }
             var tempEl = document.getElementById('tempDirectory');
@@ -321,12 +345,13 @@
     MCPPremiereBridge.prototype.saveConfig = function() {
         try {
             var tempEl = document.getElementById('tempDirectory');
-            var tempDir = tempEl ? tempEl.value.trim() : '';
+            var tempDir = tempEl ? sanitizeTempDirectoryInput(tempEl.value) : '';
             if (tempDir) this.tempDirectory = tempDir;
             var ensuredTempDir = this.getTempDirectory();
             if (!ensuredTempDir) {
                 throw new Error('Could not create or access temp directory');
             }
+            if (tempEl) tempEl.value = this.tempDirectory;
             var configPath = path.join(ensuredTempDir, 'config.json');
             fs.writeFileSync(configPath, JSON.stringify({ tempDirectory: this.tempDirectory }, null, 2));
             this.log('Configuration saved', 'info');

--- a/src/__tests__/bridge/index.test.ts
+++ b/src/__tests__/bridge/index.test.ts
@@ -160,6 +160,29 @@ describe('PremiereProBridge', () => {
     );
   });
 
+  it('creates sequences with guarded ExtendScript and safe arguments', async () => {
+    const bridge = new PremiereProBridge();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.access.mockRejectedValue(new Error('Not found'));
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.readFile.mockResolvedValue(JSON.stringify({
+      success: true,
+      id: 'seq-123',
+      name: 'Safe Sequence'
+    }));
+    mockFs.unlink.mockResolvedValue(undefined);
+
+    await bridge.initialize();
+    const result: any = await bridge.createSequence('Safe Sequence');
+    const commandPayload = JSON.parse(mockFs.writeFile.mock.calls[0][1] as string);
+
+    expect(result.success).toBe(true);
+    expect(result.id).toBe('seq-123');
+    expect(commandPayload.script).toContain('try {');
+    expect(commandPayload.script).toContain('app.project.createNewSequence(sequenceName, presetPath || "")');
+    expect(commandPayload.script).toContain('Sequence creation completed but the new sequence could not be located');
+  });
+
   it('does not delete externally managed temp directories during cleanup', async () => {
     const bridge = new PremiereProBridge();
     mockFs.mkdir.mockResolvedValue(undefined);

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -104,6 +104,52 @@ describe('PremiereProTools', () => {
       expect(result.actualPath).toBe('/tmp/AlreadyOpen.prproj');
     });
 
+    it('recovers create_sequence when the bridge times out after Premiere created it', async () => {
+      mockBridge.createSequence = jest.fn().mockRejectedValue(new Error('Bridge response timeout'));
+      mockBridge.executeScript
+        .mockResolvedValueOnce({
+          success: true,
+          sequences: [
+            {
+              id: 'seq-recovered',
+              name: 'Recovered Sequence',
+              duration: 0,
+              width: 1920,
+              height: 1080,
+              timebase: '10594584000',
+              videoTrackCount: 3,
+              audioTrackCount: 4
+            }
+          ],
+          count: 1
+        });
+
+      const result = await tools.executeTool('create_sequence', {
+        name: 'Recovered Sequence'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.recovered).toBe(true);
+      expect(result.id).toBe('seq-recovered');
+      expect(result.warning).toContain('recovered by list_sequences');
+    });
+
+    it('surfaces create_sequence bridge failures when recovery cannot find the sequence', async () => {
+      mockBridge.createSequence = jest.fn().mockRejectedValue(new Error('Bridge response timeout'));
+      mockBridge.executeScript.mockResolvedValueOnce({
+        success: true,
+        sequences: [],
+        count: 0
+      });
+
+      const result = await tools.executeTool('create_sequence', {
+        name: 'Missing Sequence'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Bridge response timeout');
+    });
+
     it('passes through successful imports', async () => {
       mockBridge.importMedia = jest.fn().mockResolvedValue({
         success: true,

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -501,18 +501,74 @@ export class PremiereProBridge implements PremiereProTransport {
 
   async createSequence(name: string, presetPath?: string): Promise<PremiereProSequence> {
     const script = `
-      // Create new sequence
-      var sequence = app.project.createNewSequence("${name}", "${presetPath || ''}");
-      
-      // Return sequence info
-      return JSON.stringify({
-        id: sequence.sequenceID,
-        name: sequence.name,
-        duration: sequence.end - sequence.zeroPoint,
-        frameRate: sequence.framerate,
-        videoTracks: [],
-        audioTracks: []
-      });
+      try {
+        var sequenceName = ${JSON.stringify(name)};
+        var presetPath = ${presetPath ? JSON.stringify(presetPath) : 'null'};
+        var beforeIds = {};
+
+        if (app.project && app.project.sequences) {
+          for (var i = 0; i < app.project.sequences.numSequences; i++) {
+            beforeIds[app.project.sequences[i].sequenceID] = true;
+          }
+        }
+
+        var sequence = null;
+        var createError = null;
+        try {
+          sequence = app.project.createNewSequence(sequenceName, presetPath || "");
+        } catch (createException) {
+          createError = createException;
+        }
+
+        var created = sequence || null;
+        if (!created && app.project && app.project.sequences) {
+          for (var j = 0; j < app.project.sequences.numSequences; j++) {
+            var candidate = app.project.sequences[j];
+            if (!beforeIds[candidate.sequenceID] && candidate.name === sequenceName) {
+              created = candidate;
+              break;
+            }
+          }
+        }
+
+        if (!created && app.project && app.project.sequences) {
+          for (var k = app.project.sequences.numSequences - 1; k >= 0; k--) {
+            var fallback = app.project.sequences[k];
+            if (fallback.name === sequenceName) {
+              created = fallback;
+              break;
+            }
+          }
+        }
+
+        if (!created) {
+          return JSON.stringify({
+            success: false,
+            error: createError
+              ? createError.toString()
+              : "Sequence creation completed but the new sequence could not be located",
+            sequenceName: sequenceName
+          });
+        }
+
+        return JSON.stringify({
+          success: true,
+          id: created.sequenceID,
+          name: created.name,
+          duration: created.end ? __ticksToSeconds(created.end) : 0,
+          frameRate: created.timebase ? (254016000000 / parseInt(created.timebase, 10)) : null,
+          videoTrackCount: created.videoTracks ? created.videoTracks.numTracks : 0,
+          audioTrackCount: created.audioTracks ? created.audioTracks.numTracks : 0,
+          videoTracks: [],
+          audioTracks: []
+        });
+      } catch (e) {
+        return JSON.stringify({
+          success: false,
+          error: e.toString(),
+          sequenceName: ${JSON.stringify(name)}
+        });
+      }
     `;
     
     return await this.executeScript(script);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2315,7 +2315,14 @@ export class PremiereProTools {
   // Sequence Management Implementation
   private async createSequence(name: string, presetPath?: string, _width?: number, _height?: number, _frameRate?: number, _sampleRate?: number): Promise<any> {
     try {
-      const result = await this.bridge.createSequence(name, presetPath);
+      const result: any = await this.bridge.createSequence(name, presetPath);
+      if (result?.success === false) {
+        return {
+          ...result,
+          sequenceName: result.sequenceName || name
+        };
+      }
+
       return {
         success: true,
         message: `Sequence "${name}" created successfully`,
@@ -2323,12 +2330,55 @@ export class PremiereProTools {
         ...result
       };
     } catch (error) {
+      const recovered = await this.recoverCreatedSequenceByName(name);
+      if (recovered) {
+        return {
+          success: true,
+          recovered: true,
+          warning: 'Bridge response timed out after Premiere created the sequence; recovered by list_sequences.',
+          message: `Sequence "${name}" created successfully`,
+          sequenceName: name,
+          ...recovered
+        };
+      }
+
       return {
         success: false,
         error: `Failed to create sequence: ${error instanceof Error ? error.message : String(error)}`,
         sequenceName: name
       };
     }
+  }
+
+  private async recoverCreatedSequenceByName(name: string): Promise<any | null> {
+    try {
+      const result = await this.listSequences();
+      if (result?.success === false || !Array.isArray(result?.sequences)) {
+        return null;
+      }
+
+      for (let i = result.sequences.length - 1; i >= 0; i--) {
+        const sequence = result.sequences[i];
+        if (sequence?.name === name) {
+          return {
+            id: sequence.id,
+            name: sequence.name,
+            duration: sequence.duration,
+            width: sequence.width,
+            height: sequence.height,
+            timebase: sequence.timebase,
+            videoTrackCount: sequence.videoTrackCount,
+            audioTrackCount: sequence.audioTrackCount,
+            videoTracks: [],
+            audioTracks: []
+          };
+        }
+      }
+    } catch (recoveryError) {
+      this.logger.warn(`Failed to recover sequence "${name}" after create_sequence error:`, recoveryError);
+    }
+
+    return null;
   }
 
   private async duplicateSequence(sequenceId: string, newName: string): Promise<any> {


### PR DESCRIPTION
Fixes #25.\n\n## What changed\n- Guard create_sequence ExtendScript and safely return success/failure payloads.\n- Recover create_sequence when the bridge response times out but Premiere already created the sequence by checking list_sequences for the requested name.\n- Sanitize pasted CEP temp directory values such as `"PREMIERE_TEMP_DIR": "C:\\tmp\\premiere-mcp-bridge"`.\n- Add regression tests for create_sequence recovery and guarded bridge script generation.\n\n## Verification\n- npm run build\n- npm test -- --runInBand\n- Live bridge smoke test: create_sequence returned success and list_sequences found the created sequence `ISSUE25_FIXED_1778952568244`.