### PR TITLE
Stop reporting unimplemented expanded tools as successes

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -2,13 +2,70 @@
 
 This file tracks current, confirmed limits. It is no longer a backlog of already-fixed prototype bugs.
 
-## Current State (May 16, 2026)
+## Current State
 
 The current built tool catalog exposes:
 
-- `104` tools
+- `108` core tools with a real dispatch in `src/tools/index.ts`
+- `62` expanded tools with a real handler in `src/tools/expanded.ts`
+- `170` advertised in total (expanded names that duplicate a core name are filtered out)
 
-The last broad live sweep in this repository was run on March 4, 2026:
+`111` further names are declared in `unimplementedExpandedToolNames` and are deliberately
+**not** advertised. See the next section for why.
+
+## Fixed: expanded tools reported fake success
+
+Status: fixed
+
+The expanded catalog advertised `173` names but only `62` had a handler. Everything else fell
+through to:
+
+```js
+default:
+  return ok({ accepted: true, name: toolName, args: args, note: "..." });
+```
+
+`ok()` sets `success: true`. So `ripple_delete`, `roll_edit`, `slip_edit`, `remove_effect`,
+`scene_edit_detection`, `move_clip_to_track`, `set_effect_property`, `replace_clip_media`,
+`export_omf` and roughly ninety others returned a success to the calling agent while doing
+nothing to the project. A further `14` read tools returned
+`{ available: true, note: "Read operation completed..." }` with no data, and `add_tracks`
+returned `success: true` alongside `skipped: true`.
+
+For an agent driving an edit this is the worst possible failure mode: it believes the timeline
+changed, and it builds its next several calls on that belief.
+
+Now:
+
+- unimplemented names are parked in `unimplementedExpandedToolNames` and never advertised
+- `executeExpandedTool` rejects them explicitly if one is reached anyway
+- the generated ExtendScript `default:` branch returns `fail(...)`, not `ok(...)`
+- `src/__tests__/tools/expanded.test.ts` pins the invariant so the list and the switch cannot
+  drift apart silently again
+
+Implementing one of the parked tools means adding a real handler and moving its name into
+`expandedToolNames`.
+
+## Known: the jest suite does not run under ESM
+
+Status: pre-existing, not addressed here
+
+`npm test` fails with `ReferenceError: jest is not defined` in five of the six original suites.
+Under `ts-jest/presets/default-esm` Jest does not inject globals, so each suite needs
+`import { jest } from '@jest/globals'`, and the `jest.mock(...)` calls need porting to
+`jest.unstable_mockModule`. `src/__tests__/tools/expanded.test.ts` takes the import route and
+passes; the older suites still need the mock rewrite.
+
+Run the passing suite with:
+
+```bash
+NODE_OPTIONS=--experimental-vm-modules npx jest src/__tests__/tools/expanded.test.ts
+```
+
+## Live sweep
+
+The last broad live sweep in this repository was run on March 4, 2026, against the pre-trim
+catalog:
 
 - `43` tools were live-executed against a real Premiere Pro session
 - `50` tools were schema-validated in the same sweep

--- a/README.md
+++ b/README.md
@@ -43,13 +43,19 @@ This repository is currently validated for:
 - the included macOS installer path for Claude Desktop
 - manual MCP registration for Codex, Claude Code, and similar MCP clients
 
-Current catalog status as of June 29, 2026:
+Current catalog status:
 
-- `278` Premiere Pro MCP tools are exposed for AI-driven video editing
+- `170` Premiere Pro MCP tools are exposed for AI-driven video editing
 - coverage spans project setup, media ingest, bins, sequences, timeline editing, transitions, effects, keyframes, captions, markers, metadata, proxies, multicam, color, audio, exports, and higher-level assembly workflows
 - the catalog includes practical agent workflows such as product-spot assembly, motion-graphics demos, timeline razoring, caption reads, audio ducking, scene edit detection, EDL import, and linked audio/video operations
 
-Most recent completed local live validation:
+That number is lower than earlier `278` claims on purpose. `111` names in the expanded catalog
+had no handler behind them and fell through to a `default:` branch that returned
+`success: true` without touching Premiere, so a calling agent was told an edit had landed when
+nothing had happened. Those names are now parked in `unimplementedExpandedToolNames`, are not
+advertised, and fail loudly if reached. See `KNOWN_ISSUES.md`.
+
+Most recent completed local live validation (against the pre-trim catalog):
 
 - `197` tools were live-executed against a real Premiere Pro 2026 session
 - `57` tools were schema-validated in the same sweep
@@ -253,7 +259,7 @@ This creates temporary `Sweep ...` sequences in the currently open project so th
 
 ## Tool Coverage
 
-The `97` exposed tools are grouped roughly like this:
+The `170` exposed tools are grouped roughly like this:
 
 - Discovery and project inspection
 - Project and sequence management

--- a/src/__tests__/tools/expanded.test.ts
+++ b/src/__tests__/tools/expanded.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Catalog-honesty tests for the expanded Premiere tool set.
+ *
+ * The expanded catalog is a hand-maintained list of tool names plus a switch statement in
+ * generated ExtendScript. Those two can drift apart, and when they do the failure is silent:
+ * an unhandled name used to fall through to a permissive `default:` branch that returned
+ * `{ success: true }` without touching Premiere, so the calling agent was told an edit had
+ * landed when nothing had happened.
+ *
+ * These tests pin the invariant: every advertised expanded tool has a real handler, and
+ * anything without one is neither advertised nor reported as a success.
+ */
+
+import { jest } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import {
+  buildExpandedToolScript,
+  executeExpandedTool,
+  expandedToolNames,
+  getExpandedTools,
+  isExpandedTool,
+  isUnimplementedExpandedTool,
+  unimplementedExpandedToolNames
+} from '../../tools/expanded.js';
+import type { PremiereProTransport } from '../../bridge/types.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const expandedSource = readFileSync(join(here, '../../tools/expanded.ts'), 'utf8');
+
+/** Tool names reachable through a `case` label in the generated ExtendScript switch. */
+const scriptHandledNames = new Set(
+  (expandedSource
+    .slice(expandedSource.indexOf('function buildExpandedToolScript'))
+    .match(/case "[a-z_0-9]+":/g) || []).map((label) => label.slice(6, -2))
+);
+
+/** Tool names short-circuited in TypeScript before any script is generated. */
+const typescriptHandledNames = new Set(['execute_extendscript']);
+
+function hasHandler(name: string): boolean {
+  return scriptHandledNames.has(name) || typescriptHandledNames.has(name);
+}
+
+/** Bridge stub that records the script it was asked to run and returns whatever it produces. */
+function stubBridge(result: unknown = { success: true }): jest.Mocked<PremiereProTransport> {
+  return {
+    executeScript: jest.fn().mockResolvedValue(result)
+  } as unknown as jest.Mocked<PremiereProTransport>;
+}
+
+describe('expanded tool catalog', () => {
+  it('advertises only tools that have a real handler', () => {
+    const advertisedWithoutHandler = expandedToolNames.filter((name) => !hasHandler(name));
+    expect(advertisedWithoutHandler).toEqual([]);
+  });
+
+  it('parks every unimplemented tool outside the advertised catalog', () => {
+    const overlap = unimplementedExpandedToolNames.filter((name) =>
+      (expandedToolNames as readonly string[]).includes(name)
+    );
+    expect(overlap).toEqual([]);
+  });
+
+  it('does not leak parked tools into getExpandedTools()', () => {
+    const advertised = new Set(getExpandedTools(new Set()).map((tool) => tool.name));
+    const leaked = unimplementedExpandedToolNames.filter((name) => advertised.has(name));
+    expect(leaked).toEqual([]);
+  });
+
+  it('still filters out names already provided by the core catalog', () => {
+    const [first] = expandedToolNames;
+    const advertised = getExpandedTools(new Set([first])).map((tool) => tool.name);
+    expect(advertised).not.toContain(first);
+  });
+
+  it('classifies names consistently across the two predicates', () => {
+    for (const name of expandedToolNames) {
+      expect(isExpandedTool(name)).toBe(true);
+      expect(isUnimplementedExpandedTool(name)).toBe(false);
+    }
+    for (const name of unimplementedExpandedToolNames) {
+      expect(isExpandedTool(name)).toBe(false);
+      expect(isUnimplementedExpandedTool(name)).toBe(true);
+    }
+  });
+});
+
+describe('executeExpandedTool()', () => {
+  it('refuses a parked tool without touching the bridge', async () => {
+    const bridge = stubBridge();
+    const [parked] = unimplementedExpandedToolNames;
+
+    const result = await executeExpandedTool(bridge, parked, {});
+
+    expect(result.success).toBe(false);
+    expect(result.implemented).toBe(false);
+    expect(result.error).toContain(parked);
+    expect(bridge.executeScript).not.toHaveBeenCalled();
+  });
+
+  it('reports add_tracks as a failure rather than a skipped success', async () => {
+    const bridge = stubBridge();
+
+    const result = await executeExpandedTool(bridge, 'add_tracks', {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('add_track');
+    expect(bridge.executeScript).not.toHaveBeenCalled();
+  });
+
+  it('rejects execute_extendscript with an empty script', async () => {
+    const bridge = stubBridge();
+
+    const result = await executeExpandedTool(bridge, 'execute_extendscript', { script: '   ' });
+
+    expect(result.success).toBe(false);
+    expect(bridge.executeScript).not.toHaveBeenCalled();
+  });
+
+  it('passes an advertised tool through to the bridge', async () => {
+    const bridge = stubBridge({ success: true, tool: 'ping' });
+
+    const result = await executeExpandedTool(bridge, 'ping', {});
+
+    expect(bridge.executeScript).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('surfaces a bridge error as a failure', async () => {
+    const bridge = {
+      executeScript: jest.fn().mockRejectedValue(new Error('bridge timeout'))
+    } as unknown as jest.Mocked<PremiereProTransport>;
+
+    const result = await executeExpandedTool(bridge, 'ping', {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('bridge timeout');
+  });
+});
+
+describe('generated ExtendScript', () => {
+  it('fails closed on an unrecognized tool name', () => {
+    const script = buildExpandedToolScript('definitely_not_a_real_tool', {});
+    const defaultBranch = script.slice(script.lastIndexOf('default:'));
+
+    expect(defaultBranch).toContain('return fail(');
+    expect(defaultBranch).not.toContain('return ok(');
+  });
+
+  it('never reports an unhandled tool as accepted', () => {
+    expect(expandedSource).not.toContain('ok({ accepted');
+  });
+
+  it('embeds the tool name and args as JSON literals', () => {
+    const script = buildExpandedToolScript('ping', { sequenceId: 'abc"def' });
+
+    expect(script).toContain('var toolName = "ping";');
+    expect(script).toContain(JSON.stringify({ sequenceId: 'abc"def' }));
+  });
+});

--- a/src/tools/expanded.ts
+++ b/src/tools/expanded.ts
@@ -2,13 +2,84 @@ import { z } from 'zod';
 import type { PremiereProTransport } from '../bridge/types.js';
 import type { MCPTool } from './index.js';
 
+// Tools below are backed by a real handler in buildExpandedToolScript (or by an explicit
+// TypeScript branch in executeExpandedTool). Only these are advertised to MCP clients.
 export const expandedToolNames = [
+  'find_items_by_media_path',
+  'get_item_info',
+  'rename_clip',
+  'get_clip_speed',
+  'set_clip_selection',
+  'link_selection',
+  'unlink_selection',
+  'get_effect_properties',
+  'execute_extendscript',
+  'evaluate_expression',
+  'inspect_dom_object',
+  'list_clip_effects',
+  'get_sequence_structure',
+  'get_premiere_state',
+  'get_full_project_overview',
+  'get_bin_contents',
+  'get_full_sequence_info',
+  'get_full_clip_info',
+  'get_project_item_info',
+  'search_project_items',
+  'get_timeline_summary',
+  'get_offline_media',
+  'get_used_media_report',
+  'select_clips_by_name',
+  'select_all_clips',
+  'deselect_all_clips',
+  'select_clips_in_range',
+  'select_disabled_clips',
+  'open_in_source',
+  'close_source_monitor',
+  'close_all_source_clips',
+  'set_source_in_out',
+  'insert_from_source',
+  'overwrite_from_source',
+  'get_source_monitor_info',
+  'set_target_track',
+  'get_target_tracks',
+  'rename_track',
+  'get_track_info',
+  'clear_item_in_out',
+  'set_item_in_out',
+  'remove_selected_clips',
+  'get_qe_clip_info',
+  'redo',
+  'multiple_undo',
+  'get_version_info',
+  'get_unused_media',
+  'get_duplicate_media',
+  'lift_selection',
+  'extract_selection',
+  'get_clip_links',
+  'get_clip_at_playhead',
+  'get_sequence_count',
+  'get_total_clip_count',
+  'match_frame',
+  'ping',
+  'get_workspaces',
+  'set_workspace',
+  'play_timeline',
+  'stop_playback',
+  'play_source_monitor',
+  'get_source_monitor_position'
+] as const;
+
+// Declared-but-unimplemented operations. These previously fell through to a permissive
+// `default:` branch that returned `success: true` without touching Premiere, so an agent
+// was told an edit had landed when nothing had happened. They are kept here as an explicit
+// roadmap and are deliberately NOT advertised in the tool catalog. Implementing one means
+// adding a real handler and moving its name into expandedToolNames above.
+export const unimplementedExpandedToolNames = [
   'close_project',
   'import_ae_comps',
   'delete_bin',
   'rename_bin',
   'create_smart_bin',
-  'find_items_by_media_path',
   'start_batch_encode',
   'add_custom_metadata_field',
   'import_sequences',
@@ -26,7 +97,6 @@ export const expandedToolNames = [
   'set_override_frame_rate',
   'set_override_pixel_aspect_ratio',
   'set_scale_to_frame_size',
-  'get_item_info',
   'select_item',
   'set_start_time',
   'unnest_sequence',
@@ -51,11 +121,6 @@ export const expandedToolNames = [
   'set_clip_speed_qe',
   'set_frame_blend',
   'set_time_interpolation',
-  'rename_clip',
-  'get_clip_speed',
-  'set_clip_selection',
-  'link_selection',
-  'unlink_selection',
   'overwrite_clip',
   'create_sequence_from_clips',
   'close_sequence',
@@ -68,56 +133,22 @@ export const expandedToolNames = [
   'get_clip_adjustment_layer',
   'get_linked_items',
   'get_mogrt_component',
-  'get_effect_properties',
   'set_effect_property',
   'remove_keyframe_range',
   'set_keyframe_interpolation',
   'get_value_at_time',
-  'execute_extendscript',
-  'evaluate_expression',
-  'inspect_dom_object',
-  'list_clip_effects',
-  'get_sequence_structure',
-  'get_premiere_state',
-  'get_full_project_overview',
-  'get_bin_contents',
-  'get_full_sequence_info',
-  'get_full_clip_info',
-  'get_project_item_info',
-  'search_project_items',
   'get_timeline_gaps',
-  'get_timeline_summary',
-  'get_offline_media',
-  'get_used_media_report',
-  'select_clips_by_name',
-  'select_all_clips',
-  'deselect_all_clips',
-  'select_clips_in_range',
   'select_clips_by_color',
   'invert_selection',
-  'select_disabled_clips',
   'copy_effects_between_clips',
   'copy_effect_values',
   'replace_clip_media',
   'batch_apply_effect',
   'remove_effect_by_name',
   'set_blend_mode',
-  'open_in_source',
-  'close_source_monitor',
-  'close_all_source_clips',
-  'set_source_in_out',
-  'insert_from_source',
-  'overwrite_from_source',
-  'get_source_monitor_info',
-  'set_target_track',
-  'get_target_tracks',
   'set_all_tracks_targeted',
-  'rename_track',
-  'get_track_info',
   'razor_all_tracks',
   'set_clip_start_time',
-  'clear_item_in_out',
-  'set_item_in_out',
   'import_image_sequence',
   'set_clip_position',
   'set_clip_scale',
@@ -128,14 +159,9 @@ export const expandedToolNames = [
   'set_clip_pan',
   'batch_rename_clips',
   'batch_enable_disable',
-  'remove_selected_clips',
   'clear_sequence_in_out',
   'get_encoder_presets',
-  'get_qe_clip_info',
-  'redo',
-  'multiple_undo',
   'set_poster_frame',
-  'get_version_info',
   'move_items_to_bin',
   'set_anti_alias_quality',
   'set_uniform_scale',
@@ -150,31 +176,15 @@ export const expandedToolNames = [
   'set_sequence_pixel_aspect_ratio',
   'set_sequence_field_type',
   'get_all_project_paths',
-  'get_unused_media',
-  'get_duplicate_media',
-  'lift_selection',
-  'extract_selection',
-  'get_clip_links',
   'get_sequence_markers_by_type',
   'get_clip_markers',
   'add_marker_to_project_item',
   'set_sequence_display_format',
-  'get_clip_at_playhead',
   'get_next_edit_point',
   'move_playhead_to_edit',
   'set_project_scratch_disk',
   'get_project_scratch_disks',
   'nest_clips',
-  'get_sequence_count',
-  'get_total_clip_count',
-  'match_frame',
-  'ping',
-  'get_workspaces',
-  'set_workspace',
-  'play_timeline',
-  'stop_playback',
-  'play_source_monitor',
-  'get_source_monitor_position',
   'consolidate_and_transfer'
 ] as const;
 
@@ -192,19 +202,35 @@ export function isExpandedTool(name: string): boolean {
   return (expandedToolNames as readonly string[]).includes(name);
 }
 
+export function isUnimplementedExpandedTool(name: string): boolean {
+  return (unimplementedExpandedToolNames as readonly string[]).includes(name);
+}
+
 export async function executeExpandedTool(
   bridge: PremiereProTransport,
   name: string,
   args: Record<string, any>
 ): Promise<any> {
   try {
+    // Belt-and-braces: the catalog no longer advertises these, so executeTool rejects them
+    // before we get here. If one is reached anyway, fail loudly rather than reporting a
+    // no-op as a success.
+    if (isUnimplementedExpandedTool(name)) {
+      return {
+        success: false,
+        tool: name,
+        implemented: false,
+        error: `Tool '${name}' is declared but not implemented against the Premiere scripting API. It is not exposed in the tool catalog and performs no work.`
+      };
+    }
+
     if (name === 'add_tracks') {
       return {
-        success: true,
+        success: false,
         tool: name,
         available: false,
         skipped: true,
-        note: 'Premiere addTracks can block CEP execution in this bridge. Use add_track repeatedly for safe one-track-at-a-time creation.'
+        error: 'Premiere addTracks can block CEP execution in this bridge. Use add_track repeatedly for safe one-track-at-a-time creation.'
       };
     }
 
@@ -227,7 +253,7 @@ export async function executeExpandedTool(
   }
 }
 
-function buildExpandedToolScript(name: string, args: Record<string, any>): string {
+export function buildExpandedToolScript(name: string, args: Record<string, any>): string {
   return `
     var toolName = ${JSON.stringify(name)};
     var args = ${JSON.stringify(args ?? {})};
@@ -660,9 +686,6 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           if (!track) return fail("Track not found");
           return ok({ name: track.name, index: trackIndex, type: trackType, clipCount: track.clips.numItems });
 
-        case "add_tracks":
-          return fail("Premiere's addTracks scripting API can block CEP execution in this bridge. Use the existing add_track tool for one track at a time.");
-
         case "get_clip_at_playhead":
           var playSeq = activeSequence();
           if (!playSeq) return fail("No active sequence");
@@ -713,24 +736,14 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "match_frame":
           return commandByName("Match Frame");
 
-        case "capture_frame":
-        case "get_encoder_presets":
-        case "get_project_scratch_disks":
-        case "get_project_panel_metadata":
-        case "get_xmp_metadata":
-        case "get_color_space":
-        case "get_graphics_white_luminance":
-        case "is_work_area_enabled":
-        case "get_insertion_bin":
-        case "get_all_project_paths":
-        case "get_timeline_gaps":
-        case "get_clip_markers":
-        case "get_sequence_markers_by_type":
-        case "get_next_edit_point":
-          return ok({ available: true, project: app.project ? app.project.name : null, note: "Read operation completed; this Premiere DOM surface exposes limited details in ExtendScript." });
-
         default:
-          return ok({ accepted: true, name: toolName, args: args, note: "Expanded tool dispatched through the native Premiere bridge. No copied upstream implementation is used." });
+          // Never report an unrecognized tool as a success. The previous behaviour returned
+          // { success: true, accepted: true } without touching Premiere, which told the calling
+          // agent that an edit had landed when nothing had happened.
+          return fail(
+            "No handler for '" + toolName + "' in the Premiere bridge. This tool performs no work and is not exposed in the tool catalog.",
+            { implemented: false }
+          );
       }
     } catch (error) {
       return fail(error && error.message ? error.message : error, { name: toolName });


### PR DESCRIPTION
## The problem

The expanded catalog advertises 173 tool names, but only 62 have a handler. Every other name falls through to the permissive `default:` branch in the generated ExtendScript:

```js
default:
  return ok({ accepted: true, name: toolName, args: args, note: "..." });
```

`ok()` sets `success: true`. So `ripple_delete`, `roll_edit`, `slip_edit`, `remove_effect`, `scene_edit_detection`, `move_clip_to_track`, `set_effect_property`, `replace_clip_media`, `export_omf` and roughly ninety others report a success to the calling agent while doing nothing to the project.

Two smaller variants of the same thing: 14 read tools return `{ available: true, note: "Read operation completed..." }` with no data, and `add_tracks` returns `success: true` next to `skipped: true`.

For an agent driving an edit this is the worst available failure mode. It doesn't just lose one call — it believes the timeline changed and builds its next several calls on that belief.

## The change

Split `expandedToolNames` into the 62 names that have a handler and 111 parked in `unimplementedExpandedToolNames`. Only the former are advertised, so the catalog goes from 281 to **170 tools that all do something**.

Defence in depth, since the two lists are hand-maintained against a switch statement:

- `executeExpandedTool` rejects a parked name explicitly before touching the bridge
- the ExtendScript `default:` branch returns `fail(...)` instead of `ok(...)`
- `src/__tests__/tools/expanded.test.ts` (13 tests) pins the invariant so the name list and the switch cannot drift apart silently again

Parking a tool is not the same as deleting it. `unimplementedExpandedToolNames` stays in the source as an explicit roadmap — implementing one means adding a real handler and moving its name back.

## Verification

Against a live Premiere Pro 26.0.2 session over the CEP bridge:

- server advertises 170 tools
- no parked name leaks into the catalog
- `ripple_delete` returns `success: false` / `"Tool not found"` in 9ms instead of a fabricated success
- `ping`, `get_project_info`, `list_sequences`, `get_premiere_state` all still return real data
- `create_sequence` lands a sequence confirmed by an independent readback

## Note on the test suite

The new test needs `import { jest } from '@jest/globals'` because the repo's ESM jest config does not inject globals. That is also why five of the six original suites currently fail with `ReferenceError: jest is not defined` on `main` — their `jest.mock(...)` calls need porting to `jest.unstable_mockModule`. I've documented that in `KNOWN_ISSUES.md` but deliberately left it alone rather than mixing a test-infrastructure rewrite into this PR.

Run the new suite with:

```bash
NODE_OPTIONS=--experimental-vm-modules npx jest src/__tests__/tools/expanded.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
