### PR TITLE
Handle modal-prone imports and caption delete gap

### DIFF
--- a/src/__tests__/bridge/index.test.ts
+++ b/src/__tests__/bridge/index.test.ts
@@ -105,6 +105,20 @@ describe('PremiereProBridge', () => {
     expect(result.id).toBe('item-123');
   });
 
+  it('blocks modal-prone unsupported subtitle imports before writing a command', async () => {
+    const bridge = new PremiereProBridge();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.access.mockRejectedValue(new Error('Not found'));
+
+    await bridge.initialize();
+    const result: any = await bridge.importMedia('/path/to/captions.ass');
+
+    expect(result.success).toBe(false);
+    expect(result.blockedBeforePremiere).toBe(true);
+    expect(result.error).toContain('Unsupported import format ".ass"');
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+  });
+
   it('creates projects using a concrete .prproj path and verifies activation', async () => {
     const bridge = new PremiereProBridge();
     mockFs.mkdir.mockResolvedValue(undefined);

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -161,6 +161,18 @@ describe('PremiereProTools', () => {
       expect(result.error).toBe('Import failed');
     });
 
+    it('adds an actionable modal warning when import_media times out', async () => {
+      mockBridge.importMedia = jest.fn().mockRejectedValue(new Error('Bridge response timeout'));
+
+      const result = await tools.executeTool('import_media', {
+        filePath: '/path/to/captions.ass'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Bridge response timeout');
+      expect(result.warning).toContain('blocking modal dialog');
+    });
+
     it('passes through successful timeline placement', async () => {
       mockBridge.addToTimeline = jest.fn().mockResolvedValue({
         success: true,
@@ -259,6 +271,19 @@ describe('PremiereProTools', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Invalid arguments');
+      expect(mockBridge.executeScript).not.toHaveBeenCalled();
+    });
+
+    it('returns an explicit unsupported result for caption track deletion', async () => {
+      const result = await tools.executeTool('delete_track', {
+        sequenceId: 'seq-123',
+        trackType: 'caption',
+        trackIndex: 0
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.unsupportedByPremiereApi).toBe(true);
+      expect(result.error).toContain('Caption track deletion is not supported');
       expect(mockBridge.executeScript).not.toHaveBeenCalled();
     });
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -8,10 +8,15 @@
 import { Logger } from '../utils/logger.js';
 import { ChildProcess } from 'child_process';
 import { promises as fs } from 'fs';
-import { join } from 'path';
+import { extname, join } from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { createSecureTempDir, validateFilePath } from '../utils/security.js';
 import type { PremiereProTransport } from './types.js';
+
+const UNSUPPORTED_MODAL_PRONE_IMPORT_EXTENSIONS = new Set([
+  '.ass',
+  '.ssa'
+]);
 
 const EXTENDSCRIPT_HELPERS = `
 function __mcpEscapeString(value) {
@@ -416,6 +421,16 @@ export class PremiereProBridge implements PremiereProTransport {
 
     // Use the normalized path from validation (don't double-escape)
     const safePath = pathValidation.normalized || filePath;
+    const ext = extname(safePath).toLowerCase();
+    if (UNSUPPORTED_MODAL_PRONE_IMPORT_EXTENSIONS.has(ext)) {
+      return {
+        success: false,
+        error: `Unsupported import format "${ext}". Premiere Pro can show a blocking "File format not supported" modal for this file type, so the MCP server refused to import it before calling Premiere. Convert it to .srt or another Premiere-supported media format first.`,
+        filePath: safePath,
+        blockedBeforePremiere: true
+      } as any;
+    }
+
     const script = `
       try {
         function __walkItems(parent, output) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -582,10 +582,10 @@ export class PremiereProTools {
       },
       {
         name: 'delete_track',
-        description: 'Deletes a track from the sequence.',
+        description: 'Deletes a video or audio track from the sequence. Caption track deletion is accepted by the schema but returns an explicit unsupported result because Premiere Pro exposes no caption-track delete/read API to scripting.',
         inputSchema: z.object({
           sequenceId: z.string().describe('The ID of the sequence'),
-          trackType: z.enum(['video', 'audio']).describe('Type of track'),
+          trackType: z.enum(['video', 'audio', 'caption']).describe('Type of track'),
           trackIndex: z.number().describe('The index of the track to delete')
         })
       },
@@ -2131,10 +2131,15 @@ export class PremiereProTools {
         ...result
       };
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const maybeModalTimeout = /timeout|timed out/i.test(message);
       return {
         success: false,
-        error: `Failed to import media: ${error instanceof Error ? error.message : String(error)}`,
-        filePath: filePath
+        error: `Failed to import media: ${message}`,
+        filePath: filePath,
+        ...(maybeModalTimeout ? {
+          warning: 'Premiere may be showing a blocking modal dialog, such as "File format not supported". Dismiss the dialog in Premiere, then retry. For subtitle files, convert unsupported formats like .ass/.ssa to .srt before importing.'
+        } : {})
       };
     }
   }
@@ -4312,13 +4317,26 @@ export class PremiereProTools {
   }
 
   private async deleteTrack(_sequenceId: string, trackType: string, trackIndex: number): Promise<any> {
+    if (trackType === 'caption') {
+      return {
+        success: false,
+        error: 'Caption track deletion is not supported by Premiere Pro scripting. The ExtendScript DOM exposes no sequence.captionTracks/getCaptionTracks surface, and the QE DOM exposes no caption-track accessor or delete method.',
+        sequenceId: _sequenceId,
+        trackType,
+        trackIndex,
+        unsupportedByPremiereApi: true,
+        workaround: 'Delete caption tracks manually in Premiere, or remove/recreate captions from the source .srt before creating the caption track.'
+      };
+    }
+
     const script = `
       try {
-        var sequence = app.project.activeSequence;
+        var sequence = __findSequence(${JSON.stringify(_sequenceId)});
+        if (!sequence) sequence = app.project.activeSequence;
         if (!sequence) {
           return JSON.stringify({
             success: false,
-            error: "No active sequence"
+            error: "Sequence not found"
           });
         } else {
           var tracks = ${trackType === 'video' ? 'sequence.videoTracks' : 'sequence.audioTracks'};


### PR DESCRIPTION
## Summary
- refuse known modal-prone unsupported subtitle imports (`.ass`, `.ssa`) before calling Premiere, preventing the blocking "File format not supported" dialog from wedging the bridge
- add an actionable timeout warning for import_media when Premiere may already be showing a modal
- allow `delete_track` to accept `trackType: "caption"` and return an explicit unsupported-by-Premiere-API result instead of schema-rejecting it
- make video/audio `delete_track` honor `sequenceId` instead of always using the active sequence

## Verification
- `npm run build`
- `npm test -- --runInBand` (114 tests)
- live CEP bridge: `.ass` import returned `blockedBeforePremiere: true` and wrote zero command files
- live CEP bridge: caption `delete_track` returned `unsupportedByPremiereApi: true` and wrote zero command files
- live CEP bridge: `.srt` import still succeeded through Premiere
- live CEP bridge: after dismissing the Premiere modal, `get_project_info` and `list_sequences` succeeded
- live CEP bridge: `create_sequence` retry returned success in ~2.6s and the new sequence appeared in `list_sequences`

## Issue notes
- Addresses the preventable wedge path in #35 for known unsupported subtitle formats.
- Clarifies #36: live probing confirmed this CEP scripting surface has no `sequence.captionTracks`, no `getCaptionTracks()`, no QE caption-track accessor, and no QE caption delete method.
- #25 was retested after the modal was dismissed; the bridge and `create_sequence` path were responsive on this Mac test environment. The original slow false-negative behavior remains Windows-specific.