### PR TITLE
Report read_sequence_captions caption-read limitation honestly

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -931,7 +931,7 @@ export class PremiereProTools {
       },
       {
         name: 'read_sequence_captions',
-        description: 'Reads all caption tracks of a sequence and returns each caption clip as { start, end, text }, with timestamps in seconds. Use this to find the timecodes of specific spoken phrases.',
+        description: 'Reads caption tracks of a sequence, returning each caption clip as { start, end, text } in seconds. IMPORTANT: Premiere Pro exposes no caption-read API in its scripting DOM, so in practice this returns trackCount:0 / captions:[] even when the sequence HAS a working caption track. The response field captionReadSupported:false (plus note) signals this — a 0 result does NOT mean the sequence has no captions. To read cue text/timing, parse the source .srt file directly instead.',
         inputSchema: z.object({
           sequenceId: z.string().optional().describe('Optional sequence ID. Defaults to the active sequence.')
         })
@@ -2493,13 +2493,25 @@ export class PremiereProTools {
           }
         }
 
+        // Premiere Pro exposes NO caption-read API in its scripting DOM (confirmed
+        // Adobe limitation — see Bruce Bullis 2021/2023 and the UXP CaptionTrack
+        // thread, 2025). createCaptionTrack can WRITE a caption track from an SRT,
+        // but there is no read counterpart: no sequence.captionTracks, no
+        // getCaptionTracks(), and caption tracks are not surfaced in videoTracks or
+        // the QE DOM. So trackCount will essentially always be 0 here. Report that
+        // honestly via captionReadSupported + note instead of implying "no captions".
+        var captionReadSupported = trackCount > 0;
+        var note = captionReadSupported ? "" : "Premiere Pro exposes no caption-read API in its scripting DOM, so caption tracks cannot be enumerated or read back from a sequence (Adobe limitation: createCaptionTrack can write a track, but there is no read counterpart). trackCount:0 does NOT mean the sequence has no captions — it may have a working, rendering caption track that is simply unreadable via script. To recover cue text/timing, parse the source .srt file off disk instead.";
+
         return JSON.stringify({
           success: true,
           sequenceId: sequence.sequenceID,
           sequenceName: sequence.name,
+          captionReadSupported: captionReadSupported,
           trackCount: trackCount,
           captionCount: output.length,
-          captions: output
+          captions: output,
+          note: note
         });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });


### PR DESCRIPTION
## Summary

Makes `read_sequence_captions` report Premiere's caption-read limitation honestly instead of returning a misleading empty result. Addresses the readback half of #34.

## Background

Premiere Pro exposes **no caption-read API** in its scripting DOM — a confirmed Adobe limitation, not an enumeration bug:

- **Legacy ExtendScript:** no `sequence.captionTracks`, no `getCaptionTracks()`; caption tracks are not surfaced in `videoTracks` or the QE DOM. (Bruce Bullis, Adobe — 2021: *"There is no API access to caption tracks."*; 2023: *"PPro offers no other caption-related APIs."*)
- **UXP `premierepro`:** a `CaptionTrack` object exists, but Adobe (2025) confirms the *"Caption API is still under construction… no available API to access and modify caption properties yet."*

So `createCaptionTrack` (write) has no read counterpart. `read_sequence_captions` therefore returns `trackCount: 0` even when a sequence has a working, rendering caption track — and the old `{ success: true, trackCount: 0, captions: [] }` reads as "no captions," which is misleading.

## Change

- Add `captionReadSupported` (boolean) and a `note` to the response. In the normal case (no tracks enumerable), `captionReadSupported: false` + the note explain the limitation and that `trackCount: 0` does **not** mean the sequence has no captions.
- Update the tool description with the same caveat.
- Purely additive — existing fields are unchanged; no behavior change for callers reading only those.

## Out of scope

Actually reading cue text/timing isn't possible via the API. The practical route is parsing the source `.srt` off disk — which overlaps the existing PR #13 (`read_srt_file`), so this intentionally does not duplicate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)