### PR TITLE
Prevent create_sequence timeout recovery wedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ High-level workflow tools included:
 If you want Codex, Claude Code, or another agent to handle installation, verification, and day-to-day usage correctly, install the included Agent Skill:
 
 ```bash
-npx skills add hetpatel-11/Adobe_Premiere_Pro_MCP --skill premiere-pro-mcp -a codex -a claude-code
+npx skills add hetpatel-11/Adobe_Premiere_Pro_MCP --skill premiere-pro-mcp
 ```
 
 Or install directly from the skill path:

--- a/cep-plugin/bridge-cep.js
+++ b/cep-plugin/bridge-cep.js
@@ -66,24 +66,28 @@
         if (!value || typeof value !== 'string') return '';
         var trimmed = value.trim();
 
+        function normalizePathLiteral(pathValue) {
+            return pathValue.trim().replace(/\\\\/g, '\\');
+        }
+
         try {
             if (trimmed.charAt(0) === '{') {
                 var parsed = JSON.parse(trimmed);
                 if (parsed && typeof parsed.PREMIERE_TEMP_DIR === 'string') {
-                    return parsed.PREMIERE_TEMP_DIR.trim();
+                    return normalizePathLiteral(parsed.PREMIERE_TEMP_DIR);
                 }
                 if (parsed && typeof parsed.tempDirectory === 'string') {
-                    return parsed.tempDirectory.trim();
+                    return normalizePathLiteral(parsed.tempDirectory);
                 }
             }
         } catch (e) {}
 
         var envMatch = trimmed.match(/["']?PREMIERE_TEMP_DIR["']?\s*:\s*["']([^"']+)["']/);
         if (envMatch && envMatch[1]) {
-            return envMatch[1].trim();
+            return normalizePathLiteral(envMatch[1]);
         }
 
-        return trimmed.replace(/^["']|["']$/g, '');
+        return normalizePathLiteral(trimmed.replace(/^["']|["']$/g, ''));
     }
 
     function MCPPremiereBridge() {
@@ -329,16 +333,34 @@
 
     MCPPremiereBridge.prototype.loadConfig = function() {
         try {
-            var defaultPath = getDefaultTempPath();
-            if (fs.existsSync(defaultPath)) {
-                var configPath = path.join(defaultPath, 'config.json');
+            var candidatePaths = [getDefaultTempPath()];
+            if (process.env.PREMIERE_TEMP_DIR) {
+                candidatePaths.push(sanitizeTempDirectoryInput(process.env.PREMIERE_TEMP_DIR));
+            }
+
+            for (var i = 0; i < candidatePaths.length; i++) {
+                var candidatePath = sanitizeTempDirectoryInput(candidatePaths[i]);
+                if (!candidatePath || !fs.existsSync(candidatePath)) continue;
+                var configPath = path.join(candidatePath, 'config.json');
                 if (fs.existsSync(configPath)) {
                     var config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-                    if (config.tempDirectory) this.tempDirectory = sanitizeTempDirectoryInput(config.tempDirectory);
+                    if (config.tempDirectory) {
+                        this.tempDirectory = sanitizeTempDirectoryInput(config.tempDirectory);
+                        break;
+                    }
                 }
             }
+
             var tempEl = document.getElementById('tempDirectory');
-            if (tempEl && this.tempDirectory) tempEl.value = this.tempDirectory;
+            if (tempEl) {
+                var fieldValue = sanitizeTempDirectoryInput(tempEl.value);
+                if (!this.tempDirectory && fieldValue) this.tempDirectory = fieldValue;
+                if (this.tempDirectory) {
+                    tempEl.value = this.tempDirectory;
+                } else if (fieldValue) {
+                    tempEl.value = fieldValue;
+                }
+            }
         } catch (e) {}
     };
 
@@ -362,6 +384,7 @@
 
     MCPPremiereBridge.prototype.startBridge = function() {
         this.log('Starting MCP Bridge...', 'info');
+        this.isProcessing = false;
         this.isConnected = true;
         this.updateUI();
         var tempPath = this.getTempDirectory();
@@ -379,6 +402,7 @@
     MCPPremiereBridge.prototype.stopBridge = function() {
         this.log('Stopping MCP Bridge...', 'info');
         this.isConnected = false;
+        this.isProcessing = false;
         this.updateUI();
         this.updateServerStatus(false);
     };

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -104,50 +104,29 @@ describe('PremiereProTools', () => {
       expect(result.actualPath).toBe('/tmp/AlreadyOpen.prproj');
     });
 
-    it('recovers create_sequence when the bridge times out after Premiere created it', async () => {
+    it('does not run automatic create_sequence recovery after a bridge timeout', async () => {
       mockBridge.createSequence = jest.fn().mockRejectedValue(new Error('Bridge response timeout'));
-      mockBridge.executeScript
-        .mockResolvedValueOnce({
-          success: true,
-          sequences: [
-            {
-              id: 'seq-recovered',
-              name: 'Recovered Sequence',
-              duration: 0,
-              width: 1920,
-              height: 1080,
-              timebase: '10594584000',
-              videoTrackCount: 3,
-              audioTrackCount: 4
-            }
-          ],
-          count: 1
-        });
 
       const result = await tools.executeTool('create_sequence', {
-        name: 'Recovered Sequence'
+        name: 'Possibly Created Sequence'
       });
 
-      expect(result.success).toBe(true);
-      expect(result.recovered).toBe(true);
-      expect(result.id).toBe('seq-recovered');
-      expect(result.warning).toContain('recovered by list_sequences');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Bridge response timeout');
+      expect(result.warning).toContain('does not run automatic recovery');
+      expect(mockBridge.executeScript).not.toHaveBeenCalled();
     });
 
-    it('surfaces create_sequence bridge failures when recovery cannot find the sequence', async () => {
-      mockBridge.createSequence = jest.fn().mockRejectedValue(new Error('Bridge response timeout'));
-      mockBridge.executeScript.mockResolvedValueOnce({
-        success: true,
-        sequences: [],
-        count: 0
-      });
+    it('surfaces create_sequence bridge failures without timeout recovery guidance', async () => {
+      mockBridge.createSequence = jest.fn().mockRejectedValue(new Error('Premiere rejected the preset'));
 
       const result = await tools.executeTool('create_sequence', {
         name: 'Missing Sequence'
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Bridge response timeout');
+      expect(result.error).toContain('Premiere rejected the preset');
+      expect(result.warning).toBeUndefined();
     });
 
     it('passes through successful imports', async () => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2330,55 +2330,17 @@ export class PremiereProTools {
         ...result
       };
     } catch (error) {
-      const recovered = await this.recoverCreatedSequenceByName(name);
-      if (recovered) {
-        return {
-          success: true,
-          recovered: true,
-          warning: 'Bridge response timed out after Premiere created the sequence; recovered by list_sequences.',
-          message: `Sequence "${name}" created successfully`,
-          sequenceName: name,
-          ...recovered
-        };
-      }
-
+      const message = error instanceof Error ? error.message : String(error);
+      const timedOut = /timeout|timed out/i.test(message);
       return {
         success: false,
-        error: `Failed to create sequence: ${error instanceof Error ? error.message : String(error)}`,
-        sequenceName: name
+        error: `Failed to create sequence: ${message}`,
+        sequenceName: name,
+        ...(timedOut ? {
+          warning: 'Premiere may still create the sequence after this timeout. Wait for the bridge to become responsive, then run list_sequences to verify before retrying. The server intentionally does not run automatic recovery after a timeout because that can wedge the CEP bridge on Windows.'
+        } : {})
       };
     }
-  }
-
-  private async recoverCreatedSequenceByName(name: string): Promise<any | null> {
-    try {
-      const result = await this.listSequences();
-      if (result?.success === false || !Array.isArray(result?.sequences)) {
-        return null;
-      }
-
-      for (let i = result.sequences.length - 1; i >= 0; i--) {
-        const sequence = result.sequences[i];
-        if (sequence?.name === name) {
-          return {
-            id: sequence.id,
-            name: sequence.name,
-            duration: sequence.duration,
-            width: sequence.width,
-            height: sequence.height,
-            timebase: sequence.timebase,
-            videoTrackCount: sequence.videoTrackCount,
-            audioTrackCount: sequence.audioTrackCount,
-            videoTracks: [],
-            audioTracks: []
-          };
-        }
-      }
-    } catch (recoveryError) {
-      this.logger.warn(`Failed to recover sequence "${name}" after create_sequence error:`, recoveryError);
-    }
-
-    return null;
   }
 
   private async duplicateSequence(sequenceId: string, newName: string): Promise<any> {


### PR DESCRIPTION
Fixes the Windows regression reported in #25 after PR #26.\n\n## What changed\n- Removed automatic in-process recovery from create_sequence after bridge timeouts.\n- Timeout responses now explain that Premiere may still create the sequence and tell users to run list_sequences after the bridge is responsive.\n- Added a regression test proving create_sequence does not issue a hidden list_sequences/executeScript call after timeout.\n- Hardened the CEP panel config load path so corrupted temp-directory values are normalized from config, env, and the displayed input.\n- Reset CEP isProcessing when Start/Stop Bridge is clicked so manual restart can clear a stale busy state.\n\n## Why\nOn Windows, the internal recovery call from PR #26 can compete with the same CEP bridge channel that just timed out. The reporter saw create_sequence timeout and then every later MCP call, including list_sequences, timeout until manually restarting the bridge. Avoiding hidden recovery restores the stable pre-PR-26 behavior: the timeout is explicit, and verification is a separate user/tool call once the bridge is responsive.\n\n## Verification\n- npm run build\n- node --check cep-plugin/bridge-cep.js\n- npm test -- --runInBand\n- Node VM simulation: CEP loadConfig normalizes `"PREMIERE_TEMP_DIR": "C:\\tmp\\premiere-mcp-bridge"` to `C:\\tmp\\premiere-mcp-bridge` in the visible Temp Directory field.