### PR TITLE
Fix create_sequence ignoring width/height/frameRate/sampleRate

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -32,9 +32,47 @@ Current behavior:
 - the tool is still exposed
 - it returns an error explaining that render queue monitoring requires Adobe Media Encoder
 
+## Confirmed Runtime Limitation
+
+### `create_sequence` can trigger an interactive "New Sequence" dialog
+
+Status: confirmed, non-deterministic, no fix identified yet
+
+Reason:
+
+- `app.project.createNewSequence(name, presetPath)` calls Premiere's stock sequence-creation
+  API. In some sessions (root cause not yet isolated -- did not reproduce on every call in
+  testing) this pops Premiere's interactive "New Sequence" dialog instead of creating silently.
+- While that dialog is open, the entire ExtendScript host is blocked -- not just the current
+  tool call. Every subsequent tool call (including `ping`) times out until a human clicks
+  through the dialog in Premiere's UI.
+- When this happens mid-`create_sequence`, the sequence is left at Premiere's default preset
+  (1920x1080 @ 23.976fps) and any requested width/height/frameRate/sampleRate never gets
+  applied, because the timeout aborts the call before the settings-apply step runs.
+
+Practical consequence:
+
+- `create_sequence` is not safe to rely on for fully unattended/headless workflows today.
+- `duplicate_sequence` (with `clearContents: true`) has not shown this behavior across dozens
+  of calls in testing and is the recommended way to reliably create a correctly-specced
+  sequence without risking an interactive dialog.
+
 ## Operational Limits
 
 These are not hidden bugs; they are boundaries of the current architecture.
+
+### Never call `getSettings()` again after `setSettings()` within the same script
+
+Calling `sequence.getSettings()` a second time immediately after `sequence.setSettings()`
+inside the *same* ExtendScript execution reliably crashes the ExtendScript host -- Premiere
+returns its generic `EvalScript error.` at the CEP layer, which bypasses any try/catch in the
+script entirely (confirmed via isolated bisection testing, not assumed from a single failure).
+
+Practical consequence for anyone adding new sequence-settings-mutating tools:
+
+- Split "mutate" and "verify" into separate `bridge.executeScript()` calls.
+- `setSequenceSettings` does this correctly (see its implementation comment) -- follow that
+  pattern rather than combining a settings mutation and a fresh settings read in one script.
 
 ### Premiere scripting is incomplete
 
@@ -87,6 +125,8 @@ These issues were real and are now resolved in the current code:
 - the server could delete an externally managed temp directory on shutdown
 - the CEP bridge could fail with `ENOENT` when the configured temp directory did not exist
 - `create_sequence` could create a sequence in Premiere but still report failure after a bridge timeout
+- `create_sequence` silently ignored its `width`/`height`/`frameRate`/`sampleRate` parameters -- they were accepted by the schema but never forwarded past the TypeScript wrapper, so every sequence came out at Premiere's default preset regardless of what was requested
+- `set_sequence_settings` was a hardcoded stub that always returned `success: false` without generating any ExtendScript at all. It now genuinely applies width/height (verified via a post-write read-back) and honestly reports per-field whether frame rate/sample rate changes actually took effect, since Premiere does not reliably support changing those on an existing sequence
 - `export_frame` called a non-existent API and now uses the QE export path
 - `remove_effect` was advertised even though actual removal is not supported and has been removed from the tool catalog
 - the branded workflow response returned the wrong message due to object spread order

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -146,6 +146,162 @@ describe('PremiereProTools', () => {
       expect(result.warning).toBeUndefined();
     });
 
+    it('create_sequence does not attempt to apply settings when none are requested', async () => {
+      mockBridge.createSequence = jest.fn().mockResolvedValue({
+        success: true,
+        id: 'seq-plain',
+        name: 'Plain Sequence'
+      });
+
+      const result = await tools.executeTool('create_sequence', { name: 'Plain Sequence' });
+
+      expect(result.success).toBe(true);
+      expect(result.settingsApplied).toBeUndefined();
+      expect(mockBridge.executeScript).not.toHaveBeenCalled();
+    });
+
+    it('create_sequence applies and verifies width/height when requested', async () => {
+      mockBridge.createSequence = jest.fn().mockResolvedValue({
+        success: true,
+        id: 'seq-custom',
+        name: 'Custom Sequence'
+      });
+
+      // setSequenceSettings makes 3 executeScript calls in sequence: before-read, mutate, after-read
+      mockBridge.executeScript
+        .mockResolvedValueOnce({
+          success: true,
+          settings: { width: 1920, height: 1080, timebase: '10594584000', audioSampleRate: { seconds: 1 / 48000 } }
+        })
+        .mockResolvedValueOnce({ success: true, applyErrors: {} })
+        .mockResolvedValueOnce({
+          success: true,
+          settings: { width: 1080, height: 1920, timebase: '10594584000', audioSampleRate: { seconds: 1 / 48000 } }
+        });
+
+      const result = await tools.executeTool('create_sequence', {
+        name: 'Custom Sequence',
+        width: 1080,
+        height: 1920
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.settingsApplied.applied.width).toBe(true);
+      expect(result.settingsApplied.applied.height).toBe(true);
+      expect(result.settingsApplied.allRequestedApplied).toBe(true);
+    });
+
+    it('create_sequence honestly reports frameRate as not applied when Premiere ignores it', async () => {
+      mockBridge.createSequence = jest.fn().mockResolvedValue({
+        success: true,
+        id: 'seq-fps',
+        name: 'FPS Sequence'
+      });
+
+      const unchangedSettings = {
+        width: 1920,
+        height: 1080,
+        timebase: '10594584000', // 23.976fps, unaffected by the requested 24fps
+        audioSampleRate: { seconds: 1 / 48000 }
+      };
+
+      mockBridge.executeScript
+        .mockResolvedValueOnce({ success: true, settings: unchangedSettings })
+        .mockResolvedValueOnce({ success: true, applyErrors: {} })
+        .mockResolvedValueOnce({ success: true, settings: unchangedSettings });
+
+      const result = await tools.executeTool('create_sequence', {
+        name: 'FPS Sequence',
+        frameRate: 24
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.settingsApplied.applied.frameRate).toBe(false);
+      expect(result.settingsApplied.allRequestedApplied).toBe(false);
+    });
+  });
+
+  describe('set_sequence_settings', () => {
+    it('rejects invalid arguments before touching the bridge', async () => {
+      const result = await tools.executeTool('set_sequence_settings', {
+        sequenceId: 'seq-1',
+        settings: { width: 'not-a-number' }
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+      expect(mockBridge.executeScript).not.toHaveBeenCalled();
+    });
+
+    it('returns an error and makes no further calls when the sequence is not found', async () => {
+      mockBridge.executeScript.mockResolvedValueOnce({
+        success: false,
+        error: 'Sequence not found by id: seq-missing'
+      });
+
+      const result = await tools.executeTool('set_sequence_settings', {
+        sequenceId: 'seq-missing',
+        settings: { width: 1080 }
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Sequence not found');
+      expect(mockBridge.executeScript).toHaveBeenCalledTimes(1);
+    });
+
+    it('never calls getSettings() again within the same script as a setSettings() call (crash-avoidance regression guard)', async () => {
+      mockBridge.executeScript
+        .mockResolvedValueOnce({
+          success: true,
+          settings: { width: 1280, height: 720, timebase: '8467200000', audioSampleRate: { seconds: 1 / 48000 } }
+        })
+        .mockResolvedValueOnce({ success: true, applyErrors: {} })
+        .mockResolvedValueOnce({
+          success: true,
+          settings: { width: 1080, height: 1920, timebase: '8467200000', audioSampleRate: { seconds: 1 / 48000 } }
+        });
+
+      await tools.executeTool('set_sequence_settings', {
+        sequenceId: 'seq-1',
+        settings: { width: 1080, height: 1920 }
+      });
+
+      // The mutate script (2nd call) must never contain a getSettings() call after its
+      // setSettings() call -- that exact pattern crashes the ExtendScript host (see comment
+      // above setSequenceSettings). Assert on the actual generated script, not just the result,
+      // so this regresses loudly if someone reintroduces the crash-prone pattern.
+      const mutateScriptCall = mockBridge.executeScript.mock.calls[1][0];
+      const setIndex = mutateScriptCall.indexOf('setSettings(mutable)');
+      const nextGetSettingsIndex = mutateScriptCall.indexOf('.getSettings()', setIndex);
+      expect(setIndex).toBeGreaterThan(-1);
+      expect(nextGetSettingsIndex).toBe(-1);
+    });
+
+    it('issues sample rate mutation as its own separate script, never combined with the dimensions setSettings call', async () => {
+      mockBridge.executeScript
+        .mockResolvedValueOnce({
+          success: true,
+          settings: { width: 1280, height: 720, timebase: '8467200000', audioSampleRate: { seconds: 1 / 44100 } }
+        })
+        .mockResolvedValueOnce({ success: true, applyErrors: {} })
+        .mockResolvedValueOnce({ success: true })
+        .mockResolvedValueOnce({
+          success: true,
+          settings: { width: 1280, height: 720, timebase: '8467200000', audioSampleRate: { seconds: 1 / 44100 } }
+        });
+
+      await tools.executeTool('set_sequence_settings', {
+        sequenceId: 'seq-1',
+        settings: { width: 1080, sampleRate: 48000 }
+      });
+
+      expect(mockBridge.executeScript).toHaveBeenCalledTimes(4);
+      const dimensionsScript = mockBridge.executeScript.mock.calls[1][0];
+      const sampleRateScript = mockBridge.executeScript.mock.calls[2][0];
+      expect(dimensionsScript).not.toContain('audioSampleRate');
+      expect(sampleRateScript).toContain('audioSampleRate');
+    });
+
     it('passes through successful imports', async () => {
       mockBridge.importMedia = jest.fn().mockResolvedValue({
         success: true,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -271,14 +271,14 @@ export class PremiereProTools {
       // Sequence Management
       {
         name: 'create_sequence',
-        description: 'Creates a new sequence in the project. A sequence is a timeline where you edit clips.',
+        description: 'Creates a new sequence in the project (from Premiere\'s default/last-used preset), then -- if width/height/frameRate/sampleRate are given -- attempts to apply them and reports per-field whether each one actually took effect (see `settingsApplied.applied`). Width/height are reliably applied; frame rate and sample rate are NOT reliably changeable on a freshly created sequence in Premiere, so check `settingsApplied.applied.frameRate`/`.sampleRate` rather than assuming success -- if false, use `presetPath` pointing at a preset with the desired rate, or duplicate_sequence from an existing sequence that already has it.',
         inputSchema: z.object({
           name: z.string().describe('The name for the new sequence'),
           presetPath: z.string().optional().describe('Optional path to a sequence preset file for custom settings'),
-          width: z.number().optional().describe('Sequence width in pixels'),
-          height: z.number().optional().describe('Sequence height in pixels'),
-          frameRate: z.number().optional().describe('Frame rate (e.g., 24, 25, 30, 60)'),
-          sampleRate: z.number().optional().describe('Audio sample rate (e.g., 48000)')
+          width: z.number().optional().describe('Sequence width in pixels -- reliably applied post-creation if provided'),
+          height: z.number().optional().describe('Sequence height in pixels -- reliably applied post-creation if provided'),
+          frameRate: z.number().optional().describe('Frame rate (e.g., 24, 25, 30, 60) -- attempted post-creation but not reliably supported by Premiere, check settingsApplied.applied.frameRate'),
+          sampleRate: z.number().optional().describe('Audio sample rate in Hz (e.g., 48000) -- attempted post-creation but not reliably supported by Premiere, check settingsApplied.applied.sampleRate')
         })
       },
       {
@@ -700,14 +700,14 @@ export class PremiereProTools {
       },
       {
         name: 'set_sequence_settings',
-        description: 'Updates sequence settings.',
+        description: 'Updates sequence settings. Width/height changes are reliably supported and verified by reading the setting back after the write. Frame rate and audio sample rate changes are attempted but are NOT reliably supported by Premiere on an existing sequence -- check the returned `applied` map per field rather than assuming success; if `applied.frameRate` or `applied.sampleRate` comes back false, use `presetPath` on create_sequence pointing at a preset with the desired rate, or duplicate_sequence from an existing sequence that already has it.',
         inputSchema: z.object({
           sequenceId: z.string().describe('The ID of the sequence'),
           settings: z.object({
-            width: z.number().optional().describe('Frame width'),
-            height: z.number().optional().describe('Frame height'),
-            frameRate: z.number().optional().describe('Frame rate'),
-            pixelAspectRatio: z.number().optional().describe('Pixel aspect ratio')
+            width: z.number().optional().describe('Frame width in pixels'),
+            height: z.number().optional().describe('Frame height in pixels'),
+            frameRate: z.number().optional().describe('Frame rate (e.g. 24, 25, 30, 60) -- attempted but not reliably supported post-creation, check applied.frameRate'),
+            sampleRate: z.number().optional().describe('Audio sample rate in Hz (e.g. 48000) -- attempted but not reliably supported post-creation, check applied.sampleRate')
           }).describe('Settings to update')
         })
       },
@@ -2394,7 +2394,7 @@ export class PremiereProTools {
   }
 
   // Sequence Management Implementation
-  private async createSequence(name: string, presetPath?: string, _width?: number, _height?: number, _frameRate?: number, _sampleRate?: number): Promise<any> {
+  private async createSequence(name: string, presetPath?: string, width?: number, height?: number, frameRate?: number, sampleRate?: number): Promise<any> {
     try {
       const result: any = await this.bridge.createSequence(name, presetPath);
       if (result?.success === false) {
@@ -2404,11 +2404,30 @@ export class PremiereProTools {
         };
       }
 
+      let settingsApplied: any = undefined;
+      const wantsCustomSettings = width !== undefined || height !== undefined || frameRate !== undefined || sampleRate !== undefined;
+      if (wantsCustomSettings && result?.id) {
+        try {
+          settingsApplied = await this.setSequenceSettings(result.id, {
+            ...(width !== undefined ? { width } : {}),
+            ...(height !== undefined ? { height } : {}),
+            ...(frameRate !== undefined ? { frameRate } : {}),
+            ...(sampleRate !== undefined ? { sampleRate } : {}),
+          });
+        } catch (settingsError) {
+          settingsApplied = {
+            success: false,
+            error: settingsError instanceof Error ? settingsError.message : String(settingsError)
+          };
+        }
+      }
+
       return {
         success: true,
         message: `Sequence "${name}" created successfully`,
         sequenceName: name,
-        ...result
+        ...result,
+        ...(settingsApplied ? { settingsApplied } : {})
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -4902,11 +4921,136 @@ export class PremiereProTools {
     return await this.bridge.executeScript(script);
   }
 
-  private async setSequenceSettings(_sequenceId: string, _settings: any): Promise<any> {
+  // IMPORTANT: calling sequence.getSettings() again immediately after sequence.setSettings()
+  // within the SAME ExtendScript execution reliably crashes the ExtendScript host (returns
+  // Adobe's generic "EvalScript error." at the CEP layer, bypassing any try/catch in the
+  // script -- confirmed by isolated testing, not assumed). So each mutation below is its own
+  // separate bridge.executeScript() call (get once, set once, return -- no re-read), and
+  // verification happens via a completely separate, later executeScript() call
+  // (getSequenceSettings), never inside the same script as a setSettings() call.
+  private async setSequenceSettings(sequenceId: string, settings: {
+    width?: number;
+    height?: number;
+    frameRate?: number;
+    sampleRate?: number;
+  }): Promise<any> {
+    const requested: { width?: number; height?: number; frameRate?: number; sampleRate?: number } = {
+      ...(settings.width !== undefined ? { width: settings.width } : {}),
+      ...(settings.height !== undefined ? { height: settings.height } : {}),
+      ...(settings.frameRate !== undefined ? { frameRate: settings.frameRate } : {}),
+      ...(settings.sampleRate !== undefined ? { sampleRate: settings.sampleRate } : {}),
+    };
+
+    const beforeRaw = await this.getSequenceSettings(sequenceId);
+    if (beforeRaw?.success === false) {
+      return { success: false, error: beforeRaw.error || `Sequence not found by id: ${sequenceId}` };
+    }
+
+    const applyErrors: Record<string, string> = {};
+
+    if (requested.width !== undefined || requested.height !== undefined || requested.frameRate !== undefined) {
+      const dimensionAssignments = [
+        requested.width !== undefined ? `mutable.videoFrameWidth = ${requested.width};` : '',
+        requested.height !== undefined ? `mutable.videoFrameHeight = ${requested.height};` : '',
+      ].filter(Boolean).join('\n          ');
+
+      const frameRateAssignment = requested.frameRate !== undefined
+        ? `
+        try {
+          sequence.timebase = String(Math.round(254016000000 / ${requested.frameRate}));
+        } catch (eFps) {
+          applyErrors.frameRate = eFps.toString();
+        }`
+        : '';
+
+      const mutateScript = `
+        try {
+          var sequence = __findSequence(${JSON.stringify(sequenceId)});
+          if (!sequence) {
+            return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
+          }
+          var applyErrors = {};
+          ${dimensionAssignments ? `
+          try {
+            var mutable = sequence.getSettings();
+            ${dimensionAssignments}
+            sequence.setSettings(mutable);
+          } catch (eDim) {
+            applyErrors.dimensions = eDim.toString();
+          }` : ''}
+          ${frameRateAssignment}
+          return JSON.stringify({ success: true, applyErrors: applyErrors });
+        } catch (e) {
+          return JSON.stringify({ success: false, error: e.toString() });
+        }
+      `;
+      const mutateResult = await this.bridge.executeScript(mutateScript);
+      if (mutateResult?.applyErrors) {
+        Object.assign(applyErrors, mutateResult.applyErrors);
+      }
+      if (mutateResult?.success === false) {
+        applyErrors.dimensionsOrFrameRate = mutateResult.error || 'Unknown error applying width/height/frameRate';
+      }
+    }
+
+    // Sample rate needs its own getSettings()+setSettings() pair -- kept in a separate bridge
+    // call so it never follows the dimensions block's setSettings() within the same script.
+    if (requested.sampleRate !== undefined) {
+      const rateScript = `
+        try {
+          var sequence = __findSequence(${JSON.stringify(sequenceId)});
+          if (!sequence) {
+            return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
+          }
+          try {
+            var rateSettings = sequence.getSettings();
+            if (rateSettings.audioSampleRate && rateSettings.audioSampleRate.ticks !== undefined) {
+              rateSettings.audioSampleRate.ticks = String(Math.round(254016000000 / ${requested.sampleRate}));
+              sequence.setSettings(rateSettings);
+            }
+            return JSON.stringify({ success: true });
+          } catch (eRate) {
+            return JSON.stringify({ success: false, error: eRate.toString() });
+          }
+        } catch (e) {
+          return JSON.stringify({ success: false, error: e.toString() });
+        }
+      `;
+      const rateResult = await this.bridge.executeScript(rateScript);
+      if (rateResult?.success === false) {
+        applyErrors.sampleRate = rateResult.error || 'Unknown error applying sampleRate';
+      }
+    }
+
+    const afterRaw = await this.getSequenceSettings(sequenceId);
+
+    const beforeSettings = beforeRaw?.settings || {};
+    const afterSettings = afterRaw?.settings || {};
+    const TICKS_PER_SECOND = 254016000000;
+    const beforeFps = beforeSettings.timebase ? TICKS_PER_SECOND / parseInt(beforeSettings.timebase, 10) : null;
+    const afterFps = afterSettings.timebase ? TICKS_PER_SECOND / parseInt(afterSettings.timebase, 10) : null;
+    const beforeSampleHz = beforeSettings.audioSampleRate?.seconds ? Math.round(1 / beforeSettings.audioSampleRate.seconds) : null;
+    const afterSampleHz = afterSettings.audioSampleRate?.seconds ? Math.round(1 / afterSettings.audioSampleRate.seconds) : null;
+
+    const applied: Record<string, boolean> = {};
+    if (requested.width !== undefined) applied.width = afterSettings.width === requested.width;
+    if (requested.height !== undefined) applied.height = afterSettings.height === requested.height;
+    if (requested.frameRate !== undefined) applied.frameRate = afterFps !== null && Math.abs(afterFps - requested.frameRate) < 0.01;
+    if (requested.sampleRate !== undefined) applied.sampleRate = afterSampleHz !== null && Math.abs(afterSampleHz - requested.sampleRate) < 1;
+
+    const anyRequested = Object.keys(applied).length > 0;
+    const allRequestedApplied = anyRequested ? Object.values(applied).every(Boolean) : null;
+
     return {
-      success: false,
-      error: "set_sequence_settings: Sequence settings cannot be changed after creation in Premiere Pro",
-      note: "Create a new sequence with desired settings instead"
+      success: true,
+      sequenceId,
+      requested,
+      applied,
+      allRequestedApplied,
+      applyErrors,
+      before: { width: beforeSettings.width, height: beforeSettings.height, frameRate: beforeFps, sampleRate: beforeSampleHz },
+      after: { width: afterSettings.width, height: afterSettings.height, frameRate: afterFps, sampleRate: afterSampleHz },
+      note: "Width/height changes are supported and verified above via read-back. Premiere does not reliably support changing an existing sequence's frame rate or audio sample rate after creation -- if applied.frameRate or applied.sampleRate is false, use presetPath on create_sequence pointing at a preset with the desired rate, or duplicate_sequence from an existing sequence that already has it."
     };
   }
 


### PR DESCRIPTION
## Summary
- `create_sequence` accepted `width`/`height`/`frameRate`/`sampleRate` in its schema but silently dropped them before reaching the bridge (received as underscore-prefixed unused params) — every sequence came out at Premiere's default preset (1920x1080 @ 23.976fps) regardless of what was requested.
- `set_sequence_settings` was a hardcoded stub that always returned `success: false` without generating any ExtendScript at all.
- `set_sequence_settings` now genuinely applies width/height via `getSettings()`/`setSettings()` and **verifies the change with a post-write read-back** rather than assuming success. Frame rate and audio sample rate are attempted too, but Premiere does not reliably support changing either on an existing sequence — the response's `applied` map reports the real, verified outcome per field.
- `create_sequence` now calls this as a second step after creation when custom settings are requested, surfacing the result under `settingsApplied`.

## Why
Confirmed via isolated bisection testing during real use: calling `sequence.getSettings()` again immediately after `sequence.setSettings()` **within the same ExtendScript execution crashes the host** (generic `EvalScript error.`, bypasses try/catch entirely — not just a slow response, a hard native failure). This meant a naive "mutate then verify in one script" implementation would crash on every call. The fix splits mutation and verification into separate `bridge.executeScript()` calls. Documented in `KNOWN_ISSUES.md` under "Operational Limits" so future contributors touching sequence settings don't hit the same wall.

Also documented a separate, non-deterministic issue found during testing: `create_sequence` can trigger an interactive "New Sequence" dialog that blocks the entire ExtendScript host until a human dismisses it. `duplicate_sequence` did not show this behavior across dozens of calls and remains the reliable path for unattended sequence creation with custom settings.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test -- --runInBand` — all tests pass (4 new tests added covering: no-op when no settings requested, width/height applied+verified, frame rate honestly reported as not-applied when Premiere ignores it, and a regression guard asserting the generated mutate script never contains a `getSettings()` call after `setSettings()`)
- [x] Live-validated against a real Premiere Pro 2026 (26.3.0) session: width/height changes confirmed via read-back, frame rate/sample rate changes confirmed to correctly report `applied: false` when Premiere silently ignores them (not a false positive)

## Tool surface changed?
`set_sequence_settings`'s response shape changed from always `{success: false}` to a real result with `applied`/`before`/`after`/`applyErrors`. `create_sequence`'s response gains an optional `settingsApplied` field when custom settings are requested. No breaking changes to existing working behavior (create_sequence with no custom settings behaves identically to before).

## Docs updated?
Yes — `KNOWN_ISSUES.md`.