### PR TITLE
Refresh known issues status

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -2,14 +2,19 @@
 
 This file tracks current, confirmed limits. It is no longer a backlog of already-fixed prototype bugs.
 
-## Current State (March 4, 2026)
+## Current State (May 16, 2026)
 
-The locally validated tool surface is:
+The current built tool catalog exposes:
 
-- `97` exposed tools
-- `43` live-executed against a real Premiere Pro session
-- `50` schema-validated in the same sweep
-- `3` intentionally skipped because they mutate or save project state during no-arg testing
+- `104` tools
+
+The last broad live sweep in this repository was run on March 4, 2026:
+
+- `43` tools were live-executed against a real Premiere Pro session
+- `50` tools were schema-validated in the same sweep
+- `3` tools were intentionally skipped because they mutate or save project state during no-arg testing
+
+Run `node scripts/live-tool-sweep.mjs` against a scratch Premiere project before making a new release-level validation claim.
 
 ## Confirmed Runtime Limitation
 
@@ -80,6 +85,8 @@ These issues were real and are now resolved in the current code:
 - `import_media` could import successfully but fail to locate the new project item
 - `add_to_timeline` used the wrong Premiere API path
 - the server could delete an externally managed temp directory on shutdown
+- the CEP bridge could fail with `ENOENT` when the configured temp directory did not exist
+- `create_sequence` could create a sequence in Premiere but still report failure after a bridge timeout
 - `export_frame` called a non-existent API and now uses the QE export path
 - `remove_effect` was advertised even though actual removal is not supported and has been removed from the tool catalog
 - the branded workflow response returned the wrong message due to object spread order


### PR DESCRIPTION
## What changed\n- Updated KNOWN_ISSUES.md from the stale March 4 tool count to the current built catalog count.\n- Clarified that the 43 live-executed / 50 schema-validated numbers are from the last broad live sweep, not the current full catalog.\n- Added the recently fixed temp directory ENOENT and create_sequence false-negative issues to the resolved list.\n\n## Verification\n- npm run build\n- Confirmed getAvailableTools() exposes 104 tools.\n- Confirmed get_render_queue_status is still exposed as a runtime limitation.\n- Confirmed remove_effect, create_nested_sequence, and unnest_sequence are not in the exposed catalog.