### PR TITLE
Add build_sequence_from_clip_plan high-level workflow tool

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -18,6 +18,22 @@ Run `node scripts/live-tool-sweep.mjs` against a scratch Premiere project before
 
 ## Confirmed Runtime Limitation
 
+### Several "expanded" tools silently no-op instead of doing anything
+
+Status: confirmed, not fixed in this change -- flagging for a future contribution
+
+While validating `build_sequence_from_clip_plan` live, `delete_bin` was called to clean up a
+disposable test bin and returned `{"success": true, "accepted": true, "args": {}}` without
+actually deleting the bin (confirmed: the bin was still present afterward). Looking at
+`src/tools/expanded.ts`, several expanded tool names (including `delete_bin`,
+`set_sequence_frame_rate`, `set_sequence_resolution`, `set_sequence_pixel_aspect_ratio`,
+`set_sequence_field_type`, `set_sequence_display_format`, `set_sequence_audio_settings`) are
+registered in `expandedToolNames` but have no matching `case` in `buildExpandedToolScript`'s
+dispatch switch -- they all fall through to the generic `default:` handler, which reports
+`accepted: true` while doing nothing to the project at all. Worth an audit and either real
+implementations or an honest "not implemented" response for each, per this project's own rule
+against fake success.
+
 ### `get_render_queue_status`
 
 Status: expected runtime limitation

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -437,6 +437,194 @@ describe('PremiereProTools', () => {
     });
   });
 
+  describe('build_sequence_from_clip_plan', () => {
+    it('builds a single-segment sequence with no markers/bin in the minimal number of calls', async () => {
+      mockBridge.executeScript.mockResolvedValueOnce({ success: true, newSequenceId: 'seq-new-1' }); // duplicateSequence
+      mockBridge.addToTimelineBatch = jest.fn().mockResolvedValue({
+        success: true, status: 'success', placed: 1, failed: 0, total: 1, results: []
+      } as any);
+
+      const result = await tools.executeTool('build_sequence_from_clip_plan', {
+        templateSequenceId: 'seq-template',
+        sequenceName: 'Short A',
+        sourceProjectItemId: 'item-1',
+        segments: [{ sourceInPoint: 10, sourceOutPoint: 40 }]
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.sequenceId).toBe('seq-new-1');
+      expect(result.expectedDurationSeconds).toBe(30);
+      expect(result.markersRequested).toBe(0);
+      expect(result.movedToBin).toBeUndefined();
+      // Only duplicateSequence goes through executeScript; addToTimelineBatch is a separate bridge method.
+      expect(mockBridge.executeScript).toHaveBeenCalledTimes(1);
+      expect(mockBridge.addToTimelineBatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('computes cumulative timeline positions correctly across multiple segments', async () => {
+      mockBridge.executeScript.mockResolvedValueOnce({ success: true, newSequenceId: 'seq-new-2' });
+      mockBridge.addToTimelineBatch = jest.fn().mockResolvedValue({
+        success: true, status: 'success', placed: 3, failed: 0, total: 3, results: []
+      } as any);
+
+      const result = await tools.executeTool('build_sequence_from_clip_plan', {
+        templateSequenceId: 'seq-template',
+        sequenceName: 'Clip B',
+        sourceProjectItemId: 'item-1',
+        segments: [
+          { sourceInPoint: 0, sourceOutPoint: 30 },   // duration 30, starts at 0
+          { sourceInPoint: 100, sourceOutPoint: 120 }, // duration 20, starts at 30
+          { sourceInPoint: 200, sourceOutPoint: 210 }  // duration 10, starts at 50
+        ]
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.expectedDurationSeconds).toBe(60);
+      const placedClips = mockBridge.addToTimelineBatch.mock.calls[0][1];
+      expect(placedClips.map((c: any) => c.time)).toEqual([0, 30, 50]);
+      expect(placedClips.map((c: any) => c.sourceInPoint)).toEqual([0, 100, 200]);
+      expect(placedClips.map((c: any) => c.sourceOutPoint)).toEqual([30, 120, 210]);
+    });
+
+    it('adds markers via an explicit setActiveSequence call, not relying on implicit active-sequence side effects', async () => {
+      mockBridge.addToTimelineBatch = jest.fn().mockResolvedValue({
+        success: true, status: 'success', placed: 2, failed: 0, total: 2, results: []
+      } as any);
+      mockBridge.executeScript
+        .mockResolvedValueOnce({ success: true, newSequenceId: 'seq-new-3' }) // duplicateSequence
+        .mockResolvedValueOnce({ success: true, message: 'Active sequence set' }) // setActiveSequence
+        .mockResolvedValueOnce({ success: true, markerId: 'm1' }); // addMarker
+
+      const result = await tools.executeTool('build_sequence_from_clip_plan', {
+        templateSequenceId: 'seq-template',
+        sequenceName: 'Clip C',
+        sourceProjectItemId: 'item-1',
+        segments: [
+          { sourceInPoint: 0, sourceOutPoint: 30 },
+          { sourceInPoint: 100, sourceOutPoint: 110 }
+        ],
+        markers: [
+          { time: 30, name: 'segment boundary', comment: 'stitched segment 2 of 2 starts here' }
+        ]
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.markersRequested).toBe(1);
+      expect(result.markersAdded).toBe(1);
+      expect(result.markersFailed).toBe(false);
+      // duplicateSequence, setActiveSequence, addMarker = 3 executeScript calls (addToTimelineBatch is separate)
+      expect(mockBridge.executeScript).toHaveBeenCalledTimes(3);
+    });
+
+    it('files the new sequence into a bin by exact name match after creation', async () => {
+      mockBridge.addToTimelineBatch = jest.fn().mockResolvedValue({
+        success: true, status: 'success', placed: 1, failed: 0, total: 1, results: []
+      } as any);
+      mockBridge.executeScript
+        .mockResolvedValueOnce({ success: true, newSequenceId: 'seq-new-4' }) // duplicateSequence
+        .mockResolvedValueOnce({
+          success: true,
+          items: [
+            { id: 'item-decoy', name: 'Short D (old copy)', type: 'sequence' },
+            { id: 'item-real', name: 'Short D', type: 'sequence' }
+          ],
+          count: 2
+        }) // findProjectItemByName -- must pick the EXACT name match, not the first substring hit
+        .mockResolvedValueOnce({ success: true, message: 'Item moved to bin', itemId: 'item-real', targetBinId: 'bin-1' }); // moveItemToBin
+
+      const result = await tools.executeTool('build_sequence_from_clip_plan', {
+        templateSequenceId: 'seq-template',
+        sequenceName: 'Short D',
+        sourceProjectItemId: 'item-1',
+        segments: [{ sourceInPoint: 0, sourceOutPoint: 10 }],
+        targetBinId: 'bin-1'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.movedToBin).toBe(true);
+      const moveCallScript = mockBridge.executeScript.mock.calls[2][0];
+      expect(moveCallScript).toContain('item-real');
+      expect(moveCallScript).not.toContain('item-decoy');
+    });
+
+    it('reports movedToBin: false without failing the whole call when the project item cannot be located', async () => {
+      mockBridge.addToTimelineBatch = jest.fn().mockResolvedValue({
+        success: true, status: 'success', placed: 1, failed: 0, total: 1, results: []
+      } as any);
+      mockBridge.executeScript
+        .mockResolvedValueOnce({ success: true, newSequenceId: 'seq-new-5' })
+        .mockResolvedValueOnce({ success: true, items: [], count: 0 }); // findProjectItemByName finds nothing
+
+      const result = await tools.executeTool('build_sequence_from_clip_plan', {
+        templateSequenceId: 'seq-template',
+        sequenceName: 'Short E',
+        sourceProjectItemId: 'item-1',
+        segments: [{ sourceInPoint: 0, sourceOutPoint: 10 }],
+        targetBinId: 'bin-1'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.movedToBin).toBe(false);
+      expect(result.steps.moveItemToBin.success).toBe(false);
+    });
+
+    it('stops early and reports the real error when duplicateSequence fails', async () => {
+      mockBridge.executeScript.mockResolvedValueOnce({ success: false, error: 'Sequence not found' });
+      mockBridge.addToTimelineBatch = jest.fn();
+
+      const result = await tools.executeTool('build_sequence_from_clip_plan', {
+        templateSequenceId: 'seq-missing',
+        sequenceName: 'Short F',
+        sourceProjectItemId: 'item-1',
+        segments: [{ sourceInPoint: 0, sourceOutPoint: 10 }]
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Sequence not found');
+      expect(mockBridge.executeScript).toHaveBeenCalledTimes(1);
+      expect(mockBridge.addToTimelineBatch).not.toHaveBeenCalled();
+    });
+
+    it('stops before markers/bin steps when a segment fails to place', async () => {
+      mockBridge.executeScript.mockResolvedValueOnce({ success: true, newSequenceId: 'seq-new-6' });
+      mockBridge.addToTimelineBatch = jest.fn().mockResolvedValue({
+        success: false,
+        status: 'partial',
+        placed: 0,
+        failed: 1,
+        total: 1,
+        results: [{ index: 0, success: false, error: 'Bad in/out point' }]
+      } as any);
+
+      const result = await tools.executeTool('build_sequence_from_clip_plan', {
+        templateSequenceId: 'seq-template',
+        sequenceName: 'Short G',
+        sourceProjectItemId: 'item-1',
+        segments: [{ sourceInPoint: 999999, sourceOutPoint: 1 }],
+        markers: [{ time: 0, name: 'should never be added' }],
+        targetBinId: 'bin-1'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('failed to place');
+      // Only duplicateSequence -- markers/bin steps never attempted, so no further executeScript calls.
+      expect(mockBridge.executeScript).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects an empty segments array before touching the bridge', async () => {
+      const result = await tools.executeTool('build_sequence_from_clip_plan', {
+        templateSequenceId: 'seq-template',
+        sequenceName: 'Short H',
+        sourceProjectItemId: 'item-1',
+        segments: []
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+      expect(mockBridge.executeScript).not.toHaveBeenCalled();
+    });
+  });
+
   describe('high-level workflow tools', () => {
     it('builds a motion graphics demo sequence', async () => {
       mockBridge.createSequence = jest.fn().mockResolvedValue({

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -297,6 +297,27 @@ export class PremiereProTools {
           sequenceId: z.string().describe('The ID of the sequence to delete')
         })
       },
+      {
+        name: 'build_sequence_from_clip_plan',
+        description: 'High-level workflow tool: builds one complete sequence from a list of source segments in a single call, instead of separately calling duplicate_sequence, add_to_timeline_batch, add_marker (per marker), find_project_item_by_name, and move_item_to_bin yourself. Duplicates templateSequenceId (clearContents) to get a correctly-specced blank target, places all segments back-to-back computing cumulative timeline positions automatically, adds any markers (at NEW-sequence-relative time, not source time), and optionally files the result into a bin. Returns a `steps` object with each sub-operation\'s raw result so a partial failure is diagnosable rather than opaque.',
+        inputSchema: z.object({
+          templateSequenceId: z.string().describe('Sequence ID to duplicate as the correctly-specced blank target (see duplicate_sequence -- this is the reliable way to get the right resolution/frame rate)'),
+          sequenceName: z.string().describe('Name for the new sequence'),
+          sourceProjectItemId: z.string().describe('Project item ID of the source clip to place on the new sequence'),
+          segments: z.array(z.object({
+            sourceInPoint: z.number().describe('Source in-point in seconds'),
+            sourceOutPoint: z.number().describe('Source out-point in seconds')
+          })).min(1).describe('Ordered segments to place back-to-back on the new sequence\'s timeline. 2+ segments stitch together with cumulative positions computed automatically (segment 2 starts where segment 1 ends, etc.)'),
+          markers: z.array(z.object({
+            time: z.number().describe('Marker time in seconds on the NEW sequence\'s own timeline -- NOT the source video\'s absolute timestamp. For a marker at a segment boundary, this is the cumulative duration of the preceding segments.'),
+            name: z.string().describe('Marker name/label'),
+            comment: z.string().optional().describe('Marker comment/description')
+          })).optional().describe('Markers to add after placement, e.g. segment-stitch boundaries or compliance flags'),
+          targetBinId: z.string().optional().describe('Bin to move the new sequence into after creation (see create_bin/list_project_items to find a bin ID)'),
+          trackIndex: z.number().optional().describe('Video/audio track index to place clips on (default 0)'),
+          linkAudio: z.boolean().optional().describe('Keep audio linked to video when placing clips (default true)')
+        })
+      },
 
       // Timeline Operations
       {
@@ -1258,6 +1279,17 @@ export class PremiereProTools {
           return await this.duplicateSequence(args.sequenceId, args.newName, args.clearContents);
         case 'delete_sequence':
           return await this.deleteSequence(args.sequenceId);
+        case 'build_sequence_from_clip_plan':
+          return await this.buildSequenceFromClipPlan(
+            args.templateSequenceId,
+            args.sequenceName,
+            args.sourceProjectItemId,
+            args.segments,
+            args.markers,
+            args.targetBinId,
+            args.trackIndex,
+            args.linkAudio
+          );
         case 'read_sequence_captions':
           return await this.readSequenceCaptions(args.sequenceId);
         case 'rename_project_item':
@@ -2515,6 +2547,98 @@ export class PremiereProTools {
     `;
 
     return await this.bridge.executeScript(script);
+  }
+
+  // High-level workflow: builds one sequence from a clip plan in a single tool call,
+  // composing duplicate_sequence + add_to_timeline_batch + add_marker (per marker) +
+  // find_project_item_by_name + move_item_to_bin -- the exact sequence of calls needed
+  // to build a short/clip sequence by hand, reduced to one round trip per sequence.
+  private async buildSequenceFromClipPlan(
+    templateSequenceId: string,
+    sequenceName: string,
+    sourceProjectItemId: string,
+    segments: Array<{ sourceInPoint: number; sourceOutPoint: number }>,
+    markers?: Array<{ time: number; name: string; comment?: string }>,
+    targetBinId?: string,
+    trackIndex = 0,
+    linkAudio = true
+  ): Promise<any> {
+    const steps: Record<string, any> = {};
+
+    const dup = await this.duplicateSequence(templateSequenceId, sequenceName, true);
+    steps.duplicateSequence = dup;
+    if (dup?.success === false || !dup?.newSequenceId) {
+      return {
+        success: false,
+        error: dup?.error || 'Failed to duplicate templateSequenceId into a blank target sequence',
+        steps
+      };
+    }
+    const sequenceId: string = dup.newSequenceId;
+
+    let cumulative = 0;
+    const clips = segments.map((seg) => {
+      const clip = {
+        projectItemId: sourceProjectItemId,
+        trackIndex,
+        time: cumulative,
+        sourceInPoint: seg.sourceInPoint,
+        sourceOutPoint: seg.sourceOutPoint,
+        linkAudio
+      };
+      cumulative += seg.sourceOutPoint - seg.sourceInPoint;
+      return clip;
+    });
+
+    const placeResult = await this.addToTimelineBatch(sequenceId, clips);
+    steps.addToTimelineBatch = placeResult;
+    if (placeResult?.success === false) {
+      return {
+        success: false,
+        error: 'One or more segments failed to place -- see steps.addToTimelineBatch.results for per-clip detail',
+        sequenceId,
+        steps
+      };
+    }
+
+    const markerResults: any[] = [];
+    if (markers && markers.length > 0) {
+      steps.setActiveSequence = await this.setActiveSequence(sequenceId);
+      for (const marker of markers) {
+        markerResults.push(await this.addMarker(sequenceId, marker.time, marker.name, marker.comment));
+      }
+    }
+    steps.markers = markerResults;
+
+    let binResult: any;
+    if (targetBinId) {
+      const findResult = await this.findProjectItemByName(sequenceName, 'sequence');
+      steps.findProjectItemByName = findResult;
+      const matchedItem = Array.isArray(findResult?.items)
+        ? findResult.items.find((item: any) => item.name === sequenceName)
+        : undefined;
+      if (matchedItem?.id) {
+        binResult = await this.moveItemToBin(matchedItem.id, targetBinId);
+      } else {
+        binResult = { success: false, error: 'Could not find the newly created sequence\'s project item by exact name to move it into the bin' };
+      }
+      steps.moveItemToBin = binResult;
+    }
+
+    const markersFailed = markerResults.some((m) => m?.success === false);
+
+    return {
+      success: true,
+      sequenceId,
+      sequenceName,
+      segmentCount: segments.length,
+      expectedDurationSeconds: cumulative,
+      markersRequested: markers?.length || 0,
+      markersAdded: markerResults.filter((m) => m?.success !== false).length,
+      markersFailed,
+      movedToBin: targetBinId ? binResult?.success !== false : undefined,
+      steps
+    };
   }
 
   private async renameProjectItem(projectItemId: string, newName: string): Promise<any> {


### PR DESCRIPTION
## Summary
Building each short/clip sequence by hand currently takes 4-5 separate tool calls: `duplicate_sequence` → `add_to_timeline_batch` → `add_marker` (once per marker) → `find_project_item_by_name` → `move_item_to_bin`. This adds one composite tool that does all of it in a single call, matching the existing "high-level workflow tools" pattern already used elsewhere in this codebase (`build_motion_graphics_demo`, `assemble_product_spot`).

- Duplicates `templateSequenceId` (`clearContents: true`) to get a correctly-specced blank target, matching the documented reliable way to avoid `create_sequence`'s frame-rate limitation.
- Computes cumulative timeline positions for 2+ segments automatically (segment 2 starts where segment 1 ends, etc.) instead of requiring the caller to do that math.
- Explicitly calls `set_active_sequence` before adding markers, since `add_marker` operates on `app.project.activeSequence` rather than a passed `sequenceId` — does not rely on `duplicate_sequence`'s undocumented tendency to leave the new sequence active.
- Bin filing matches the new sequence by **exact name**, not the first substring hit from `find_project_item_by_name`'s search (which does partial matching).
- Returns a `steps` object with every sub-operation's raw result so a partial failure (a bad segment, or a sequence that can't be located for bin filing) is diagnosable rather than opaque. Marker/bin failures are reported but don't fail the overall call, since the sequence itself was still built successfully; a failed segment placement does fail the call and stops before markers/bin are attempted.

## Why
Came up building an automated rough-cut pipeline — assembling 7 sequences by hand took ~30+ individual tool calls in one session. This directly reflects that real workflow.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test -- --runInBand` — all tests pass (8 new tests covering: minimal-call happy path, cumulative timeline position math, marker addition via explicit `set_active_sequence`, exact-name bin matching vs. a decoy substring match, graceful `movedToBin: false` when the item can't be located, early-stop on `duplicate_sequence` failure, early-stop before markers/bin when a segment fails to place, and schema rejection of an empty `segments` array)
- [x] Live-validated against real project data: built both a single-segment short and a 3-segment stitched clip with markers in one call each; durations (29.54s, 355.78s) and marker positions matched exactly what the equivalent manual 5-call sequence produced in an earlier session

## Tool surface changed?
Adds one new tool, `build_sequence_from_clip_plan`. No changes to existing tools' behavior.

## Docs updated?
Yes — `KNOWN_ISSUES.md`. Also documented (not fixed, flagged for a separate future PR) a related finding from live validation: `delete_bin` and several other "expanded" tools (`set_sequence_frame_rate`, `set_sequence_resolution`, etc.) are registered but have no real dispatch implementation in `expanded.ts` — they silently report success while doing nothing.