### PR TITLE
Add detect_silence tool for audio-based silence detection

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -18,6 +18,24 @@ Run `node scripts/live-tool-sweep.mjs` against a scratch Premiere project before
 
 ## Confirmed Runtime Limitation
 
+### `detect_silence` requires ffmpeg on PATH, and does not use Premiere's scripting API at all
+
+Status: by design, not a bug
+
+Reason:
+
+- Premiere's ExtendScript/QE DOM surface has no audio-level or RMS/waveform reading
+  capability whatsoever -- confirmed by inspecting every existing audio tool in this
+  codebase (`adjust_audio_levels`, `add_audio_keyframes`, `apply_audio_effect`), all of
+  which only *write* levels, never read them.
+- `detect_silence` therefore runs `ffmpeg`'s `silencedetect` audio filter directly via
+  `child_process`, analyzing the underlying media file rather than anything inside
+  Premiere. It requires `ffmpeg` to be installed and on `PATH`; if it is not found, the
+  tool returns an explicit error explaining why, rather than a cryptic spawn failure.
+- This is a detection-only tool -- it never cuts anything itself. Use the returned
+  intervals with `split_clip`/`ripple_delete`/`razor_timeline_at_time` to actually remove
+  silence from a sequence.
+
 ### `get_render_queue_status`
 
 Status: expected runtime limitation

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -2,10 +2,34 @@
  * Unit tests for PremiereProTools
  */
 
+import { EventEmitter } from 'events';
+import { spawn } from 'child_process';
 import { PremiereProTools } from '../../tools/index.js';
 import { PremiereProBridge } from '../../bridge/index.js';
 
 jest.mock('../../bridge/index.js');
+jest.mock('child_process');
+
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+
+/** Builds a fake child_process for a scripted ffmpeg run: emits stderr, then closes. */
+function fakeFfmpegProcess(stderrOutput: string, closeCode: number | null = 0): any {
+  const proc: any = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  process.nextTick(() => {
+    if (stderrOutput) proc.stderr.emit('data', Buffer.from(stderrOutput));
+    proc.emit('close', closeCode);
+  });
+  return proc;
+}
+
+/** Builds a fake child_process that immediately errors (e.g. ffmpeg not on PATH). */
+function fakeMissingFfmpegProcess(): any {
+  const proc: any = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  process.nextTick(() => proc.emit('error', new Error('ENOENT')));
+  return proc;
+}
 
 describe('PremiereProTools', () => {
   let tools: PremiereProTools;
@@ -15,6 +39,7 @@ describe('PremiereProTools', () => {
     mockBridge = new PremiereProBridge() as jest.Mocked<PremiereProBridge>;
     tools = new PremiereProTools(mockBridge);
     jest.clearAllMocks();
+    mockSpawn.mockReset();
   });
 
   describe('getAvailableTools()', () => {
@@ -223,6 +248,105 @@ describe('PremiereProTools', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Track not found');
+    });
+  });
+
+  describe('detect_silence', () => {
+    it('rejects when neither mediaPath nor projectItemId is provided', async () => {
+      const result = await tools.executeTool('detect_silence', {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(mockBridge.executeScript).not.toHaveBeenCalled();
+    });
+
+    it('returns an explicit error when ffmpeg is not on PATH, rather than a cryptic spawn failure', async () => {
+      mockSpawn.mockReturnValueOnce(fakeMissingFfmpegProcess());
+
+      const result = await tools.executeTool('detect_silence', {
+        mediaPath: '/tmp/some-clip.mp4'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('ffmpeg was not found on PATH');
+      // Only the version-check spawn should have happened -- never attempted the real analysis.
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+    });
+
+    it('parses silence_start/silence_end pairs from ffmpeg stderr into intervals', async () => {
+      const ffmpegStderr = [
+        '[silencedetect @ 0x0] silence_start: 1.999977',
+        '[silencedetect @ 0x0] silence_end: 5.000045 | silence_duration: 3.000068',
+        '[silencedetect @ 0x0] silence_start: 6.999977',
+        '[silencedetect @ 0x0] silence_end: 10.000000 | silence_duration: 3.000023'
+      ].join('\n');
+
+      // Dispatch on the actual args ffmpeg was invoked with, rather than call order --
+      // more robust than chained mockReturnValueOnce for a two-spawn-call code path.
+      mockSpawn.mockImplementation((_cmd: any, spawnArgs: any) => {
+        const isVersionCheck = Array.isArray(spawnArgs) && spawnArgs.includes('-version');
+        return isVersionCheck ? fakeFfmpegProcess('', 0) : fakeFfmpegProcess(ffmpegStderr, 0);
+      });
+
+      const result = await tools.executeTool('detect_silence', {
+        mediaPath: '/tmp/some-clip.mp4',
+        noiseThresholdDb: -30,
+        minDurationSeconds: 1
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.silenceIntervals).toEqual([
+        { start: 1.999977, end: 5.000045, duration: 3 },
+        { start: 6.999977, end: 10, duration: 3 }
+      ]);
+      expect(result.note).toContain('Detection only');
+    });
+
+    it('resolves a projectItemId to a media path via the bridge before running ffmpeg', async () => {
+      mockBridge.executeScript.mockResolvedValueOnce({
+        success: true,
+        mediaPath: '/Volumes/Footage/session.mp4'
+      });
+      mockSpawn.mockImplementation(() => fakeFfmpegProcess('', 0));
+
+      const result = await tools.executeTool('detect_silence', {
+        projectItemId: 'item-789'
+      });
+
+      expect(mockBridge.executeScript).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(true);
+      expect(result.mediaPath).toBe('/Volumes/Footage/session.mp4');
+      expect(result.silenceIntervals).toEqual([]);
+    });
+
+    it('surfaces a clear error when the project item cannot be resolved to a media path', async () => {
+      mockBridge.executeScript.mockResolvedValueOnce({
+        success: false,
+        error: 'Project item has no media path (is it a sequence or bin?)'
+      });
+
+      const result = await tools.executeTool('detect_silence', {
+        projectItemId: 'item-a-bin'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('no media path');
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it('reports a clear failure when ffmpeg cannot read the file at all', async () => {
+      mockSpawn.mockImplementation((_cmd: any, spawnArgs: any) => {
+        const isVersionCheck = Array.isArray(spawnArgs) && spawnArgs.includes('-version');
+        return isVersionCheck ? fakeFfmpegProcess('', 0) : fakeFfmpegProcess('Error opening input file', 254);
+      });
+
+      const result = await tools.executeTool('detect_silence', {
+        mediaPath: '/tmp/does-not-exist.mp4'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("couldn't be read");
     });
   });
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+import { spawn } from 'child_process';
 import type { PremiereProTransport } from '../bridge/types.js';
 import { Logger } from '../utils/logger.js';
 import { createMotionDemoAssets } from '../utils/demoAssets.js';
@@ -426,6 +427,20 @@ export class PremiereProTools {
         inputSchema: z.object({
           clipId: z.string().describe('The ID of the audio clip to adjust'),
           level: z.number().describe('The new audio level in decibels (dB). Can be positive or negative.')
+        })
+      },
+
+      // Audio Analysis
+      {
+        name: 'detect_silence',
+        description: 'Analyzes a media file\'s audio for silent stretches using ffmpeg\'s silencedetect filter, run locally via child_process -- NOT via Premiere\'s scripting API, which has no audio-level/RMS reading capability at all (confirmed: every audio tool in this codebase only writes levels, never reads them). Requires ffmpeg on PATH; returns an explicit error if it is not found rather than failing silently. This is DETECTION ONLY -- it does not cut or modify anything. Use the returned intervals with split_clip/ripple_delete/razor_timeline_at_time if you want to remove the silence.',
+        inputSchema: z.object({
+          mediaPath: z.string().optional().describe('Direct filesystem path to the media file to analyze'),
+          projectItemId: z.string().optional().describe('Project item ID to resolve to a media path instead of passing mediaPath directly'),
+          noiseThresholdDb: z.number().optional().describe('Silence threshold in dBFS, e.g. -30 (default -30). Audio quieter than this is considered silent.'),
+          minDurationSeconds: z.number().optional().describe('Minimum duration in seconds for a quiet stretch to be reported as silence (default 1.5)')
+        }).refine((data) => Boolean(data.mediaPath) || Boolean(data.projectItemId), {
+          message: 'Provide either mediaPath or projectItemId'
         })
       },
       {
@@ -1297,6 +1312,10 @@ export class PremiereProTools {
           return await this.addTransition(args.clipId1, args.clipId2, args.transitionName, args.duration);
         case 'add_transition_to_clip':
           return await this.addTransitionToClip(args.clipId, args.transitionName, args.position, args.duration);
+
+        // Audio Analysis
+        case 'detect_silence':
+          return await this.detectSilence(args.mediaPath, args.projectItemId, args.noiseThresholdDb, args.minDurationSeconds);
 
         // Audio Operations
         case 'adjust_audio_levels':
@@ -3488,6 +3507,137 @@ export class PremiereProTools {
     `;
 
     return await this.bridge.executeScript(script);
+  }
+
+  // Audio Analysis Implementation
+  private async resolveProjectItemMediaPath(projectItemId: string): Promise<{ path?: string; error?: string }> {
+    const script = `
+      try {
+        var item = __findProjectItem(${JSON.stringify(projectItemId)});
+        if (!item) {
+          return JSON.stringify({ success: false, error: "Project item not found by id: " + ${JSON.stringify(projectItemId)} });
+        }
+        var mediaPath = null;
+        try {
+          mediaPath = item.getMediaPath();
+        } catch (eMedia) {
+          return JSON.stringify({ success: false, error: "Could not read media path: " + eMedia.toString() });
+        }
+        if (!mediaPath) {
+          return JSON.stringify({ success: false, error: "Project item has no media path (is it a sequence or bin?)" });
+        }
+        return JSON.stringify({ success: true, mediaPath: mediaPath });
+      } catch (e) {
+        return JSON.stringify({ success: false, error: e.toString() });
+      }
+    `;
+    const result = await this.bridge.executeScript(script);
+    if (result?.success === false) {
+      return { error: result.error || 'Failed to resolve project item media path' };
+    }
+    return { path: result?.mediaPath };
+  }
+
+  private checkFfmpegAvailable(): Promise<boolean> {
+    return new Promise((resolve) => {
+      const proc = spawn('ffmpeg', ['-version']);
+      proc.on('error', () => resolve(false));
+      proc.on('close', (code) => resolve(code === 0));
+    });
+  }
+
+  private parseSilenceIntervals(stderr: string): Array<{ start: number; end: number; duration: number }> {
+    const starts: number[] = [];
+    const ends: number[] = [];
+    const startRe = /silence_start:\s*(-?[\d.]+)/g;
+    const endRe = /silence_end:\s*(-?[\d.]+)/g;
+    let match: RegExpExecArray | null;
+    while ((match = startRe.exec(stderr)) !== null) {
+      starts.push(parseFloat(match[1]!));
+    }
+    while ((match = endRe.exec(stderr)) !== null) {
+      ends.push(parseFloat(match[1]!));
+    }
+    const intervals: Array<{ start: number; end: number; duration: number }> = [];
+    const count = Math.min(starts.length, ends.length);
+    for (let i = 0; i < count; i++) {
+      const start = starts[i]!;
+      const end = ends[i]!;
+      intervals.push({
+        start,
+        end,
+        duration: Math.round((end - start) * 1000) / 1000,
+      });
+    }
+    return intervals;
+  }
+
+  private async detectSilence(
+    mediaPath?: string,
+    projectItemId?: string,
+    noiseThresholdDb = -30,
+    minDurationSeconds = 1.5
+  ): Promise<any> {
+    let resolvedPath = mediaPath;
+
+    if (!resolvedPath && projectItemId) {
+      const resolved = await this.resolveProjectItemMediaPath(projectItemId);
+      if (resolved.error) {
+        return { success: false, error: resolved.error };
+      }
+      resolvedPath = resolved.path;
+    }
+
+    if (!resolvedPath) {
+      return { success: false, error: 'Provide either mediaPath or projectItemId' };
+    }
+
+    const ffmpegAvailable = await this.checkFfmpegAvailable();
+    if (!ffmpegAvailable) {
+      return {
+        success: false,
+        error: 'ffmpeg was not found on PATH. detect_silence analyzes audio via ffmpeg\'s silencedetect filter, not Premiere\'s scripting API (which cannot read audio levels at all). Install ffmpeg (e.g. `brew install ffmpeg` on macOS) and try again.'
+      };
+    }
+
+    return new Promise((resolve) => {
+      const ffmpegArgs = [
+        '-i', resolvedPath as string,
+        '-af', `silencedetect=noise=${noiseThresholdDb}dB:d=${minDurationSeconds}`,
+        '-f', 'null', '-'
+      ];
+      const proc = spawn('ffmpeg', ffmpegArgs);
+      let stderr = '';
+
+      proc.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+
+      proc.on('error', (err) => {
+        resolve({ success: false, error: `Failed to run ffmpeg: ${err.message}` });
+      });
+
+      proc.on('close', (code) => {
+        if (code !== 0 && stderr.indexOf('silence_start') === -1) {
+          resolve({
+            success: false,
+            error: `ffmpeg exited with code ${code} and produced no silence data. This usually means the file couldn't be read.`,
+            mediaPath: resolvedPath,
+            ffmpegStderr: stderr.slice(-2000)
+          });
+          return;
+        }
+        const silenceIntervals = this.parseSilenceIntervals(stderr);
+        resolve({
+          success: true,
+          mediaPath: resolvedPath,
+          noiseThresholdDb,
+          minDurationSeconds,
+          silenceIntervals,
+          note: 'Detection only -- nothing was cut. Use split_clip/ripple_delete/razor_timeline_at_time on a sequence to remove any of these intervals.'
+        });
+      });
+    });
   }
 
   // Audio Operations Implementation


### PR DESCRIPTION
## Summary
- New `detect_silence` tool that analyzes a media file's audio for silent stretches using ffmpeg's `silencedetect` filter, run via `child_process` — **not** through Premiere's scripting API.
- Confirmed by inspecting every existing audio tool in this codebase (`adjust_audio_levels`, `add_audio_keyframes`, `apply_audio_effect`): Premiere's ExtendScript/QE DOM surface has no capability to read audio levels/RMS/waveform data at all, only to write them. So silence detection genuinely cannot be done through Premiere's own API here.
- Accepts either a direct `mediaPath` or a `projectItemId` (resolved to a media path via the existing `__findProjectItem` bridge helper, reusing the same pattern `move_item_to_bin` already uses).
- Checks for ffmpeg's presence first and returns an explicit, actionable error if it's missing, rather than a cryptic spawn failure.
- This is **detection only** — it never cuts or modifies anything. Returns candidate intervals; pair with the existing `split_clip`/`ripple_delete`/`razor_timeline_at_time` tools to actually remove silence from a sequence.

## Why
Came up while building an automated rough-cut pipeline that needs to trim dead air from long-form raw footage before handing it to a human editor. Wanted the detection step to be honest about what it found rather than auto-cutting blindly.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test -- --runInBand` — all tests pass (6 new tests: missing-args rejection, ffmpeg-not-found handling, interval parsing from real `silencedetect` stderr format, `projectItemId` resolution, resolution failure handling, unreadable-file handling)
- [x] Live-validated with a synthetic 10s test clip (silence at 2-5s and 7-10s, generated via `ffmpeg -f lavfi`) — detected intervals matched exactly (1.999977–5.000045, 6.999977–10.0)
- [x] Live-validated against a real ~16-minute source video via `projectItemId` resolution — correctly resolved the media path and ran to completion with zero false positives on continuous narration

## Tool surface changed?
Adds one new tool, `detect_silence`. No changes to existing tools.

## Docs updated?
Yes — `KNOWN_ISSUES.md` documents the new external `ffmpeg` dependency and why this couldn't be a pure-ExtendScript tool.