### PR TITLE
Add crop_clip tool (Crop video effect)

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -367,6 +367,19 @@ export class PremiereProTools {
         })
       },
       {
+        name: 'crop_clip',
+        description: 'Crops a clip\'s frame using Premiere\'s built-in Crop video effect, trimming the picture edges inward by a percentage on each side (Left/Right/Top/Bottom, 0-100). Useful for removing letterbox/pillarbox bars, hiding edge artifacts or burned-in elements, and reframing. Note: each call adds a new Crop effect instance to the clip rather than updating an existing one — call remove_effect with effectName "Crop" first if you need to reset.',
+        inputSchema: z.object({
+          clipId: z.string().describe('The ID of the timeline clip to crop'),
+          left: z.number().optional().describe('Percent to crop from the left edge (0-100)'),
+          right: z.number().optional().describe('Percent to crop from the right edge (0-100)'),
+          top: z.number().optional().describe('Percent to crop from the top edge (0-100)'),
+          bottom: z.number().optional().describe('Percent to crop from the bottom edge (0-100)'),
+          zoom: z.boolean().optional().describe('Crop effect Zoom toggle: when true, scales the cropped image back up to fill the frame instead of leaving the cropped area empty'),
+          edgeFeather: z.number().optional().describe('Edge Feather amount in pixels to soften the crop edges (default 0)')
+        })
+      },
+      {
         name: 'add_transition',
         description: 'Adds a transition (e.g., cross dissolve) between two adjacent clips on the timeline.',
         inputSchema: z.object({
@@ -1217,6 +1230,8 @@ export class PremiereProTools {
         // Effects and Transitions
         case 'apply_effect':
           return await this.applyEffect(args.clipId, args.effectName, args.parameters);
+        case 'crop_clip':
+          return await this.cropClip(args.clipId, { left: args.left, right: args.right, top: args.top, bottom: args.bottom, zoom: args.zoom, edgeFeather: args.edgeFeather });
         case 'remove_effect':
           return await this.removeEffect(args.clipId, args.effectName);
         case 'add_transition':
@@ -2904,6 +2919,22 @@ export class PremiereProTools {
     `;
 
     return await this.bridge.executeScript(script);
+  }
+
+  private async cropClip(clipId: string, options: { left?: number; right?: number; top?: number; bottom?: number; zoom?: boolean; edgeFeather?: number }): Promise<any> {
+    // Premiere's "Crop" video effect exposes Left/Top/Right/Bottom (percent 0-100),
+    // a Zoom toggle, and Edge Feather (pixels). Delegate to applyEffect, which adds
+    // the Crop effect via the QE DOM and sets each property by display-name — the
+    // same path verified to set all four crop edges correctly.
+    const opts = options || {};
+    const params: Record<string, any> = {};
+    if (opts.left !== undefined) params['Left'] = opts.left;
+    if (opts.top !== undefined) params['Top'] = opts.top;
+    if (opts.right !== undefined) params['Right'] = opts.right;
+    if (opts.bottom !== undefined) params['Bottom'] = opts.bottom;
+    if (opts.zoom !== undefined) params['Zoom'] = opts.zoom;
+    if (opts.edgeFeather !== undefined) params['Edge Feather'] = opts.edgeFeather;
+    return await this.applyEffect(clipId, 'Crop', params);
   }
 
   private async removeEffect(clipId: string, effectName: string): Promise<any> {


### PR DESCRIPTION
## Summary

Adds a `crop_clip` tool to crop a clip's frame using Premiere's built-in **Crop** video effect. Implements #39.

## API

```
crop_clip(clipId, { left?, right?, top?, bottom?, zoom?, edgeFeather? })
```

- `left` / `right` / `top` / `bottom` — percent 0–100 (maps to the Crop effect's Left / Top / Right / Bottom)
- `zoom` — boolean (Crop's Zoom toggle: scales the cropped image back to fill the frame)
- `edgeFeather` — pixels (softens the crop edges)

Delegates to `applyEffect(clipId, "Crop", {...})`, which adds the effect via the QE DOM and sets each property by display-name.

## Verification

The underlying mechanism is **verified live on Premiere Pro 2025** via the existing `apply_effect` tool that `crop_clip` wraps:

- `apply_effect(clip, "Crop", { Left: 40, Right: 40, Top: 15, Bottom: 15 })` → all four `paramResults` came back `ok: true`, `valueBefore: 0 → valueAfter: 40/15`, not clamped. The Crop component exposes exactly `Left / Top / Right / Bottom / Zoom / Edge Feather`.
- `export_frame` before/after confirmed the picture cropped correctly on all four sides (center band retained, edges trimmed).

`crop_clip` delegates to that exact path. Marked **draft** pending a tool-level live call (needs the MCP server reloaded onto this build) — will confirm and mark ready shortly.

## Notes

- v1 adds a new Crop effect instance per call (matching `apply_effect`'s behavior); `remove_effect` with effectName `"Crop"` resets it. A future enhancement could update an existing Crop instance instead of stacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)