### PR TITLE
add_to_timeline: honor source in/out (Source-monitor overwrite)

### DIFF
--- a/cep-plugin/bridge-cep.js
+++ b/cep-plugin/bridge-cep.js
@@ -232,10 +232,10 @@
                 return;
             }
             done({ success: true, result: result, timestamp: new Date().toISOString() });
-        });
+        }, command.timeoutMs);
     };
 
-    MCPPremiereBridge.prototype.executeExtendScript = function(script, callback) {
+    MCPPremiereBridge.prototype.executeExtendScript = function(script, callback, requestedTimeoutMs) {
         var self = this;
         try {
             if (!this.csInterface) {
@@ -252,7 +252,12 @@
 
             var fullScript = EXTENDSCRIPT_COMPAT_HELPERS + '\n' + script;
             var settled = false;
+            // Honor a per-command timeout from the server (batch operations request up to 300s).
+            // Fall back to 45s when the server does not specify one, and never go below it.
             var timeoutMs = 45000;
+            if (typeof requestedTimeoutMs === 'number' && requestedTimeoutMs > timeoutMs) {
+                timeoutMs = requestedTimeoutMs;
+            }
             var timeoutId = setTimeout(function() {
                 if (settled) return;
                 settled = true;

--- a/src/__tests__/bridge/index.test.ts
+++ b/src/__tests__/bridge/index.test.ts
@@ -183,6 +183,53 @@ describe('PremiereProBridge', () => {
     expect(commandPayload.script).toContain('Sequence creation completed but the new sequence could not be located');
   });
 
+  it('honors per-clip linkAudio in addToTimelineBatch (mirrors single-call audio-counterpart cleanup)', async () => {
+    const bridge = new PremiereProBridge();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.access.mockRejectedValue(new Error('Not found'));
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ success: true, placed: 2, total: 2, results: [] }));
+    mockFs.unlink.mockResolvedValue(undefined);
+
+    await bridge.initialize();
+    await bridge.addToTimelineBatch('seq-1', [
+      { projectItemId: 'pi-1', trackIndex: 0, time: 0, linkAudio: false },
+      { projectItemId: 'pi-2', trackIndex: 0, time: 5 } // omitted → defaults to true
+    ]);
+    const commandPayload = JSON.parse(mockFs.writeFile.mock.calls[0][1] as string);
+
+    // per-clip linkAudio is embedded in the specs (explicit false + defaulted true)
+    expect(commandPayload.script).toContain('"linkAudio":false');
+    expect(commandPayload.script).toContain('"linkAudio":true');
+    // the counterpart-audio cleanup is mirrored from the single-call addToTimeline path
+    expect(commandPayload.script).toContain('spec.linkAudio === false');
+    expect(commandPayload.script).toContain('audioClip.remove(false, false)');
+    expect(commandPayload.script).toContain('unlinkedAudioRemoved');
+  });
+
+  it('reports aggregate success/partial/failure in addToTimelineBatch instead of always claiming success', async () => {
+    const bridge = new PremiereProBridge();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.access.mockRejectedValue(new Error('Not found'));
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ success: false, status: 'partial', placed: 1, failed: 1, total: 2, results: [] }));
+    mockFs.unlink.mockResolvedValue(undefined);
+
+    await bridge.initialize();
+    await bridge.addToTimelineBatch('seq-1', [
+      { projectItemId: 'pi-1', trackIndex: 0, time: 0 },
+      { projectItemId: 'pi-2', trackIndex: 0, time: 5 }
+    ]);
+    const commandPayload = JSON.parse(mockFs.writeFile.mock.calls[0][1] as string);
+
+    // aggregate success is derived from the placed count, not hard-coded true
+    expect(commandPayload.script).toContain('var allPlaced = (specs.length > 0 && placed === specs.length)');
+    expect(commandPayload.script).toContain('success: allPlaced');
+    expect(commandPayload.script).toContain('status:');
+    // the old always-true aggregate must be gone
+    expect(commandPayload.script).not.toContain('success: true, placed: placed, total: specs.length');
+  });
+
   it('does not delete externally managed temp directories during cleanup', async () => {
     const bridge = new PremiereProBridge();
     mockFs.mkdir.mockResolvedValue(undefined);

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -392,8 +392,8 @@ describe('PremiereProTools', () => {
       expect(result.message).toContain('directed clip plan');
       expect(result.transitions).toHaveLength(0);
       expect(result.animations).toHaveLength(0);
-      expect(mockBridge.addToTimeline).toHaveBeenNthCalledWith(1, 'seq-2b', 'item-a', 1, 1.5, true);
-      expect(mockBridge.addToTimeline).toHaveBeenNthCalledWith(2, 'seq-2b', 'item-b', 2, 3.6, true);
+      expect(mockBridge.addToTimeline).toHaveBeenNthCalledWith(1, 'seq-2b', 'item-a', 1, 1.5, true, undefined, undefined);
+      expect(mockBridge.addToTimeline).toHaveBeenNthCalledWith(2, 'seq-2b', 'item-b', 2, 3.6, true, undefined, undefined);
     });
 
     it('builds a brand spot from assets without requiring a mogrt', async () => {

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -728,11 +728,13 @@ export class PremiereProBridge implements PremiereProTransport {
   // single-clip logic: audio-only routing by extension, Source-monitor in/out marking (mediaType
   // 4 with per-stream + no-arg fallbacks), overwriteClip. Returns a per-clip result array so a
   // single bad clip never sinks the batch.
-  async addToTimelineBatch(sequenceId: string, clips: Array<{ projectItemId: string; trackIndex: number; time: number; sourceInPoint?: number; sourceOutPoint?: number }>): Promise<any> {
+  async addToTimelineBatch(sequenceId: string, clips: Array<{ projectItemId: string; trackIndex: number; time: number; linkAudio?: boolean; sourceInPoint?: number; sourceOutPoint?: number }>): Promise<any> {
     const specs = clips.map(c => ({
       projectItemId: c.projectItemId,
       trackIndex: c.trackIndex,
       time: c.time,
+      // Mirror the single-call default (true = keep Premiere's native audio linking).
+      linkAudio: c.linkAudio === undefined ? true : c.linkAudio,
       sourceInPoint: c.sourceInPoint === undefined ? null : c.sourceInPoint,
       sourceOutPoint: c.sourceOutPoint === undefined ? null : c.sourceOutPoint,
     }));
@@ -795,6 +797,36 @@ export class PremiereProBridge implements PremiereProTransport {
             r.name = placedClip.name;
             r.inPoint = placedClip.start.seconds;
             r.outPoint = placedClip.end.seconds;
+
+            // linkAudio=false cleanup — mirror the single-call addToTimeline path so batch
+            // rebuild/overlay workflows don't reintroduce the silent embedded-audio overwrite
+            // bug. When a video-track clip's source carries an embedded audio stream, Premiere
+            // auto-links and overwrites its counterpart onto an audio track, which can DESTROY
+            // existing audio. When linkAudio is false, remove that counterpart at the same
+            // start time. The video on the target track is untouched.
+            r.linkAudio = spec.linkAudio;
+            r.unlinkedAudioRemoved = 0;
+            if (!isAudioOnly && spec.linkAudio === false) {
+              var videoStart = placedClip.start.seconds;
+              var tolerance = 0.1;
+              for (var at = 0; at < sequence.audioTracks.numTracks; at++) {
+                var audioTrack = sequence.audioTracks[at];
+                // iterate backwards because remove() may shift indices
+                for (var ai = audioTrack.clips.numItems - 1; ai >= 0; ai--) {
+                  var audioClip = audioTrack.clips[ai];
+                  if (audioClip && audioClip.projectItem &&
+                      audioClip.projectItem.nodeId === projectItem.nodeId &&
+                      Math.abs(audioClip.start.seconds - videoStart) < tolerance) {
+                    try {
+                      audioClip.remove(false, false); // ripple=false, alignToVideo=false
+                      r.unlinkedAudioRemoved++;
+                    } catch (rmErr) {
+                      // best effort — don't fail this clip over cleanup
+                    }
+                  }
+                }
+              }
+            }
           } catch (e) {
             r.error = e.toString();
           }
@@ -802,7 +834,19 @@ export class PremiereProBridge implements PremiereProTransport {
         }
         var placed = 0;
         for (var k = 0; k < results.length; k++) { if (results[k].success) placed++; }
-        return JSON.stringify({ success: true, placed: placed, total: specs.length, results: results });
+        var failed = specs.length - placed;
+        // Aggregate status must reflect reality: success is true ONLY when every requested
+        // clip placed. placed===0 => failure; some-but-not-all => partial. Per-clip results[]
+        // still carry the detail. (PR #48 review: don't report success when placements failed.)
+        var allPlaced = (specs.length > 0 && placed === specs.length);
+        return JSON.stringify({
+          success: allPlaced,
+          status: (placed === 0 ? "failure" : (allPlaced ? "success" : "partial")),
+          placed: placed,
+          failed: failed,
+          total: specs.length,
+          results: results
+        });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
       }

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -250,7 +250,7 @@ export class PremiereProBridge implements PremiereProTransport {
     return EXTENDSCRIPT_HELPERS + '(function(){\n' + script + '\n})();';
   }
 
-  async executeScript(script: string): Promise<any> {
+  async executeScript(script: string, timeoutMs?: number): Promise<any> {
     if (!this.isInitialized) {
       throw new Error('Bridge not initialized. Call initialize() first.');
     }
@@ -262,15 +262,20 @@ export class PremiereProBridge implements PremiereProTransport {
     try {
       const fullScript = this.buildExecutableScript(script);
 
-      // Write command to file
+      // Write command to file. Include timeoutMs so the CEP/UXP panel can extend its own
+      // execution watchdog to match — otherwise the panel's default (45s) kills long batch
+      // scripts well before the server's own timeout elapses.
       await fs.writeFile(commandFile, JSON.stringify({
         id: commandId,
         script: fullScript,
+        timeoutMs: timeoutMs,
         timestamp: new Date().toISOString()
       }));
 
-      // Wait for response (in a real implementation, this would be handled by the UXP plugin)
-      const response = await this.waitForResponse(responseFile);
+      // Wait for response (in a real implementation, this would be handled by the UXP plugin).
+      // Batch operations pass a larger timeout because a single round-trip does the work of
+      // dozens of individual calls inside one ExtendScript pass.
+      const response = await this.waitForResponse(responseFile, timeoutMs);
       
       // Clean up files
       await fs.unlink(commandFile).catch(() => {});
@@ -715,6 +720,94 @@ export class PremiereProBridge implements PremiereProTransport {
     `;
 
     return await this.executeScript(script);
+  }
+
+  // Batch variant of addToTimeline: place many clips in ONE ExtendScript round-trip.
+  // The per-call file/WS round-trip (~seconds each, 60s timeout) is the real bottleneck when
+  // placing a whole edit; looping inside one script collapses N round-trips into 1. Mirrors the
+  // single-clip logic: audio-only routing by extension, Source-monitor in/out marking (mediaType
+  // 4 with per-stream + no-arg fallbacks), overwriteClip. Returns a per-clip result array so a
+  // single bad clip never sinks the batch.
+  async addToTimelineBatch(sequenceId: string, clips: Array<{ projectItemId: string; trackIndex: number; time: number; sourceInPoint?: number; sourceOutPoint?: number }>): Promise<any> {
+    const specs = clips.map(c => ({
+      projectItemId: c.projectItemId,
+      trackIndex: c.trackIndex,
+      time: c.time,
+      sourceInPoint: c.sourceInPoint === undefined ? null : c.sourceInPoint,
+      sourceOutPoint: c.sourceOutPoint === undefined ? null : c.sourceOutPoint,
+    }));
+    const script = `
+      try {
+        var sequence = __findSequence(${JSON.stringify(sequenceId)});
+        if (!sequence) {
+          return JSON.stringify({ success: false, error: "Sequence not found" });
+        }
+        var specs = ${JSON.stringify(specs)};
+        var results = [];
+        for (var c = 0; c < specs.length; c++) {
+          var spec = specs[c];
+          var r = { index: c, time: spec.time, success: false };
+          try {
+            var projectItem = __findProjectItem(spec.projectItemId);
+            if (!projectItem) { r.error = "Project item not found"; results.push(r); continue; }
+
+            var mediaPath = projectItem.getMediaPath ? projectItem.getMediaPath() : "";
+            var isAudioOnly = /\\.(mp3|wav|aif|aiff|m4a|aac|flac|ogg|wma)$/i.test(mediaPath);
+            var track = isAudioOnly ? sequence.audioTracks[spec.trackIndex] : sequence.videoTracks[spec.trackIndex];
+            if (!track) { r.error = "Track not found at index " + spec.trackIndex; results.push(r); continue; }
+
+            if (spec.sourceInPoint !== null && spec.sourceOutPoint !== null) {
+              try {
+                projectItem.setInPoint(spec.sourceInPoint, 4);
+                projectItem.setOutPoint(spec.sourceOutPoint, 4);
+              } catch (eio) {
+                try {
+                  projectItem.setInPoint(spec.sourceInPoint, 1);
+                  projectItem.setOutPoint(spec.sourceOutPoint, 1);
+                  projectItem.setInPoint(spec.sourceInPoint, 2);
+                  projectItem.setOutPoint(spec.sourceOutPoint, 2);
+                } catch (eio2) {
+                  try {
+                    projectItem.setInPoint(spec.sourceInPoint);
+                    projectItem.setOutPoint(spec.sourceOutPoint);
+                  } catch (eio3) {}
+                }
+              }
+            }
+
+            track.overwriteClip(projectItem, spec.time);
+
+            var placedClip = null;
+            for (var i = 0; i < track.clips.numItems; i++) {
+              var candidate = track.clips[i];
+              if (candidate && candidate.projectItem && candidate.projectItem.nodeId === projectItem.nodeId && Math.abs(candidate.start.seconds - spec.time) < 0.1) {
+                placedClip = candidate;
+                break;
+              }
+            }
+            if (!placedClip && track.clips.numItems > 0) {
+              placedClip = track.clips[track.clips.numItems - 1];
+            }
+            if (!placedClip) { r.error = "Clip placement did not produce a track item"; results.push(r); continue; }
+
+            r.success = true;
+            r.id = placedClip.nodeId;
+            r.name = placedClip.name;
+            r.inPoint = placedClip.start.seconds;
+            r.outPoint = placedClip.end.seconds;
+          } catch (e) {
+            r.error = e.toString();
+          }
+          results.push(r);
+        }
+        var placed = 0;
+        for (var k = 0; k < results.length; k++) { if (results[k].success) placed++; }
+        return JSON.stringify({ success: true, placed: placed, total: specs.length, results: results });
+      } catch (e) {
+        return JSON.stringify({ success: false, error: e.toString() });
+      }
+    `;
+    return await this.executeScript(script, 300000);
   }
 
   async renderSequence(sequenceId: string, outputPath: string, presetPath: string): Promise<any> {

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -574,7 +574,7 @@ export class PremiereProBridge implements PremiereProTransport {
     return await this.executeScript(script);
   }
 
-  async addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio: boolean = true): Promise<PremiereProClip> {
+  async addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio: boolean = true, sourceInPoint?: number, sourceOutPoint?: number): Promise<PremiereProClip> {
     const script = `
       try {
         var sequence = __findSequence("${sequenceId}");
@@ -605,6 +605,41 @@ export class PremiereProBridge implements PremiereProTransport {
           track = sequence.videoTracks[${trackIndex}];
           if (!track) {
             return JSON.stringify({ success: false, error: "Video track not found at index ${trackIndex}", videoTrackCount: sequence.videoTracks.numTracks });
+          }
+        }
+
+        // Source in/out: replicate the Source-monitor "mark in / mark out then
+        // overwrite" move. overwriteClip(projectItem, time) places whatever range
+        // is currently marked on the projectItem, so set the marks first. Without
+        // this, an arbitrary interior sub-range of a source cannot be placed.
+        var srcIn = ${sourceInPoint === undefined ? 'null' : sourceInPoint};
+        var srcOut = ${sourceOutPoint === undefined ? 'null' : sourceOutPoint};
+        var appliedSourceInOut = false;
+        var sourceInOutError = "";
+        if (srcIn !== null && srcOut !== null) {
+          try {
+            // mediaType 4 = all streams (video + audio) in one call
+            projectItem.setInPoint(srcIn, 4);
+            projectItem.setOutPoint(srcOut, 4);
+            appliedSourceInOut = true;
+          } catch (eio) {
+            try {
+              // fall back to per-stream marks (video=1, audio=2)
+              projectItem.setInPoint(srcIn, 1);
+              projectItem.setOutPoint(srcOut, 1);
+              projectItem.setInPoint(srcIn, 2);
+              projectItem.setOutPoint(srcOut, 2);
+              appliedSourceInOut = true;
+            } catch (eio2) {
+              try {
+                // last resort: no mediaType arg
+                projectItem.setInPoint(srcIn);
+                projectItem.setOutPoint(srcOut);
+                appliedSourceInOut = true;
+              } catch (eio3) {
+                sourceInOutError = String(eio3);
+              }
+            }
           }
         }
 
@@ -667,7 +702,9 @@ export class PremiereProBridge implements PremiereProTransport {
           duration: placedClip.duration.seconds,
           mediaPath: placedClip.projectItem && placedClip.projectItem.getMediaPath ? placedClip.projectItem.getMediaPath() : "",
           linkAudio: ${linkAudio},
-          unlinkedAudioRemoved: unlinkedAudioRemoved
+          unlinkedAudioRemoved: unlinkedAudioRemoved,
+          appliedSourceInOut: appliedSourceInOut,
+          sourceInOutError: sourceInOutError
         });
       } catch (e) {
         return JSON.stringify({

--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -12,7 +12,7 @@ export interface PremiereProTransport {
   saveProject(): Promise<void>;
   importMedia(filePath: string): Promise<PremiereProProjectItem>;
   createSequence(name: string, presetPath?: string): Promise<PremiereProSequence>;
-  addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio?: boolean): Promise<PremiereProClip>;
+  addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio?: boolean, sourceInPoint?: number, sourceOutPoint?: number): Promise<PremiereProClip>;
   renderSequence(sequenceId: string, outputPath: string, presetPath: string): Promise<{
     success: boolean;
     queued?: boolean;

--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -13,7 +13,7 @@ export interface PremiereProTransport {
   importMedia(filePath: string): Promise<PremiereProProjectItem>;
   createSequence(name: string, presetPath?: string): Promise<PremiereProSequence>;
   addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio?: boolean, sourceInPoint?: number, sourceOutPoint?: number): Promise<PremiereProClip>;
-  addToTimelineBatch(sequenceId: string, clips: Array<{ projectItemId: string; trackIndex: number; time: number; sourceInPoint?: number; sourceOutPoint?: number }>): Promise<any>;
+  addToTimelineBatch(sequenceId: string, clips: Array<{ projectItemId: string; trackIndex: number; time: number; linkAudio?: boolean; sourceInPoint?: number; sourceOutPoint?: number }>): Promise<any>;
   renderSequence(sequenceId: string, outputPath: string, presetPath: string): Promise<{
     success: boolean;
     queued?: boolean;

--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -6,13 +6,14 @@ import type {
 } from './index.js';
 
 export interface PremiereProTransport {
-  executeScript(script: string): Promise<any>;
+  executeScript(script: string, timeoutMs?: number): Promise<any>;
   createProject(name: string, location: string): Promise<PremiereProProject>;
   openProject(path: string): Promise<PremiereProProject>;
   saveProject(): Promise<void>;
   importMedia(filePath: string): Promise<PremiereProProjectItem>;
   createSequence(name: string, presetPath?: string): Promise<PremiereProSequence>;
   addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio?: boolean, sourceInPoint?: number, sourceOutPoint?: number): Promise<PremiereProClip>;
+  addToTimelineBatch(sequenceId: string, clips: Array<{ projectItemId: string; trackIndex: number; time: number; sourceInPoint?: number; sourceOutPoint?: number }>): Promise<any>;
   renderSequence(sequenceId: string, outputPath: string, presetPath: string): Promise<{
     success: boolean;
     queued?: boolean;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -306,7 +306,9 @@ export class PremiereProTools {
           trackIndex: z.number().describe('The index of the video or audio track (0-based)'),
           time: z.number().describe('The time in seconds where the clip should be placed on the timeline'),
           insertMode: z.enum(['overwrite', 'insert']).optional().describe('Whether to overwrite existing content or insert and shift'),
-          linkAudio: z.boolean().optional().describe('When false, removes the auto-linked audio counterpart that Premiere places on audio tracks for video-track clips. Useful for video overlays whose source media (e.g. Remotion .mov outputs) carry silent PCM that would overwrite existing audio. Default true (preserves Premiere\'s native linking behavior).')
+          linkAudio: z.boolean().optional().describe('When false, removes the auto-linked audio counterpart that Premiere places on audio tracks for video-track clips. Useful for video overlays whose source media (e.g. Remotion .mov outputs) carry silent PCM that would overwrite existing audio. Default true (preserves Premiere\'s native linking behavior).'),
+          sourceInPoint: z.number().optional().describe('Source IN point in seconds — the start of the sub-range to pull from the source (footage or sequence). Replicates marking an in point in the Source monitor. Requires sourceOutPoint. When omitted, the whole source (or its current marks) is placed.'),
+          sourceOutPoint: z.number().optional().describe('Source OUT point in seconds — the end of the sub-range to pull from the source. Replicates marking an out point in the Source monitor. Requires sourceInPoint.')
         })
       },
       {
@@ -1202,7 +1204,7 @@ export class PremiereProTools {
 
         // Timeline Operations
         case 'add_to_timeline':
-          return await this.addToTimeline(args.sequenceId, args.projectItemId, args.trackIndex, args.time, args.insertMode, args.linkAudio);
+          return await this.addToTimeline(args.sequenceId, args.projectItemId, args.trackIndex, args.time, args.insertMode, args.linkAudio, args.sourceInPoint, args.sourceOutPoint);
         case 'remove_from_timeline':
           return await this.removeFromTimeline(args.clipId, args.sequenceId, args.deleteMode);
         case 'move_clip':
@@ -2530,9 +2532,9 @@ export class PremiereProTools {
   }
 
   // Timeline Operations Implementation
-  private async addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, insertMode = 'overwrite', linkAudio: boolean = true): Promise<any> {
+  private async addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, insertMode = 'overwrite', linkAudio: boolean = true, sourceInPoint?: number, sourceOutPoint?: number): Promise<any> {
     try {
-      const result: any = await this.bridge.addToTimeline(sequenceId, projectItemId, trackIndex, time, linkAudio);
+      const result: any = await this.bridge.addToTimeline(sequenceId, projectItemId, trackIndex, time, linkAudio, sourceInPoint, sourceOutPoint);
       if (!result.success) {
         return {
           ...result,
@@ -2541,7 +2543,9 @@ export class PremiereProTools {
           trackIndex: trackIndex,
           time: time,
           insertMode: insertMode,
-          linkAudio: linkAudio
+          linkAudio: linkAudio,
+          sourceInPoint: sourceInPoint,
+          sourceOutPoint: sourceOutPoint
         };
       }
       return {
@@ -2553,6 +2557,8 @@ export class PremiereProTools {
         time: time,
         insertMode: insertMode,
         linkAudio: linkAudio,
+        sourceInPoint: sourceInPoint,
+        sourceOutPoint: sourceOutPoint,
         ...result
       };
     } catch (error) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -314,13 +314,14 @@ export class PremiereProTools {
       },
       {
         name: 'add_to_timeline_batch',
-        description: 'Places MANY clips onto one sequence in a single round-trip — the fast path for rebuilding a whole edit (e.g. a Descript/EDL stringout). Equivalent to calling add_to_timeline (overwrite) once per clip, but ~50x faster because it loops inside one ExtendScript pass instead of one file round-trip per clip. Each clip supports per-clip sourceInPoint/sourceOutPoint (Source-monitor in/out). Returns a per-clip result array so one bad clip does not sink the batch.',
+        description: 'Places MANY clips onto one sequence in a single round-trip — the fast path for rebuilding a whole edit (e.g. a Descript/EDL stringout). Equivalent to calling add_to_timeline (overwrite) once per clip, but ~50x faster because it loops inside one ExtendScript pass instead of one file round-trip per clip. Each clip supports per-clip linkAudio and sourceInPoint/sourceOutPoint (Source-monitor in/out). Returns a per-clip result array so one bad clip does not sink the batch, plus an aggregate status: top-level success is true ONLY when every clip placed; status is "success" | "partial" | "failure" with placed/failed/total counts.',
         inputSchema: z.object({
           sequenceId: z.string().describe('The ID of the sequence (timeline) to add clips to'),
           clips: z.array(z.object({
             projectItemId: z.string().describe('The ID of the project item (clip / multicam) to add'),
             trackIndex: z.number().describe('The index of the video or audio track (0-based)'),
             time: z.number().describe('Timeline position in seconds where the clip is placed (overwrite)'),
+            linkAudio: z.boolean().optional().describe('When false, removes the auto-linked audio counterpart Premiere places on audio tracks for a video-track clip whose source carries an embedded audio stream (prevents overwriting existing audio in overlay/rebuild workflows). Default true (preserves Premiere\'s native linking).'),
             sourceInPoint: z.number().optional().describe('Source IN point in seconds (requires sourceOutPoint)'),
             sourceOutPoint: z.number().optional().describe('Source OUT point in seconds (requires sourceInPoint)')
           })).describe('Ordered list of clips to place. All use overwrite mode.')
@@ -2607,7 +2608,7 @@ export class PremiereProTools {
   }
 
   // Timeline Operations Implementation
-  private async addToTimelineBatch(sequenceId: string, clips: Array<{ projectItemId: string; trackIndex: number; time: number; sourceInPoint?: number; sourceOutPoint?: number }>): Promise<any> {
+  private async addToTimelineBatch(sequenceId: string, clips: Array<{ projectItemId: string; trackIndex: number; time: number; linkAudio?: boolean; sourceInPoint?: number; sourceOutPoint?: number }>): Promise<any> {
     try {
       const result: any = await this.bridge.addToTimelineBatch(sequenceId, clips);
       return { sequenceId, requested: clips.length, ...result };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -698,7 +698,7 @@ export class PremiereProTools {
       },
       {
         name: 'get_clip_properties',
-        description: 'Gets detailed properties of a clip. Pass sequenceId when the clip ID came from list_sequence_tracks for a non-active sequence.',
+        description: 'Gets detailed properties of a clip, INCLUDING current Motion values (opacity/scale/rotation/position). Position is returned both normalized (0..1) and in PIXELS (`motion.position`, using the sequence frame size) so you can verify or copy framing without exporting a frame. Pass sequenceId when the clip ID came from list_sequence_tracks for a non-active sequence.',
         inputSchema: z.object({
           clipId: z.string().describe('The ID of the clip'),
           sequenceId: z.string().optional().describe('Optional sequence ID to search. If omitted, searches the active sequence first, then all sequences.')
@@ -722,7 +722,7 @@ export class PremiereProTools {
       },
       {
         name: 'set_clip_properties_batch',
-        description: 'Applies Motion properties (opacity/scale/rotation/position) to MANY clips in a single round-trip — the fast path for per-speaker framing across a whole rebuilt edit. ~50x faster than one set_clip_properties call per clip. Returns a per-clip result array.',
+        description: 'Applies Motion properties (opacity/scale/rotation/position) to MANY clips in a single round-trip — the fast path for per-speaker framing across a whole rebuilt edit. ~50x faster than one set_clip_properties call per clip. Returns a per-clip result array; each result carries an `applied` map ({opacity,scale,rotation,position}) and `success` is true only when EVERY requested property was actually found and set (a missing Motion property is reported, not silently ignored).',
         inputSchema: z.object({
           items: z.array(z.object({
             clipId: z.string().describe('The ID of the clip'),
@@ -4486,6 +4486,41 @@ export class PremiereProTools {
         var info = __findClip(${JSON.stringify(clipId)}, ${sequenceId ? JSON.stringify(sequenceId) : 'null'});
         if (!info) return JSON.stringify({ success: false, error: ${sequenceId ? JSON.stringify(`Clip not found in sequence: ${sequenceId}`) : '"Clip not found"'} });
         var clip = info.clip;
+
+        // Read back Motion (opacity/scale/rotation/position). Position is stored NORMALIZED
+        // (0..1); expose both the raw normalized value and PIXELS (using the sequence frame size)
+        // so callers can verify/copy framing without exporting a frame. Only present for video clips.
+        var __seqW = 1920, __seqH = 1080;
+        try {
+          if (info.sequence) {
+            if (info.sequence.frameSizeHorizontal) { __seqW = info.sequence.frameSizeHorizontal; __seqH = info.sequence.frameSizeVertical; }
+            else { var __ss = info.sequence.getSettings(); if (__ss) { __seqW = __ss.videoFrameWidth; __seqH = __ss.videoFrameHeight; } }
+          }
+        } catch (e0) {}
+        var motion = null;
+        try {
+          var m = {};
+          for (var ci = 0; ci < clip.components.numItems; ci++) {
+            var comp = clip.components[ci];
+            for (var pj = 0; pj < comp.properties.numItems; pj++) {
+              var pp = comp.properties[pj];
+              try {
+                if (pp.displayName === "Opacity") m.opacity = pp.getValue();
+                else if (pp.displayName === "Scale") m.scale = pp.getValue();
+                else if (pp.displayName === "Rotation") m.rotation = pp.getValue();
+                else if (pp.displayName === "Position") {
+                  var pv = pp.getValue();
+                  if (pv && pv.length >= 2) {
+                    m.positionNormalized = { x: pv[0], y: pv[1] };
+                    m.position = { x: Math.round(pv[0] * __seqW * 1000) / 1000, y: Math.round(pv[1] * __seqH * 1000) / 1000 };
+                  }
+                }
+              } catch (ep) {}
+            }
+          }
+          motion = m;
+        } catch (em) { motion = null; }
+
         return JSON.stringify({
           success: true,
           properties: {
@@ -4500,6 +4535,8 @@ export class PremiereProTools {
             trackType: info.trackType,
             sequenceId: info.sequenceId,
             sequenceName: info.sequenceName,
+            frameSize: { width: __seqW, height: __seqH },
+            motion: motion,
             speed: clip.getSpeed()
           }
         });
@@ -4514,24 +4551,21 @@ export class PremiereProTools {
   }
 
   private async setClipProperties(clipId: string, properties: any): Promise<any> {
-    const posX = properties?.position?.x;
-    const posY = properties?.position?.y;
-    const propCode = [
-      properties?.opacity !== undefined ? `if (p.displayName === "Opacity") p.setValue(${properties.opacity}, true);` : '',
-      properties?.scale !== undefined ? `if (p.displayName === "Scale") p.setValue(${properties.scale}, true);` : '',
-      properties?.rotation !== undefined ? `if (p.displayName === "Rotation") p.setValue(${properties.rotation}, true);` : '',
-      // Position is the Motion "Position" property. Callers pass PIXEL coordinates matching the
-      // Effect Controls panel (e.g. 960,756 in a 1920x1280 sequence); the API stores it as a
-      // NORMALIZED [x,y] (0..1, 0.5,0.5 = frame center), so divide by the sequence frame size
-      // (__seqW/__seqH, computed below). When only one axis is supplied, keep the current value
-      // for the other. Position was previously accepted by the schema but silently dropped here.
-      (posX !== undefined || posY !== undefined)
-        ? `if (p.displayName === "Position") { var __cur = [0.5, 0.5]; try { __cur = p.getValue(); } catch (ep) {} var __nx = ${posX !== undefined ? `(${posX})/__seqW` : '__cur[0]'}; var __ny = ${posY !== undefined ? `(${posY})/__seqH` : '__cur[1]'}; p.setValue([__nx, __ny], true); }`
-        : '',
-    ].filter(Boolean).join('\n              ');
-
+    // Position is the Motion "Position" property. Callers pass PIXEL coordinates matching the
+    // Effect Controls panel (e.g. 960,756 in a 1920x1280 sequence); the API stores it as a
+    // NORMALIZED [x,y] (0..1, 0.5,0.5 = frame center), so we divide by the sequence frame size
+    // (__seqW/__seqH). Per-property flags surface a silently-failed setValue or a missing Motion
+    // property instead of reporting a blanket success.
+    const spec = {
+      opacity: properties?.opacity === undefined ? null : properties.opacity,
+      scale: properties?.scale === undefined ? null : properties.scale,
+      rotation: properties?.rotation === undefined ? null : properties.rotation,
+      posX: properties?.position?.x === undefined ? null : properties.position.x,
+      posY: properties?.position?.y === undefined ? null : properties.position.y,
+    };
     const script = `
       try {
+        var it = ${JSON.stringify(spec)};
         var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
         var clip = info.clip;
@@ -4544,16 +4578,37 @@ export class PremiereProTools {
             else { var __ss = info.sequence.getSettings(); if (__ss) { __seqW = __ss.videoFrameWidth; __seqH = __ss.videoFrameHeight; } }
           }
         } catch (e0) {}
+        var want = { opacity: it.opacity !== null, scale: it.scale !== null, rotation: it.rotation !== null, position: (it.posX !== null || it.posY !== null) };
+        var done = { opacity: false, scale: false, rotation: false, position: false };
         for (var i = 0; i < clip.components.numItems; i++) {
           var comp = clip.components[i];
           for (var j = 0; j < comp.properties.numItems; j++) {
             var p = comp.properties[j];
             try {
-              ${propCode}
+              if (want.opacity && p.displayName === "Opacity") { p.setValue(it.opacity, true); done.opacity = true; }
+              if (want.scale && p.displayName === "Scale") { p.setValue(it.scale, true); done.scale = true; }
+              if (want.rotation && p.displayName === "Rotation") { p.setValue(it.rotation, true); done.rotation = true; }
+              if (want.position && p.displayName === "Position") {
+                var __cur = [0.5, 0.5];
+                try { __cur = p.getValue(); } catch (ep) {}
+                var __nx = it.posX !== null ? (it.posX / __seqW) : __cur[0];
+                var __ny = it.posY !== null ? (it.posY / __seqH) : __cur[1];
+                p.setValue([__nx, __ny], true);
+                done.position = true;
+              }
             } catch (e2) {}
           }
         }
-        return JSON.stringify({ success: true, message: "Clip properties updated" });
+        var missing = [];
+        if (want.opacity && !done.opacity) missing.push("opacity");
+        if (want.scale && !done.scale) missing.push("scale");
+        if (want.rotation && !done.rotation) missing.push("rotation");
+        if (want.position && !done.position) missing.push("position");
+        return JSON.stringify({
+          success: (missing.length === 0),
+          applied: done,
+          message: missing.length ? ("properties not applied: " + missing.join(", ")) : "Clip properties updated"
+        });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
       }
@@ -4592,25 +4647,37 @@ export class PremiereProTools {
                 else { var __ss = info.sequence.getSettings(); if (__ss) { __seqW = __ss.videoFrameWidth; __seqH = __ss.videoFrameHeight; } }
               }
             } catch (e0) {}
+            // Track which requested properties we actually FOUND and SET, so a silently-failed
+            // setValue (or a Motion property that isn't present) surfaces instead of a false success.
+            var want = { opacity: it.opacity !== null, scale: it.scale !== null, rotation: it.rotation !== null, position: (it.posX !== null || it.posY !== null) };
+            var done = { opacity: false, scale: false, rotation: false, position: false };
             for (var i = 0; i < clip.components.numItems; i++) {
               var comp = clip.components[i];
               for (var j = 0; j < comp.properties.numItems; j++) {
                 var p = comp.properties[j];
                 try {
-                  if (it.opacity !== null && p.displayName === "Opacity") p.setValue(it.opacity, true);
-                  if (it.scale !== null && p.displayName === "Scale") p.setValue(it.scale, true);
-                  if (it.rotation !== null && p.displayName === "Rotation") p.setValue(it.rotation, true);
-                  if ((it.posX !== null || it.posY !== null) && p.displayName === "Position") {
+                  if (want.opacity && p.displayName === "Opacity") { p.setValue(it.opacity, true); done.opacity = true; }
+                  if (want.scale && p.displayName === "Scale") { p.setValue(it.scale, true); done.scale = true; }
+                  if (want.rotation && p.displayName === "Rotation") { p.setValue(it.rotation, true); done.rotation = true; }
+                  if (want.position && p.displayName === "Position") {
                     var __cur = [0.5, 0.5];
                     try { __cur = p.getValue(); } catch (ep) {}
                     var __nx = it.posX !== null ? (it.posX / __seqW) : __cur[0];
                     var __ny = it.posY !== null ? (it.posY / __seqH) : __cur[1];
                     p.setValue([__nx, __ny], true);
+                    done.position = true;
                   }
                 } catch (e2) {}
               }
             }
-            r.success = true;
+            var missing = [];
+            if (want.opacity && !done.opacity) missing.push("opacity");
+            if (want.scale && !done.scale) missing.push("scale");
+            if (want.rotation && !done.rotation) missing.push("rotation");
+            if (want.position && !done.position) missing.push("position");
+            r.applied = done;
+            r.success = (missing.length === 0);
+            if (missing.length) r.error = "properties not applied: " + missing.join(", ");
           } catch (e) {
             r.error = e.toString();
           }
@@ -4618,7 +4685,7 @@ export class PremiereProTools {
         }
         var applied = 0;
         for (var k = 0; k < results.length; k++) { if (results[k].success) applied++; }
-        return JSON.stringify({ success: true, applied: applied, total: specs.length, results: results });
+        return JSON.stringify({ success: (applied === specs.length), applied: applied, total: specs.length, results: results });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
       }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -282,10 +282,11 @@ export class PremiereProTools {
       },
       {
         name: 'duplicate_sequence',
-        description: 'Creates a copy of an existing sequence with a new name.',
+        description: 'Creates a copy of an existing sequence with a new name. Set clearContents=true to get an EMPTY copy that inherits the source sequence\'s exact settings (frame rate, resolution, track layout) — the reliable way to auto-create a correctly-specced blank target, since create_sequence ignores frame rate.',
         inputSchema: z.object({
           sequenceId: z.string().describe('The ID of the sequence to duplicate'),
-          newName: z.string().describe('The name for the new sequence copy')
+          newName: z.string().describe('The name for the new sequence copy'),
+          clearContents: z.boolean().optional().describe('When true, remove all clips from the copy so it is empty but keeps the source\'s frame rate/resolution/track layout. Default false (full copy).')
         })
       },
       {
@@ -309,6 +310,20 @@ export class PremiereProTools {
           linkAudio: z.boolean().optional().describe('When false, removes the auto-linked audio counterpart that Premiere places on audio tracks for video-track clips. Useful for video overlays whose source media (e.g. Remotion .mov outputs) carry silent PCM that would overwrite existing audio. Default true (preserves Premiere\'s native linking behavior).'),
           sourceInPoint: z.number().optional().describe('Source IN point in seconds — the start of the sub-range to pull from the source (footage or sequence). Replicates marking an in point in the Source monitor. Requires sourceOutPoint. When omitted, the whole source (or its current marks) is placed.'),
           sourceOutPoint: z.number().optional().describe('Source OUT point in seconds — the end of the sub-range to pull from the source. Replicates marking an out point in the Source monitor. Requires sourceInPoint.')
+        })
+      },
+      {
+        name: 'add_to_timeline_batch',
+        description: 'Places MANY clips onto one sequence in a single round-trip — the fast path for rebuilding a whole edit (e.g. a Descript/EDL stringout). Equivalent to calling add_to_timeline (overwrite) once per clip, but ~50x faster because it loops inside one ExtendScript pass instead of one file round-trip per clip. Each clip supports per-clip sourceInPoint/sourceOutPoint (Source-monitor in/out). Returns a per-clip result array so one bad clip does not sink the batch.',
+        inputSchema: z.object({
+          sequenceId: z.string().describe('The ID of the sequence (timeline) to add clips to'),
+          clips: z.array(z.object({
+            projectItemId: z.string().describe('The ID of the project item (clip / multicam) to add'),
+            trackIndex: z.number().describe('The index of the video or audio track (0-based)'),
+            time: z.number().describe('Timeline position in seconds where the clip is placed (overwrite)'),
+            sourceInPoint: z.number().optional().describe('Source IN point in seconds (requires sourceOutPoint)'),
+            sourceOutPoint: z.number().optional().describe('Source OUT point in seconds (requires sourceInPoint)')
+          })).describe('Ordered list of clips to place. All use overwrite mode.')
         })
       },
       {
@@ -691,7 +706,7 @@ export class PremiereProTools {
       },
       {
         name: 'set_clip_properties',
-        description: 'Sets properties of a clip.',
+        description: 'Sets Motion properties of a clip (opacity, scale, rotation, position).',
         inputSchema: z.object({
           clipId: z.string().describe('The ID of the clip'),
           properties: z.object({
@@ -701,8 +716,26 @@ export class PremiereProTools {
             position: z.object({
               x: z.number().optional(),
               y: z.number().optional()
-            }).optional().describe('Position coordinates')
+            }).optional().describe('Position in PIXELS matching the Effect Controls panel (e.g. 960,640 = center of a 1920x1280 sequence). Converted to the normalized API value internally using the clip sequence frame size.')
           }).describe('Properties to set')
+        })
+      },
+      {
+        name: 'set_clip_properties_batch',
+        description: 'Applies Motion properties (opacity/scale/rotation/position) to MANY clips in a single round-trip — the fast path for per-speaker framing across a whole rebuilt edit. ~50x faster than one set_clip_properties call per clip. Returns a per-clip result array.',
+        inputSchema: z.object({
+          items: z.array(z.object({
+            clipId: z.string().describe('The ID of the clip'),
+            properties: z.object({
+              opacity: z.number().optional().describe('Opacity 0-100'),
+              scale: z.number().optional().describe('Scale percentage'),
+              rotation: z.number().optional().describe('Rotation in degrees'),
+              position: z.object({
+                x: z.number().optional(),
+                y: z.number().optional()
+              }).optional().describe('Position in PIXELS matching the Effect Controls panel (converted to the normalized API value internally using the clip sequence frame size)')
+            }).describe('Properties to set for this clip')
+          })).describe('List of clip + properties pairs')
         })
       },
 
@@ -1194,7 +1227,7 @@ export class PremiereProTools {
         case 'create_sequence':
           return await this.createSequence(args.name, args.presetPath, args.width, args.height, args.frameRate, args.sampleRate);
         case 'duplicate_sequence':
-          return await this.duplicateSequence(args.sequenceId, args.newName);
+          return await this.duplicateSequence(args.sequenceId, args.newName, args.clearContents);
         case 'delete_sequence':
           return await this.deleteSequence(args.sequenceId);
         case 'read_sequence_captions':
@@ -1205,6 +1238,8 @@ export class PremiereProTools {
         // Timeline Operations
         case 'add_to_timeline':
           return await this.addToTimeline(args.sequenceId, args.projectItemId, args.trackIndex, args.time, args.insertMode, args.linkAudio, args.sourceInPoint, args.sourceOutPoint);
+        case 'add_to_timeline_batch':
+          return await this.addToTimelineBatch(args.sequenceId, args.clips);
         case 'remove_from_timeline':
           return await this.removeFromTimeline(args.clipId, args.sequenceId, args.deleteMode);
         case 'move_clip':
@@ -1311,6 +1346,8 @@ export class PremiereProTools {
           return await this.getClipProperties(args.clipId, args.sequenceId);
         case 'set_clip_properties':
           return await this.setClipProperties(args.clipId, args.properties);
+        case 'set_clip_properties_batch':
+          return await this.setClipPropertiesBatch(args.items);
 
         // Render Queue
         case 'add_to_render_queue':
@@ -2345,19 +2382,55 @@ export class PremiereProTools {
     }
   }
 
-  private async duplicateSequence(sequenceId: string, newName: string): Promise<any> {
+  private async duplicateSequence(sequenceId: string, newName: string, clearContents = false): Promise<any> {
     const safeName = JSON.stringify(newName);
     const script = `
       try {
         var originalSeq = __findSequence(${JSON.stringify(sequenceId)});
         if (!originalSeq) return JSON.stringify({ success: false, error: "Sequence not found" });
 
-        var newSeq = originalSeq.clone();
-        newSeq.name = ${safeName};
+        // In current Premiere, Sequence.clone() returns the clone's ProjectItem (NOT a Sequence),
+        // which has a settable .name but no .sequenceID / .videoTracks. Resolve the real Sequence
+        // object via getSequence() before touching tracks; handle builds that return a Sequence too.
+        var cloneResult = originalSeq.clone();
+        var newItem = null, newSeqObj = null;
+        if (cloneResult) {
+          if (typeof cloneResult.getSequence === "function") {
+            newItem = cloneResult;
+            try { newSeqObj = cloneResult.getSequence(); } catch (_) {}
+          } else if (cloneResult.videoTracks) {
+            newSeqObj = cloneResult;
+          }
+        }
+        // Fallback: a freshly cloned sequence usually becomes the active sequence.
+        if (!newSeqObj) { try { newSeqObj = app.project.activeSequence; } catch (_) {} }
 
-        // Sequence.name does NOT propagate to the project panel — find and rename
-        // the matching ProjectItem so the rename is visible to the user and to
-        // future MCP calls.
+        // Rename on the ProjectItem (visible in the project panel) AND the Sequence object.
+        if (newItem) { try { newItem.name = ${safeName}; } catch (_) {} }
+        if (newSeqObj) { try { newSeqObj.name = ${safeName}; } catch (_) {} }
+
+        // clearContents=true → produce an EMPTY sequence that inherits the source's exact
+        // settings (frame rate, resolution, track layout). This is the reliable way to auto-create
+        // a correctly-specced target because create_sequence ignores frameRate. Remove every clip
+        // from all tracks (iterate backwards; remove() shifts indices).
+        var clearedClips = 0;
+        if (${clearContents ? 'true' : 'false'} && newSeqObj) {
+          function __clearTracks(tracks) {
+            if (!tracks) return;
+            for (var t = 0; t < tracks.numTracks; t++) {
+              var tr = tracks[t];
+              if (!tr || !tr.clips) continue;
+              for (var ci = tr.clips.numItems - 1; ci >= 0; ci--) {
+                try { tr.clips[ci].remove(false, false); clearedClips++; } catch (_) {}
+              }
+            }
+          }
+          __clearTracks(newSeqObj.videoTracks);
+          __clearTracks(newSeqObj.audioTracks);
+        }
+
+        // Sequence.name does NOT always propagate to the project panel — if clone() didn't give us
+        // the ProjectItem directly, find the matching one by sequenceID and rename it too.
         function __findItemForSequence(parent, seqId) {
           if (!parent || !parent.children) return null;
           for (var i = 0; i < parent.children.numItems; i++) {
@@ -2376,21 +2449,23 @@ export class PremiereProTools {
         }
 
         var renamedAtItem = false;
-        var newItem = __findItemForSequence(app.project.rootItem, newSeq.sequenceID);
         if (newItem) {
-          try {
-            newItem.name = ${safeName};
-            renamedAtItem = true;
-          } catch (_) { /* fall through */ }
+          renamedAtItem = true;
+        } else if (newSeqObj) {
+          newItem = __findItemForSequence(app.project.rootItem, newSeqObj.sequenceID);
+          if (newItem) {
+            try { newItem.name = ${safeName}; renamedAtItem = true; } catch (_) { /* fall through */ }
+          }
         }
 
         return JSON.stringify({
           success: true,
           originalSequenceId: ${JSON.stringify(sequenceId)},
-          newSequenceId: newSeq.sequenceID,
+          newSequenceId: newSeqObj ? newSeqObj.sequenceID : null,
           newName: ${safeName},
           newProjectItemId: newItem ? newItem.nodeId : null,
-          renamedAtProjectItem: renamedAtItem
+          renamedAtProjectItem: renamedAtItem,
+          clearedClips: clearedClips
         });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
@@ -2532,6 +2607,15 @@ export class PremiereProTools {
   }
 
   // Timeline Operations Implementation
+  private async addToTimelineBatch(sequenceId: string, clips: Array<{ projectItemId: string; trackIndex: number; time: number; sourceInPoint?: number; sourceOutPoint?: number }>): Promise<any> {
+    try {
+      const result: any = await this.bridge.addToTimelineBatch(sequenceId, clips);
+      return { sequenceId, requested: clips.length, ...result };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error), sequenceId, requested: clips.length };
+    }
+  }
+
   private async addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, insertMode = 'overwrite', linkAudio: boolean = true, sourceInPoint?: number, sourceOutPoint?: number): Promise<any> {
     try {
       const result: any = await this.bridge.addToTimeline(sequenceId, projectItemId, trackIndex, time, linkAudio, sourceInPoint, sourceOutPoint);
@@ -4430,10 +4514,20 @@ export class PremiereProTools {
   }
 
   private async setClipProperties(clipId: string, properties: any): Promise<any> {
+    const posX = properties?.position?.x;
+    const posY = properties?.position?.y;
     const propCode = [
       properties?.opacity !== undefined ? `if (p.displayName === "Opacity") p.setValue(${properties.opacity}, true);` : '',
       properties?.scale !== undefined ? `if (p.displayName === "Scale") p.setValue(${properties.scale}, true);` : '',
       properties?.rotation !== undefined ? `if (p.displayName === "Rotation") p.setValue(${properties.rotation}, true);` : '',
+      // Position is the Motion "Position" property. Callers pass PIXEL coordinates matching the
+      // Effect Controls panel (e.g. 960,756 in a 1920x1280 sequence); the API stores it as a
+      // NORMALIZED [x,y] (0..1, 0.5,0.5 = frame center), so divide by the sequence frame size
+      // (__seqW/__seqH, computed below). When only one axis is supplied, keep the current value
+      // for the other. Position was previously accepted by the schema but silently dropped here.
+      (posX !== undefined || posY !== undefined)
+        ? `if (p.displayName === "Position") { var __cur = [0.5, 0.5]; try { __cur = p.getValue(); } catch (ep) {} var __nx = ${posX !== undefined ? `(${posX})/__seqW` : '__cur[0]'}; var __ny = ${posY !== undefined ? `(${posY})/__seqH` : '__cur[1]'}; p.setValue([__nx, __ny], true); }`
+        : '',
     ].filter(Boolean).join('\n              ');
 
     const script = `
@@ -4441,6 +4535,15 @@ export class PremiereProTools {
         var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
         var clip = info.clip;
+        // Sequence frame size, for converting Position pixels -> normalized. Try frameSize props
+        // first, then getSettings(); fall back to 1920x1080 if neither is available.
+        var __seqW = 1920, __seqH = 1080;
+        try {
+          if (info.sequence) {
+            if (info.sequence.frameSizeHorizontal) { __seqW = info.sequence.frameSizeHorizontal; __seqH = info.sequence.frameSizeVertical; }
+            else { var __ss = info.sequence.getSettings(); if (__ss) { __seqW = __ss.videoFrameWidth; __seqH = __ss.videoFrameHeight; } }
+          }
+        } catch (e0) {}
         for (var i = 0; i < clip.components.numItems; i++) {
           var comp = clip.components[i];
           for (var j = 0; j < comp.properties.numItems; j++) {
@@ -4456,6 +4559,71 @@ export class PremiereProTools {
       }
     `;
     return await this.bridge.executeScript(script);
+  }
+
+  // Batch variant of setClipProperties: apply Motion values to many clips in ONE round-trip.
+  // Same per-clip loop as the single version (opacity/scale/rotation/position), collapsing N
+  // file round-trips into 1. Returns a per-clip result array.
+  private async setClipPropertiesBatch(items: Array<{ clipId: string; properties: any }>): Promise<any> {
+    const specs = items.map(it => ({
+      clipId: it.clipId,
+      opacity: it.properties?.opacity === undefined ? null : it.properties.opacity,
+      scale: it.properties?.scale === undefined ? null : it.properties.scale,
+      rotation: it.properties?.rotation === undefined ? null : it.properties.rotation,
+      posX: it.properties?.position?.x === undefined ? null : it.properties.position.x,
+      posY: it.properties?.position?.y === undefined ? null : it.properties.position.y,
+    }));
+    const script = `
+      try {
+        var specs = ${JSON.stringify(specs)};
+        var results = [];
+        for (var n = 0; n < specs.length; n++) {
+          var it = specs[n];
+          var r = { index: n, clipId: it.clipId, success: false };
+          try {
+            var info = __findClip(it.clipId);
+            if (!info) { r.error = "Clip not found"; results.push(r); continue; }
+            var clip = info.clip;
+            // Sequence frame size for converting Position pixels -> normalized (see single variant).
+            var __seqW = 1920, __seqH = 1080;
+            try {
+              if (info.sequence) {
+                if (info.sequence.frameSizeHorizontal) { __seqW = info.sequence.frameSizeHorizontal; __seqH = info.sequence.frameSizeVertical; }
+                else { var __ss = info.sequence.getSettings(); if (__ss) { __seqW = __ss.videoFrameWidth; __seqH = __ss.videoFrameHeight; } }
+              }
+            } catch (e0) {}
+            for (var i = 0; i < clip.components.numItems; i++) {
+              var comp = clip.components[i];
+              for (var j = 0; j < comp.properties.numItems; j++) {
+                var p = comp.properties[j];
+                try {
+                  if (it.opacity !== null && p.displayName === "Opacity") p.setValue(it.opacity, true);
+                  if (it.scale !== null && p.displayName === "Scale") p.setValue(it.scale, true);
+                  if (it.rotation !== null && p.displayName === "Rotation") p.setValue(it.rotation, true);
+                  if ((it.posX !== null || it.posY !== null) && p.displayName === "Position") {
+                    var __cur = [0.5, 0.5];
+                    try { __cur = p.getValue(); } catch (ep) {}
+                    var __nx = it.posX !== null ? (it.posX / __seqW) : __cur[0];
+                    var __ny = it.posY !== null ? (it.posY / __seqH) : __cur[1];
+                    p.setValue([__nx, __ny], true);
+                  }
+                } catch (e2) {}
+              }
+            }
+            r.success = true;
+          } catch (e) {
+            r.error = e.toString();
+          }
+          results.push(r);
+        }
+        var applied = 0;
+        for (var k = 0; k < results.length; k++) { if (results[k].success) applied++; }
+        return JSON.stringify({ success: true, applied: applied, total: specs.length, results: results });
+      } catch (e) {
+        return JSON.stringify({ success: false, error: e.toString() });
+      }
+    `;
+    return await this.bridge.executeScript(script, 300000);
   }
 
   // Render Queue


### PR DESCRIPTION
add_to_timeline ran track.overwriteClip(projectItem, time), which places the whole source and ignores in/out, so an arbitrary interior sub-range of a clip or sequence could not be placed via MCP.

Add optional sourceInPoint/sourceOutPoint. When both are provided, mark the project item's in/out (setInPoint/setOutPoint, mediaType 4 with per-stream and no-arg fallbacks) before overwriteClip -- replicating the Source-monitor 'mark in / mark out -> overwrite' workflow. Response now reports appliedSourceInOut (+ sourceInOutError on failure).

Verified on a multicam source sequence in Premiere Pro 2026 (macOS): a 17.73s interior range placed as a single trimmed clip (previously the call dropped a default-length clip from the source head).