### PR TITLE
Add Premiere MCP agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ High-level workflow tools included:
 
 `assemble_product_spot` and `build_brand_spot_from_mogrt_and_assets` now support an optional `clipPlan` argument so an LLM can direct per-clip timing, track placement, transitions, motion, trims, effects, and color adjustments instead of relying on fixed template defaults.
 
+## Agent Skill
+
+If you want Codex, Claude Code, or another agent to handle installation, verification, and day-to-day usage correctly, install the included Agent Skill:
+
+```bash
+npx skills add hetpatel-11/Adobe_Premiere_Pro_MCP --skill premiere-pro-mcp -a codex -a claude-code
+```
+
+Or install directly from the skill path:
+
+```bash
+npx skills add https://github.com/hetpatel-11/Adobe_Premiere_Pro_MCP/tree/main/skills/premiere-pro-mcp
+```
+
+The skill teaches agents how to install the MCP, start and verify the CEP bridge, use the Premiere tools safely, import real media before editing, prefer sequence-aware operations, and run diagnostics when something fails.
+
 ## Fastest Install (macOS)
 
 ```bash

--- a/skills/premiere-pro-mcp/SKILL.md
+++ b/skills/premiere-pro-mcp/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: premiere-pro-mcp
+description: Install, verify, troubleshoot, and operate the Adobe Premiere Pro MCP server. Use when a user wants an agent to set up Premiere MCP, connect Claude Code/Codex/Claude Desktop, control Premiere, import media, build sequences, edit timelines, apply effects, or diagnose bridge issues.
+---
+
+# Adobe Premiere Pro MCP
+
+Use this skill when working with the Adobe Premiere Pro MCP server from `hetpatel-11/Adobe_Premiere_Pro_MCP`.
+
+## Core Rules
+
+- Use the MCP tools for Premiere operations; do not invent ExtendScript unless the MCP tool surface is missing the needed operation.
+- Prefer read-only discovery first: `get_project_info`, `list_sequences`, `list_project_items`, `get_active_sequence`, and relevant resource reads.
+- Use real imported media. If the user asks to edit with assets, verify file paths exist, import them with `import_media`, then place the imported project item IDs on a sequence.
+- Keep the temp directory consistent across the MCP server and CEP panel: `/tmp/premiere-mcp-bridge` unless the user explicitly configured another path.
+- Ask before destructive or externally visible actions: deleting clips/media, overwriting exports, closing projects, saving over important project files, or sending files elsewhere.
+- For generated/demo edits, prefer creating a new clearly named sequence instead of modifying the user's active sequence.
+- If a tool returns `success: false`, report the exact error and run diagnostics before retrying blindly.
+
+## Install Workflow
+
+If the user asks you to install or set up the MCP:
+
+1. Check the OS. The automated installer is macOS-focused.
+2. Clone or open the repo:
+
+```bash
+git clone https://github.com/hetpatel-11/Adobe_Premiere_Pro_MCP.git
+cd Adobe_Premiere_Pro_MCP
+```
+
+3. On macOS, run:
+
+```bash
+npm run setup:mac
+```
+
+4. For non-macOS or manual client setup, run:
+
+```bash
+npm install
+npm run build
+```
+
+5. Register the MCP server in the user's client with:
+
+```text
+command: node /absolute/path/to/Adobe_Premiere_Pro_MCP/dist/index.js
+env: PREMIERE_TEMP_DIR=/tmp/premiere-mcp-bridge
+```
+
+For Codex, prefer:
+
+```bash
+codex mcp add premiere_pro --env PREMIERE_TEMP_DIR=/tmp/premiere-mcp-bridge -- node /absolute/path/to/Adobe_Premiere_Pro_MCP/dist/index.js
+```
+
+## Premiere Bridge Startup
+
+After installing:
+
+1. Restart the MCP client if it reads config only at startup.
+2. Restart Premiere Pro.
+3. Open `Window > Extensions > MCP Bridge (CEP)`.
+4. Set `Temp Directory` to `/tmp/premiere-mcp-bridge`.
+5. Click `Save Configuration`.
+6. Click `Start Bridge`.
+7. Confirm the bridge panel says Premiere is ready before running editing tools.
+
+If Premiere is not running, you can install/build/register the MCP, but tell the user live tool verification requires Premiere and the CEP bridge panel.
+
+## Verification
+
+Run local checks:
+
+```bash
+npm run setup:doctor
+```
+
+If Premiere is running and the bridge is started, verify with safe read-only calls:
+
+- `get_project_info`
+- `list_sequences`
+- `list_project_items`
+
+For deeper validation in a disposable project, create a test sequence with a unique name, then call `list_sequences` and confirm it exists.
+
+## Editing Strategy
+
+- Start by understanding the project: project info, active sequence, existing media, tracks, markers, and selected sequence.
+- Build a plan in concrete Premiere operations before changing anything.
+- For rough cuts, create or choose a sequence, import media, place clips, then add trims/transitions/effects.
+- For product or brand spots, prefer `assemble_product_spot` or `build_brand_spot_from_mogrt_and_assets` when the user's request fits those workflows.
+- For black-and-white looks, use `apply_effect` with `Black & White` rather than generic saturation-only changes.
+- For timeline cuts, prefer sequence-aware tools and include `sequenceId` when available.
+- Export only after confirming output path, format/preset, and overwrite behavior.
+
+## Troubleshooting
+
+If commands time out or report bridge errors:
+
+1. Confirm Premiere is open.
+2. Confirm `Window > Extensions > MCP Bridge (CEP)` is open and bridge is started.
+3. Confirm both sides use the same temp directory.
+4. Run:
+
+```bash
+npm run setup:doctor
+```
+
+5. Ask the user to click `Run Diagnostics` in the CEP panel.
+6. Read `/tmp/premiere-mcp-bridge/premiere-mcp-diagnostics-latest.json` if it exists.
+7. Remove stale command/response files only if they are clearly old and the bridge is stopped or idle.
+
+Common fixes:
+
+- `ENOENT` on temp directory: create `/tmp/premiere-mcp-bridge`, save config again, restart bridge.
+- Tool succeeds in Premiere but reports failure: run `list_sequences` or the relevant list tool to confirm state before retrying.
+- Empty or malformed temp directory config: set the field to the path only, not JSON or an env assignment.
+


### PR DESCRIPTION
## What changed\n- Added an installable Agent Skill at `skills/premiere-pro-mcp/SKILL.md`.\n- Documented skills.sh install commands in the README for Codex and Claude Code users.\n- Included agent behavior guidance for install, bridge startup, media import, safe editing, verification, and diagnostics.\n\n## Verification\n- Validated SKILL.md frontmatter.\n- Ran `DISABLE_TELEMETRY=1 npx skills add . --list`; the CLI found `premiere-pro-mcp`.