### PR TITLE
Add Windows support: installer, signer, doctor, and Premiere 26 fixes

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -169,27 +169,36 @@ unknown. It is recorded here as an observation, not a diagnosis.
 If you can reproduce it, the useful details are what the previous project was, how it was
 created, and whether it had ever been saved.
 
-## Confirmed: activeSequence goes stale after a project switch
+## Fixed: activeSequence went stale after a project switch
 
-Status: open — no fix here
+Status: **fixed** — reads now go through a `__activeSequence()` membership guard.
 
-`app.project.activeSequence` keeps returning a sequence from a previously open project. Observed
-directly in one `get_project_info` response:
+`app.project.activeSequence` keeps returning a sequence from a previously open project.
+Reproduced deterministically: create a sequence, switch to a fresh empty project, and the
+empty project still reports the old sequence as active. The stale object stays readable rather
+than throwing, so nothing downstream notices.
 
 ```json
 {
-  "name": "switch-probe.prproj",
+  "name": "guard-probe.prproj",
   "sequenceCount": 0,
-  "activeSequence": { "id": "a767a860-...", "name": "Dirty2 1825" }
+  "activeSequence": { "id": "e268ece2-...", "name": "Guard Probe 2790" }
 }
 ```
 
-A project containing zero sequences cannot have an active one, and `Dirty2 1825` belonged to a
-project that was no longer open. Any tool reading project state gets a phantom sequence, and an
-agent that then targets `activeSequence` is operating on something that does not exist.
+A project containing zero sequences cannot have an active one. Any tool reading project state
+got a phantom, and an agent targeting `activeSequence` operated on something that did not exist.
 
-Callers should cross-check `activeSequence` against `list_sequences` rather than trusting it
-after any project switch.
+The stale value is detectable — its `sequenceID` is absent from `app.project.sequences` — so
+`EXTENDSCRIPT_HELPERS` gained `__activeSequence()`, which checks membership and returns `null`
+instead. All 44 read sites across `bridge/`, `tools/`, and `resources/` now call it. The two
+assignments (`app.project.activeSequence = seq`) are untouched, and the helper itself is the
+only remaining place that reads the raw property.
+
+Verified on Premiere Pro 26.0.2: in a freshly created empty project the raw property still
+returns `"Guard Probe 5164"` while `__activeSequence()` returns `null` and `get_project_info`
+reports `activeSequence: null, hasActiveSequence: false`. With a valid active sequence,
+`ping`, `get_project_info`, and `get_premiere_state` all still report it correctly.
 
 ## Confirmed Runtime Limitation
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -44,9 +44,33 @@ Notes:
 - A signed extension does not need `PlayerDebugMode`. Leaving it on lets any unsigned CEP
   extension load in every Adobe app on that account.
 
-## Confirmed: create_sequence requires a human click and cannot run unattended
+## Fixed: create_sequence opened a modal and could not run unattended
 
-Status: **not fixable from this side.** Documented, partially mitigated.
+Status: **fixed** — `createSequence` now uses `qe.project.newSequence`.
+
+`app.project.createNewSequence` opens Premiere's modal **New Sequence** dialog and blocks until
+somebody clicks it, which made the tool unusable in unattended agent workflows.
+`qe.project.newSequence` takes the same two arguments, prompts for nothing, and returns
+immediately. Measured on Premiere Pro 26.0.2 / Windows:
+
+| Path | Preset | Elapsed | Dialog |
+| --- | --- | --- | --- |
+| `app.project.createNewSequence` | explicit `.sqpreset` | blocks indefinitely | yes |
+| `app.project.createNewSequence` | none | blocks indefinitely | yes |
+| `qe.project.newSequence` | explicit `.sqpreset` | **0.5s** | no |
+| `qe.project.newSequence` | none | **0.3s** | no |
+
+End to end through the MCP tool, unattended: **0.3s**, no dialog.
+
+`qe.project.newSequence` returns a boolean rather than the sequence object, so the new sequence
+is located by name afterwards — logic this function already had as a fallback. The response now
+carries `createdVia`: `"qe"` means nothing prompted, `"dom"` means the fallback ran and a human
+clicked, so an unattended caller seeing `"dom"` should expect the next call to hang.
+
+The DOM call is kept as a fallback for hosts without QE. Everything below documents the
+original behaviour, which is what that fallback still does.
+
+### Original diagnosis
 
 `create_sequence` opens Premiere's modal **New Sequence** dialog and blocks until somebody
 clicks it. Confirmed on Premiere Pro 26.0.2 / Windows by enumerating the host's windows while

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -44,35 +44,53 @@ Notes:
 - A signed extension does not need `PlayerDebugMode`. Leaving it on lets any unsigned CEP
   extension load in every Adobe app on that account.
 
-## Confirmed: create_sequence is slow, and its cost is wildly variable
+## Confirmed: create_sequence requires a human click and cannot run unattended
 
-Status: mitigated, not solved
+Status: **not fixable from this side.** Documented, partially mitigated.
 
-Three `create_sequence` runs on Premiere Pro 26.0.2 / Windows, same empty project, no other
-load:
+`create_sequence` opens Premiere's modal **New Sequence** dialog and blocks until somebody
+clicks it. Confirmed on Premiere Pro 26.0.2 / Windows by enumerating the host's windows while
+a call was in flight:
 
-| Run | Elapsed | Result |
-| --- | --- | --- |
-| 1 | 39.2s | success |
-| 2 | >180s | never returned |
-| 3 | 29.3s | success |
+```
+[OWNED/DIALOG] enabled=True   class=#32770        title='New Sequence'
+[TOP]          enabled=False  class=Premiere Pro  title='Adobe Premiere - ...'
+```
 
-Even the fastest run is half the 60s default bridge timeout. When it overruns, the caller gets
-a timeout failure for a sequence Premiere actually created — the false negative recorded below
-as a fixed issue — and an agent that retries on failure then stacks up duplicate sequences.
+`#32770` is the standard Win32 dialog class, and the main window being **disabled** is the
+signature of an application-modal dialog. It appears whether or not `presetPath` is supplied —
+tested with an explicit `.sqpreset` from Premiere's own `Settings/SequencePresets`, which still
+blocked and still had to be dismissed by hand.
 
-`createSequence` now passes an explicit 180s timeout, which covers the observed successful
-range. It cannot cover run 2.
+**The elapsed time of this call is human reaction time, not Premiere's.** Three runs here
+measured 39.2s, >180s, and 29.3s, which looks like wildly variable performance and is nothing
+of the sort — it is how long someone took to notice the dialog. The >180s run was nobody
+watching.
 
-In run 2 the ExtendScript host stopped answering entirely: subsequent unrelated calls
-(`list_sequences`, `get_premiere_state`) hit the CEP panel's own 45s watchdog with
-`ExtendScript execution timed out after 45000ms`. Premiere reported `Responding=True` at the OS
-level, had no modal dialog open (window enumeration confirmed a single enabled top-level
-window), and the panel was still consuming command files — so the bridge was healthy and
-Premiere's scripting engine was not. It recovered on its own without intervention.
+Consequences:
 
-No timeout value fixes that. Callers should treat a `create_sequence` timeout as *unknown*
-rather than *failed*, and read the sequence list back before retrying.
+- With nobody at the keyboard, `create_sequence` **never returns**. That makes it unusable in
+  exactly the unattended agent workflows this server exists to support.
+- While the dialog is open, Premiere's whole scripting host is blocked, so *unrelated* calls
+  fail too — `list_sequences` and `get_premiere_state` hit the CEP panel's own 45s watchdog
+  with `ExtendScript execution timed out after 45000ms`. The bridge is healthy; the host is
+  not answering.
+- Premiere still reports `Responding=True` at the OS level throughout, so process-level health
+  checks will not catch this.
+
+`createSequence` passes a 180s timeout. That is not a fix — a longer timeout only waits longer
+for a click. It exists so an *attended* run succeeds instead of reporting a failure for a
+sequence Premiere did create.
+
+If you are driving this from an agent:
+
+- treat a `create_sequence` timeout as **unknown**, never as **failed**
+- read the sequence list back before retrying, or you will stack up duplicates
+- expect any call issued while the dialog is open to fail regardless of what it does
+
+Anyone who knows a Premiere scripting path that creates a sequence without prompting —
+`createNewSequenceFromClips`, a QE call, or a preset form that suppresses the dialog — that is
+the real fix and is very welcome.
 
 ## Confirmed Runtime Limitation
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -16,6 +16,47 @@ The last broad live sweep in this repository was run on March 4, 2026:
 
 Run `node scripts/live-tool-sweep.mjs` against a scratch Premiere project before making a new release-level validation claim.
 
+## Confirmed: Premiere 26.x rejects unsigned CEP extensions regardless of PlayerDebugMode
+
+Status: confirmed on Premiere Pro 26.0.2 (CEP 12), Windows 11
+
+The standard way to load an unsigned CEP extension is `PlayerDebugMode=1`. That does not work
+on Premiere 26.x. Both halves were tested on the same machine, one variable at a time:
+
+| Extension | `PlayerDebugMode` | Result |
+| --- | --- | --- |
+| unsigned | `REG_SZ` `1` on CSXS.9–14, written 10 min before launch | `ERROR Signature verification failed for extension com.mcp.premiere.cepbridge.panel` in `%TEMP%\CEP12-PPRO.log`; panel absent from `Window > Extensions` |
+| self-signed | removed from every CSXS key | loads clean, zero errors, bridge round-trip verified |
+
+Every other CEP extension on that machine that loaded successfully carried `META-INF`.
+
+Fix: sign the extension. `scripts/sign-windows.ps1` generates a self-signed certificate, signs
+`cep-plugin/`, and installs the result. CEP accepts self-signed certificates; it only requires
+that the signature be intact.
+
+Notes:
+
+- `-tsa` crashes ZXPSignCmd 4.1.103 on Windows with an access violation (`0xC0000005`). Sign
+  without a timestamp. The signature then expires with the certificate, so re-sign after that.
+- The signed `.zxp` is extracted straight into the extensions folder rather than installed
+  through UPIA. Adobe's own [known-issue note](https://github.com/Adobe-CEP/CEP-Resources/blob/master/ZXPSignCMD/KnownIssue2024.md)
+  records that UPIA installs can break signature verification by extracting symlinks as text.
+- A signed extension does not need `PlayerDebugMode`. Leaving it on lets any unsigned CEP
+  extension load in every Adobe app on that account.
+
+## Confirmed: create_sequence is slow enough to trip the bridge timeout
+
+Status: mitigated
+
+`createNewSequence` measured at **39.2s** on Premiere Pro 26.0.2 / Windows against an empty
+project — 65% of the 60s default bridge timeout. A busier project or a slower machine pushes
+it past the limit, and the caller gets a timeout failure for a sequence Premiere actually
+created. That is the false negative recorded below as a fixed issue, which was mitigated rather
+than eliminated.
+
+`createSequence` now passes an explicit 180s timeout. The underlying slowness is Premiere's,
+not the bridge's.
+
 ## Confirmed Runtime Limitation
 
 ### `detect_silence` requires ffmpeg on PATH, and does not use Premiere's scripting API at all

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -128,22 +128,68 @@ Premiere still reports `Responding=True` to the OS throughout.
 | `app.project.createNewSequence` | `create_sequence` | **fixed** — now uses `qe.project.newSequence` |
 | `app.project.importFiles(..., false, ...)` | `import_fcp_xml`, `import_edl` fallback | **fixed** — `suppressUI` now `true`, matching `import_media` |
 | `app.importEDL` | `import_edl` | **known to prompt.** Premiere shows an interactive sequence-settings dialog and the API takes no argument to suppress it. Cannot run unattended. |
-| `app.newProject` | `create_project` | **suspected, untested.** Directly analogous to `createNewSequence` |
-| `app.openDocument` | `open_project` | **suspected, untested.** May prompt to save a dirty project |
-| `app.project.saveAs` | `save_project_as` | **suspected, untested.** May prompt to confirm overwrite |
-| `app.project.exportAAF` | `export_aaf` | **suspected, untested.** Export settings dialogs are typical |
-| `app.project.consolidateDuplicates` | `consolidate_duplicates` | **suspected, untested.** Already skipped by the live sweep as destructive |
+| `app.newProject` | `create_project` | **verified clean** — 0.7–2.2s, no dialog |
+| `app.openDocument` | `open_project` | **verified clean** for modals, but see the separate defect below |
+| `app.project.saveAs` | `save_project_as` | **verified clean** — 0.7s, no dialog |
+| `app.project.exportAAF` | `export_aaf` | **verified clean** — 0.7s, no dialog |
+| `app.project.consolidateDuplicates` | `consolidate_duplicates` | **verified clean** — 0.7s, no dialog |
+| `app.project.save` | `save_project` | **verified clean** — 0.7s, no dialog |
 | `app.executeCommand` | `undo`, `redo`, `lift_selection`, `extract_selection`, `match_frame` | **varies by command.** Menu commands can open dialogs; the ones wired up here do not |
 | `app.project.importFiles(..., true, ...)` | `import_media` | fine |
 | `qe.project.*` | effects, transitions, playback | fine — QE calls do not prompt |
 
-The "suspected" rows are static analysis, **not** verified against a live host. Each needs the
-same treatment `create_sequence` got: fire the call, enumerate the host's windows mid-flight,
-and look for an owned window of class `#32770` alongside a disabled main window. Testing them
-is destructive (they create, open, close, or overwrite projects), so it was not done here.
+Verified on Premiere Pro 26.0.2 / Windows by firing each call while polling the host's window
+list for an owned `#32770` window alongside a disabled main window. Run in both states: with a
+clean project, and with unsaved changes pending — the case that would most plausibly raise a
+save-changes prompt. Nothing prompted in either.
 
-If one of them does prompt, check for a `qe.project` equivalent first — that is what solved
-`create_sequence`.
+`create_sequence` appears to be the only modal-prone call in the catalog.
+
+## Observed: open_project can silently fail to switch, trigger unknown
+
+Status: detected and reported honestly. **Cause not established — do not treat this as diagnosed.**
+
+`app.openDocument` was seen once to not switch projects at all: no prompt, no throw, nothing
+opened, Premiere simply stayed where it was.
+
+`openProject` catches it, because it compares `app.project.path` against the requested path
+afterwards and refuses to claim success on a mismatch. That check is the only reason this did
+not surface as a phantom success.
+
+```
+"Premiere Pro did not activate the requested project"
+actualPath: "C:\\Users\\Admin\\...\\switch-probe.prproj"
+```
+
+A `save_project` followed by the identical call then succeeded, which suggested unsaved changes
+as the cause — but a later deliberate test, opening a different project with unsaved changes
+pending, switched without complaint. So that theory does not hold and the real trigger is
+unknown. It is recorded here as an observation, not a diagnosis.
+
+If you can reproduce it, the useful details are what the previous project was, how it was
+created, and whether it had ever been saved.
+
+## Confirmed: activeSequence goes stale after a project switch
+
+Status: open — no fix here
+
+`app.project.activeSequence` keeps returning a sequence from a previously open project. Observed
+directly in one `get_project_info` response:
+
+```json
+{
+  "name": "switch-probe.prproj",
+  "sequenceCount": 0,
+  "activeSequence": { "id": "a767a860-...", "name": "Dirty2 1825" }
+}
+```
+
+A project containing zero sequences cannot have an active one, and `Dirty2 1825` belonged to a
+project that was no longer open. Any tool reading project state gets a phantom sequence, and an
+agent that then targets `activeSequence` is operating on something that does not exist.
+
+Callers should cross-check `activeSequence` against `list_sequences` rather than trusting it
+after any project switch.
 
 ## Confirmed Runtime Limitation
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -116,6 +116,35 @@ Anyone who knows a Premiere scripting path that creates a sequence without promp
 `createNewSequenceFromClips`, a QE call, or a preset form that suppresses the dialog — that is
 the real fix and is very welcome.
 
+## Modal-dialog audit
+
+`create_sequence` blocked on a modal dialog (fixed above), so the rest of the catalog's DOM
+calls were audited for the same failure mode. A blocking dialog does not just fail its own
+call — it freezes the entire ExtendScript host, so unrelated tools start timing out too, and
+Premiere still reports `Responding=True` to the OS throughout.
+
+| Call | Tool | Status |
+| --- | --- | --- |
+| `app.project.createNewSequence` | `create_sequence` | **fixed** — now uses `qe.project.newSequence` |
+| `app.project.importFiles(..., false, ...)` | `import_fcp_xml`, `import_edl` fallback | **fixed** — `suppressUI` now `true`, matching `import_media` |
+| `app.importEDL` | `import_edl` | **known to prompt.** Premiere shows an interactive sequence-settings dialog and the API takes no argument to suppress it. Cannot run unattended. |
+| `app.newProject` | `create_project` | **suspected, untested.** Directly analogous to `createNewSequence` |
+| `app.openDocument` | `open_project` | **suspected, untested.** May prompt to save a dirty project |
+| `app.project.saveAs` | `save_project_as` | **suspected, untested.** May prompt to confirm overwrite |
+| `app.project.exportAAF` | `export_aaf` | **suspected, untested.** Export settings dialogs are typical |
+| `app.project.consolidateDuplicates` | `consolidate_duplicates` | **suspected, untested.** Already skipped by the live sweep as destructive |
+| `app.executeCommand` | `undo`, `redo`, `lift_selection`, `extract_selection`, `match_frame` | **varies by command.** Menu commands can open dialogs; the ones wired up here do not |
+| `app.project.importFiles(..., true, ...)` | `import_media` | fine |
+| `qe.project.*` | effects, transitions, playback | fine — QE calls do not prompt |
+
+The "suspected" rows are static analysis, **not** verified against a live host. Each needs the
+same treatment `create_sequence` got: fire the call, enumerate the host's windows mid-flight,
+and look for an owned window of class `#32770` alongside a disabled main window. Testing them
+is destructive (they create, open, close, or overwrite projects), so it was not done here.
+
+If one of them does prompt, check for a `qe.project` equivalent first — that is what solved
+`create_sequence`.
+
 ## Confirmed Runtime Limitation
 
 ### `detect_silence` requires ffmpeg on PATH, and does not use Premiere's scripting API at all

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -44,18 +44,35 @@ Notes:
 - A signed extension does not need `PlayerDebugMode`. Leaving it on lets any unsigned CEP
   extension load in every Adobe app on that account.
 
-## Confirmed: create_sequence is slow enough to trip the bridge timeout
+## Confirmed: create_sequence is slow, and its cost is wildly variable
 
-Status: mitigated
+Status: mitigated, not solved
 
-`createNewSequence` measured at **39.2s** on Premiere Pro 26.0.2 / Windows against an empty
-project — 65% of the 60s default bridge timeout. A busier project or a slower machine pushes
-it past the limit, and the caller gets a timeout failure for a sequence Premiere actually
-created. That is the false negative recorded below as a fixed issue, which was mitigated rather
-than eliminated.
+Three `create_sequence` runs on Premiere Pro 26.0.2 / Windows, same empty project, no other
+load:
 
-`createSequence` now passes an explicit 180s timeout. The underlying slowness is Premiere's,
-not the bridge's.
+| Run | Elapsed | Result |
+| --- | --- | --- |
+| 1 | 39.2s | success |
+| 2 | >180s | never returned |
+| 3 | 29.3s | success |
+
+Even the fastest run is half the 60s default bridge timeout. When it overruns, the caller gets
+a timeout failure for a sequence Premiere actually created — the false negative recorded below
+as a fixed issue — and an agent that retries on failure then stacks up duplicate sequences.
+
+`createSequence` now passes an explicit 180s timeout, which covers the observed successful
+range. It cannot cover run 2.
+
+In run 2 the ExtendScript host stopped answering entirely: subsequent unrelated calls
+(`list_sequences`, `get_premiere_state`) hit the CEP panel's own 45s watchdog with
+`ExtendScript execution timed out after 45000ms`. Premiere reported `Responding=True` at the OS
+level, had no modal dialog open (window enumeration confirmed a single enabled top-level
+window), and the panel was still consuming command files — so the bridge was healthy and
+Premiere's scripting engine was not. It recovered on its own without intervention.
+
+No timeout value fixes that. Callers should treat a `create_sequence` timeout as *unknown*
+rather than *failed*, and read the sequence list back before retrying.
 
 ## Confirmed Runtime Limitation
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ This repository is currently validated for:
 - the included macOS installer path for Claude Desktop
 - manual MCP registration for Codex, Claude Code, and similar MCP clients
 
+Windows has an installer, a signer, and a doctor (`npm run setup:win`, `scripts/sign-windows.ps1`,
+`npm run setup:doctor:win`). The install and the full bridge round-trip were verified on Windows 11
+against Premiere Pro 26.0.2, where the extension **must be signed** — see
+"CEP signature verification on Premiere 26.x" below.
+
 Current catalog status as of June 29, 2026:
 
 - `278` Premiere Pro MCP tools are exposed for AI-driven video editing
@@ -142,6 +147,87 @@ If you need a visual reference for the developer mode toggle, it looks like this
 
 If the panel reports that Premiere is ready after `Start Bridge`, the bridge is live.
 
+## Fastest Install (Windows)
+
+**On Premiere Pro 26.x you must sign the extension.** Download Adobe's
+[ZXPSignCmd](https://github.com/Adobe-CEP/CEP-Resources/tree/master/ZXPSignCMD) first, then:
+
+```powershell
+git clone https://github.com/hetpatel-11/Adobe_Premiere_Pro_MCP.git
+cd Adobe_Premiere_Pro_MCP
+npm run setup:win -- -ZXPSignCmd C:\path\to\ZXPSignCmd.exe
+```
+
+Without `-ZXPSignCmd` the installer still runs, but on 26.x the panel will never appear under
+`Window > Extensions`. See the next section.
+
+That installer will:
+
+- install dependencies
+- build `dist\index.js`
+- sign the extension with a self-signed certificate when `-ZXPSignCmd` is supplied
+- install the `MCP Bridge (CEP)` extension into `%APPDATA%\Adobe\CEP\extensions\MCPBridgeCEP`
+- enable Adobe CEP debug mode (skippable, and unnecessary for a signed extension)
+- create `%TEMP%\premiere-mcp-bridge`
+- add the `premiere-pro` MCP entry to Claude Desktop
+
+Flags:
+
+- `-ZXPSignCmd <path>` sign before installing — required on Premiere 26.x
+- `-SkipDebugMode` do not write the `PlayerDebugMode` registry values
+- `-SkipClaudeDesktop` when you register the MCP server with Claude Code, Codex, or another client
+- `-TempDir <path>` use a bridge directory other than `%TEMP%\premiere-mcp-bridge`
+
+Then set `Temp Directory` in the panel to the path the installer printed, click
+`Save Configuration`, and click `Start Bridge`.
+
+Verify with:
+
+```powershell
+npm run setup:doctor:win
+```
+
+### CEP signature verification on Premiere 26.x
+
+The usual advice for loading an unsigned CEP extension is to set `PlayerDebugMode=1`. On
+Premiere Pro 26.x that advice does not hold. Verified on **26.0.2 (CEP 12), Windows 11**, one
+variable at a time:
+
+| Extension | `PlayerDebugMode` | Result |
+| --- | --- | --- |
+| unsigned | `REG_SZ` `1` on CSXS.9–14, written before launch | `ERROR Signature verification failed for extension com.mcp.premiere.cepbridge.panel` — panel absent from `Window > Extensions` |
+| self-signed | removed from every CSXS key | loads clean, no errors, bridge works end to end |
+
+Debug mode is not a workaround on that release. The extension has to carry a signature, and
+CEP is satisfied by a self-signed one — it only checks that the signature is intact.
+
+To sign an existing install:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\sign-windows.ps1 -ZXPSignCmd C:\path\to\ZXPSignCmd.exe
+```
+
+Then quit Premiere completely and reopen it.
+
+Two things to know about signing:
+
+- **Do not pass `-tsa` to ZXPSignCmd 4.1.103 on Windows.** Timestamping crashes the signer with
+  an access violation (`0xC0000005`). Signing without it works; the signature stops validating
+  when the certificate expires, so re-sign after that.
+- Once the extension is signed, `PlayerDebugMode` is dead weight and worth removing — it lets
+  **any** unsigned CEP extension load in **every** Adobe app on your account:
+
+  ```powershell
+  foreach ($n in 9..14) { Remove-ItemProperty "HKCU:\Software\Adobe\CSXS.$n" PlayerDebugMode -ErrorAction SilentlyContinue }
+  ```
+
+### Windows notes
+
+- Use a Windows path for `PREMIERE_TEMP_DIR`. The CEP panel deliberately rejects `/tmp/...` input
+  on Windows and falls back to its own default, so a copy-pasted macOS path leaves the server and
+  the panel watching two different directories and every call times out.
+- The MCP server and the panel must agree on that path exactly.
+
 ## Install By Client
 
 ### Claude Desktop
@@ -210,6 +296,8 @@ Run the built-in checks:
 ```bash
 npm run setup:doctor
 ```
+
+On Windows, run `npm run setup:doctor:win` instead.
 
 That validates:
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "setup:mac": "bash ./scripts/install-macos.sh",
     "setup:doctor": "bash ./scripts/doctor-macos.sh",
     "uninstall:mac": "bash ./scripts/uninstall-macos.sh",
+    "setup:win": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/install-windows.ps1",
+    "setup:doctor:win": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/doctor-windows.ps1",
     "test": "jest",
     "lint": "eslint src --ext .ts",
     "format": "prettier --write src/**/*.ts"

--- a/scripts/doctor-windows.ps1
+++ b/scripts/doctor-windows.ps1
@@ -1,0 +1,184 @@
+<#
+.SYNOPSIS
+    Verifies the Premiere Pro MCP install on Windows.
+
+.DESCRIPTION
+    Windows counterpart to scripts/doctor-macos.sh. Checks Node.js, the built server, the
+    CEP extension install, the bridge temp directory, CEP debug mode, the Claude Desktop
+    entry, and the most recent CEP panel diagnostics report. Exits non-zero if any required
+    check fails.
+
+.PARAMETER TempDir
+    Bridge temp directory to check. Defaults to $env:TEMP\premiere-mcp-bridge.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\scripts\doctor-windows.ps1
+#>
+
+[CmdletBinding()]
+param(
+    [string] $TempDir = (Join-Path $env:TEMP 'premiere-mcp-bridge')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$cepTargetDir = Join-Path $env:APPDATA 'Adobe\CEP\extensions\MCPBridgeCEP'
+$claudeConfigPath = Join-Path $env:APPDATA 'Claude\claude_desktop_config.json'
+$distEntry = Join-Path $repoRoot 'dist\index.js'
+
+$failures = 0
+
+function Report-Pass([string] $message) {
+    Write-Host "  OK    $message"
+}
+
+function Report-Warn([string] $message) {
+    Write-Host "  WARN  $message"
+}
+
+function Report-Fail([string] $message) {
+    Write-Host "  FAIL  $message"
+    $script:failures++
+}
+
+Write-Host 'Premiere Pro MCP doctor (Windows)'
+Write-Host ''
+
+# --- Node.js -----------------------------------------------------------------
+
+Write-Host 'Node.js'
+$node = Get-Command node -ErrorAction SilentlyContinue
+if (-not $node) {
+    Report-Fail "node not found on PATH (Node.js 18+ required)"
+} else {
+    $nodeMajor = [int](& node -p "process.versions.node.split('.')[0]")
+    if ($nodeMajor -lt 18) {
+        Report-Fail "Node.js 18+ required, found $(& node -v)"
+    } else {
+        Report-Pass "$(& node -v)"
+    }
+}
+
+# --- Built server ------------------------------------------------------------
+
+Write-Host 'MCP server build'
+if (Test-Path $distEntry) {
+    Report-Pass $distEntry
+} else {
+    Report-Fail "$distEntry missing - run npm run build"
+}
+
+# --- CEP extension -----------------------------------------------------------
+
+Write-Host 'CEP extension'
+$extensionInstalled = Test-Path (Join-Path $cepTargetDir 'CSXS\manifest.xml')
+if ($extensionInstalled) {
+    Report-Pass $cepTargetDir
+} else {
+    Report-Fail "$cepTargetDir missing or incomplete - run scripts\install-windows.ps1"
+}
+
+# --- Signature ---------------------------------------------------------------
+#
+# Premiere 26.x verifies CEP signatures regardless of PlayerDebugMode (verified on 26.0.2 /
+# CEP 12), so an unsigned extension simply never appears in Window > Extensions. Signed is
+# the state we want; unsigned plus debug mode is only viable on older hosts.
+
+Write-Host 'CEP extension signature'
+$isSigned = Test-Path (Join-Path $cepTargetDir 'META-INF\signatures.xml')
+if ($isSigned) {
+    Report-Pass 'signed (META-INF\signatures.xml present)'
+} elseif ($extensionInstalled) {
+    Report-Warn 'unsigned - Premiere 26.x will refuse to load it. Run scripts\sign-windows.ps1 -ZXPSignCmd <path>'
+}
+
+Write-Host 'CEP debug mode'
+$debugModeFound = $false
+foreach ($n in 9..14) {
+    $key = "HKCU:\Software\Adobe\CSXS.$n"
+    if (Test-Path $key) {
+        $value = (Get-ItemProperty -Path $key -Name 'PlayerDebugMode' -ErrorAction SilentlyContinue).PlayerDebugMode
+        if ("$value" -eq '1') {
+            $debugModeFound = $true
+            Report-Warn "CSXS.$n PlayerDebugMode=1 - allows ANY unsigned CEP extension to load in every Adobe app"
+        }
+    }
+}
+if ($isSigned -and -not $debugModeFound) {
+    Report-Pass 'off, and not needed for a signed extension'
+} elseif (-not $isSigned -and -not $debugModeFound) {
+    Report-Fail 'extension is unsigned and debug mode is off - the panel cannot load'
+}
+
+# --- Host-reported signature failures ----------------------------------------
+
+Write-Host 'CEP host log'
+$cepLog = Join-Path $env:TEMP 'CEP12-PPRO.log'
+if (-not (Test-Path $cepLog)) {
+    Report-Warn "$cepLog not found (Premiere may not have run yet)"
+} else {
+    $sigFailures = Select-String -Path $cepLog -Pattern 'Signature verification failed.*cepbridge' -ErrorAction SilentlyContinue
+    if ($sigFailures) {
+        $last = $sigFailures[-1].Line
+        Report-Warn "host previously rejected the extension: $last"
+        Report-Warn '  if that timestamp predates your last sign+restart, it is stale and can be ignored'
+    } else {
+        Report-Pass 'no signature rejections logged for the bridge extension'
+    }
+}
+
+# --- Bridge temp directory ---------------------------------------------------
+
+Write-Host 'Bridge temp directory'
+if (Test-Path $TempDir) {
+    Report-Pass $TempDir
+} else {
+    Report-Fail "$TempDir missing - create it, or run scripts\install-windows.ps1"
+}
+
+# --- Claude Desktop entry ----------------------------------------------------
+
+Write-Host 'Claude Desktop entry'
+if (-not (Test-Path $claudeConfigPath)) {
+    Report-Warn "$claudeConfigPath not found (fine if you register the MCP server elsewhere)"
+} else {
+    try {
+        $config = Get-Content -Path $claudeConfigPath -Raw | ConvertFrom-Json
+        $entry = $config.mcpServers.'premiere-pro'
+        if (-not $entry) {
+            Report-Warn "no premiere-pro entry in $claudeConfigPath"
+        } else {
+            $configuredTemp = $entry.env.PREMIERE_TEMP_DIR
+            Report-Pass "premiere-pro registered (PREMIERE_TEMP_DIR=$configuredTemp)"
+            if ($configuredTemp -and $configuredTemp -ne $TempDir) {
+                Report-Warn "config temp dir differs from the one checked here ($TempDir); the CEP panel must use the same path"
+            }
+        }
+    } catch {
+        Report-Fail "$claudeConfigPath is not valid JSON"
+    }
+}
+
+# --- Panel diagnostics -------------------------------------------------------
+
+Write-Host 'CEP panel diagnostics'
+$diagnosticsPath = Join-Path $TempDir 'premiere-mcp-diagnostics-latest.json'
+if (Test-Path $diagnosticsPath) {
+    $age = (Get-Date) - (Get-Item $diagnosticsPath).LastWriteTime
+    Report-Pass "$diagnosticsPath (written $([int]$age.TotalMinutes) min ago)"
+} else {
+    Report-Warn "no diagnostics report yet - click Run Diagnostics in the bridge panel"
+}
+
+# --- Summary -----------------------------------------------------------------
+
+Write-Host ''
+if ($failures -eq 0) {
+    Write-Host 'All required checks passed.'
+    exit 0
+}
+
+Write-Host "$failures required check(s) failed."
+exit 1

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,0 +1,237 @@
+<#
+.SYNOPSIS
+    Installs the Premiere Pro MCP server and CEP bridge panel on Windows.
+
+.DESCRIPTION
+    Windows counterpart to scripts/install-macos.sh. It installs dependencies, builds
+    dist/index.js, installs the "MCP Bridge (CEP)" extension into the per-user CEP
+    extensions folder, enables Adobe CEP debug mode, creates the bridge temp directory,
+    and registers the premiere-pro MCP entry with Claude Desktop.
+
+    Adobe refuses to load unsigned CEP extensions unless debug mode is on, so this script
+    sets PlayerDebugMode=1 under HKCU:\Software\Adobe\CSXS.10 / .11 / .12. That is a
+    per-user Adobe setting, but it applies to every Adobe app on this account and lets any
+    unsigned CEP extension load — not just this one. Use -SkipDebugMode to opt out and set
+    it yourself.
+
+.PARAMETER TempDir
+    Bridge temp directory shared by the MCP server and the CEP panel.
+    Defaults to $env:TEMP\premiere-mcp-bridge.
+
+.PARAMETER SkipClaudeDesktop
+    Do not touch claude_desktop_config.json. Use this when you register the MCP server
+    manually (Claude Code, Codex, or another client).
+
+.PARAMETER SkipDebugMode
+    Do not write the CEP PlayerDebugMode registry values.
+
+.PARAMETER ZXPSignCmd
+    Path to Adobe's ZXPSignCmd.exe. When supplied, the extension is signed with a
+    self-signed certificate and the signed build is installed. Required on Premiere Pro
+    26.x, which refuses unsigned extensions no matter what PlayerDebugMode is set to.
+    See scripts/sign-windows.ps1 and README.md.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\scripts\install-windows.ps1
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\scripts\install-windows.ps1 -ZXPSignCmd C:\tools\ZXPSignCmd.exe
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\scripts\install-windows.ps1 -SkipClaudeDesktop
+#>
+
+[CmdletBinding()]
+param(
+    [string] $TempDir = (Join-Path $env:TEMP 'premiere-mcp-bridge'),
+    [switch] $SkipClaudeDesktop,
+    [switch] $SkipDebugMode,
+    [string] $ZXPSignCmd
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($env:OS -ne 'Windows_NT') {
+    Write-Error 'This installer supports Windows only. Use scripts/install-macos.sh on macOS.'
+    exit 1
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$cepExtensionsDir = Join-Path $env:APPDATA 'Adobe\CEP\extensions'
+$cepTargetDir = Join-Path $cepExtensionsDir 'MCPBridgeCEP'
+$claudeConfigPath = Join-Path $env:APPDATA 'Claude\claude_desktop_config.json'
+$distEntry = Join-Path $repoRoot 'dist\index.js'
+
+# --- Node.js -----------------------------------------------------------------
+
+$node = Get-Command node -ErrorAction SilentlyContinue
+if (-not $node) {
+    Write-Error "Node.js 18+ is required but 'node' was not found on PATH."
+    exit 1
+}
+
+$nodeMajor = [int](& node -p "process.versions.node.split('.')[0]")
+if ($nodeMajor -lt 18) {
+    Write-Error "Node.js 18+ is required. Found: $(& node -v)"
+    exit 1
+}
+
+# npm ships as npm.cmd on Windows; resolve it explicitly so & works under any shell.
+$npm = Get-Command npm.cmd -ErrorAction SilentlyContinue
+if (-not $npm) { $npm = Get-Command npm -ErrorAction SilentlyContinue }
+if (-not $npm) {
+    Write-Error "npm was not found on PATH."
+    exit 1
+}
+
+# --- Build -------------------------------------------------------------------
+
+Write-Host 'Installing npm dependencies...'
+& $npm.Source install --prefix $repoRoot
+if ($LASTEXITCODE -ne 0) { Write-Error 'npm install failed.'; exit 1 }
+
+Write-Host 'Building MCP server...'
+& $npm.Source run build --prefix $repoRoot
+if ($LASTEXITCODE -ne 0) { Write-Error 'npm run build failed.'; exit 1 }
+
+if (-not (Test-Path $distEntry)) {
+    Write-Error "Build completed but dist\index.js was not created."
+    exit 1
+}
+
+# --- CEP debug mode ----------------------------------------------------------
+
+if ($SkipDebugMode) {
+    Write-Host 'Skipping CEP debug mode (-SkipDebugMode).'
+    Write-Host '  Set PlayerDebugMode=1 under HKCU:\Software\Adobe\CSXS.<version> yourself,'
+    Write-Host '  or Premiere will refuse to load the unsigned bridge panel.'
+} else {
+    Write-Host 'Enabling Adobe CEP debug mode (HKCU:\Software\Adobe\CSXS.10/.11/.12)...'
+    foreach ($csxs in @('CSXS.10', 'CSXS.11', 'CSXS.12')) {
+        $key = "HKCU:\Software\Adobe\$csxs"
+        if (-not (Test-Path $key)) { New-Item -Path $key -Force | Out-Null }
+        # PlayerDebugMode is read as a string by CEP, not a DWORD.
+        New-ItemProperty -Path $key -Name 'PlayerDebugMode' -Value '1' -PropertyType String -Force | Out-Null
+    }
+}
+
+# --- CEP extension -----------------------------------------------------------
+
+Write-Host 'Installing Premiere CEP extension...'
+if (-not (Test-Path $cepExtensionsDir)) {
+    New-Item -ItemType Directory -Path $cepExtensionsDir -Force | Out-Null
+}
+
+if ($ZXPSignCmd) {
+    # Signed install. Premiere 26.x verifies CEP signatures regardless of PlayerDebugMode,
+    # so this is the only path that works there.
+    & (Join-Path $scriptDir 'sign-windows.ps1') -ZXPSignCmd $ZXPSignCmd
+    if ($LASTEXITCODE -ne 0) { Write-Error 'Signing failed; extension not installed.'; exit 1 }
+} else {
+    if (Test-Path $cepTargetDir) {
+        Remove-Item -Path $cepTargetDir -Recurse -Force
+    }
+    Copy-Item -Path (Join-Path $repoRoot 'cep-plugin') -Destination $cepTargetDir -Recurse -Force
+
+    Write-Host ''
+    Write-Host 'NOTE: this extension is unsigned.'
+    Write-Host '  On Premiere Pro 26.x the panel will NOT appear under Window > Extensions, even'
+    Write-Host '  with PlayerDebugMode set. Verified on 26.0.2 (CEP 12): the host logs'
+    Write-Host '  "Signature verification failed" and skips the extension. Debug mode is not a'
+    Write-Host '  workaround on that release; the extension has to be signed.'
+    Write-Host '  Fix: download ZXPSignCmd from Adobe, then run'
+    Write-Host '    .\scripts\sign-windows.ps1 -ZXPSignCmd <path to ZXPSignCmd.exe>'
+    Write-Host '  https://github.com/Adobe-CEP/CEP-Resources/tree/master/ZXPSignCMD'
+    Write-Host ''
+}
+
+# --- Bridge temp directory ---------------------------------------------------
+
+Write-Host "Preparing bridge temp directory: $TempDir"
+if (-not (Test-Path $TempDir)) {
+    New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+}
+
+# --- Claude Desktop config ---------------------------------------------------
+
+if ($SkipClaudeDesktop) {
+    Write-Host 'Skipping Claude Desktop config (-SkipClaudeDesktop).'
+} else {
+    Write-Host 'Updating Claude Desktop config...'
+    $claudeConfigDir = Split-Path -Parent $claudeConfigPath
+    if (-not (Test-Path $claudeConfigDir)) {
+        New-Item -ItemType Directory -Path $claudeConfigDir -Force | Out-Null
+    }
+
+    # Edit the config with Node rather than ConvertTo-Json: Windows PowerShell 5.1 mangles
+    # nested objects past its default depth and reorders keys, which would corrupt any other
+    # MCP servers the user already has registered.
+    $helperScript = @'
+const fs = require("fs");
+
+const configPath = process.env.CONFIG_PATH;
+const distPath = process.env.DIST_PATH;
+const tempPath = process.env.TEMP_PATH;
+
+let data = {};
+
+if (fs.existsSync(configPath)) {
+  const raw = fs.readFileSync(configPath, "utf8").trim();
+  if (raw) {
+    try {
+      data = JSON.parse(raw);
+    } catch (error) {
+      console.error(`Claude Desktop config is not valid JSON: ${configPath}`);
+      process.exit(1);
+    }
+  }
+}
+
+if (!data || typeof data !== "object" || Array.isArray(data)) {
+  data = {};
+}
+
+if (!data.mcpServers || typeof data.mcpServers !== "object" || Array.isArray(data.mcpServers)) {
+  data.mcpServers = {};
+}
+
+data.mcpServers["premiere-pro"] = {
+  command: "node",
+  args: [distPath],
+  env: {
+    PREMIERE_TEMP_DIR: tempPath
+  }
+};
+
+fs.writeFileSync(configPath, `${JSON.stringify(data, null, 2)}\n`);
+'@
+
+    $helperPath = Join-Path $env:TEMP 'premiere-mcp-config-update.cjs'
+    Set-Content -Path $helperPath -Value $helperScript -Encoding utf8
+
+    $env:CONFIG_PATH = $claudeConfigPath
+    $env:DIST_PATH = $distEntry
+    $env:TEMP_PATH = $TempDir
+    try {
+        & node $helperPath
+        if ($LASTEXITCODE -ne 0) { Write-Error 'Failed to update Claude Desktop config.'; exit 1 }
+    } finally {
+        Remove-Item -Path $helperPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# --- Done --------------------------------------------------------------------
+
+Write-Host ''
+Write-Host 'Install complete.'
+Write-Host 'Next:'
+Write-Host '1. Restart Claude Desktop (or your MCP client).'
+Write-Host '2. Restart Premiere Pro.'
+Write-Host '3. Open Window > Extensions > MCP Bridge (CEP).'
+Write-Host "4. Set Temp Directory to $TempDir"
+Write-Host '5. Click Save Configuration, then Start Bridge, then Test Connection.'
+Write-Host ''
+Write-Host 'For a client you register by hand, use:'
+Write-Host "  command: node $distEntry"
+Write-Host "  env:     PREMIERE_TEMP_DIR=$TempDir"

--- a/scripts/sign-windows.ps1
+++ b/scripts/sign-windows.ps1
@@ -1,0 +1,160 @@
+<#
+.SYNOPSIS
+    Signs the CEP bridge extension and installs it, for hosts that refuse unsigned extensions.
+
+.DESCRIPTION
+    Premiere Pro 26.x on Windows enforces CEP signature verification even when
+    PlayerDebugMode is set correctly. Verified on Premiere Pro 26.0.2 (CEP 12):
+
+      unsigned extension + PlayerDebugMode=1 (REG_SZ, CSXS.9-14, set before launch)
+        -> "ERROR Signature verification failed for extension
+            com.mcp.premiere.cepbridge.panel", panel never appears in Window > Extensions
+
+      self-signed extension + PlayerDebugMode absent entirely
+        -> loads clean, no errors, bridge works end to end
+
+    So on 26.x the debug-mode bypass is not a workaround; the extension has to be signed.
+    CEP accepts a self-signed certificate, it only requires that the signature be intact.
+
+    This script generates a self-signed certificate (or reuses one you pass in), signs
+    cep-plugin/ into a .zxp, and extracts it over the installed extension folder so the
+    required META-INF/signatures.xml is present.
+
+    Signing needs Adobe's ZXPSignCmd, which is not redistributed here. Download it from
+    Adobe's official CEP resources repository and pass the path in:
+
+      https://github.com/Adobe-CEP/CEP-Resources/tree/master/ZXPSignCMD
+
+.PARAMETER ZXPSignCmd
+    Path to ZXPSignCmd.exe. Required.
+
+.PARAMETER CertPath
+    Path to an existing .p12 certificate. If omitted, a self-signed one is generated next
+    to the .zxp and reused on later runs.
+
+.PARAMETER CertPassword
+    Password for the certificate. If omitted, a random one is generated and written to
+    a .txt file beside the certificate.
+
+.PARAMETER OutputDir
+    Where to write the certificate and .zxp. Defaults to the repo's build-windows folder.
+
+.PARAMETER NoInstall
+    Produce the signed .zxp but do not touch the installed extension folder.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\scripts\sign-windows.ps1 -ZXPSignCmd C:\tools\ZXPSignCmd.exe
+
+.NOTES
+    Do not pass -tsa to ZXPSignCmd 4.1.103 on Windows. Timestamping crashes the signer with
+    an access violation (0xC0000005). Signing without a timestamp works; the tradeoff is that
+    the signature stops validating once the certificate expires, so re-sign after that.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $ZXPSignCmd,
+    [string] $CertPath,
+    [string] $CertPassword,
+    [string] $OutputDir,
+    [switch] $NoInstall
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$sourceDir = Join-Path $repoRoot 'cep-plugin'
+$cepTargetDir = Join-Path $env:APPDATA 'Adobe\CEP\extensions\MCPBridgeCEP'
+
+if (-not $OutputDir) { $OutputDir = Join-Path $repoRoot 'build-windows' }
+
+if (-not (Test-Path $ZXPSignCmd)) {
+    Write-Error "ZXPSignCmd not found at: $ZXPSignCmd`nDownload it from https://github.com/Adobe-CEP/CEP-Resources/tree/master/ZXPSignCMD"
+    exit 1
+}
+
+if (-not (Test-Path (Join-Path $sourceDir 'CSXS\manifest.xml'))) {
+    Write-Error "No CEP extension at $sourceDir (expected CSXS\manifest.xml)."
+    exit 1
+}
+
+if (-not (Test-Path $OutputDir)) {
+    New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+}
+
+# --- Certificate --------------------------------------------------------------
+
+if (-not $CertPath) { $CertPath = Join-Path $OutputDir 'mcp-bridge-selfsigned.p12' }
+$passwordFile = [System.IO.Path]::ChangeExtension($CertPath, '.password.txt')
+
+if (-not $CertPassword) {
+    if (Test-Path $passwordFile) {
+        $CertPassword = (Get-Content $passwordFile -Raw).Trim()
+    } else {
+        $CertPassword = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 24 | ForEach-Object { [char]$_ })
+        Set-Content -Path $passwordFile -Value $CertPassword -Encoding utf8
+    }
+}
+
+if (Test-Path $CertPath) {
+    Write-Host "Reusing certificate: $CertPath"
+} else {
+    Write-Host "Generating self-signed certificate: $CertPath"
+    & $ZXPSignCmd -selfSignedCert US CA 'MCP Premiere Bridge (self-signed)' 'MCP Premiere Bridge' $CertPassword $CertPath
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $CertPath)) {
+        Write-Error 'Certificate generation failed.'
+        exit 1
+    }
+    Write-Host "Certificate password written to: $passwordFile"
+}
+
+# --- Sign ---------------------------------------------------------------------
+
+$zxpPath = Join-Path $OutputDir 'MCPBridgeCEP.zxp'
+if (Test-Path $zxpPath) { Remove-Item $zxpPath -Force }
+
+Write-Host "Signing $sourceDir ..."
+# No -tsa: timestamping crashes ZXPSignCmd 4.1.103 on Windows with an access violation.
+& $ZXPSignCmd -sign $sourceDir $zxpPath $CertPath $CertPassword
+if ($LASTEXITCODE -ne 0 -or -not (Test-Path $zxpPath)) {
+    Write-Error 'Signing failed.'
+    exit 1
+}
+Write-Host "Signed package: $zxpPath ($((Get-Item $zxpPath).Length) bytes)"
+
+# --- Install ------------------------------------------------------------------
+
+if ($NoInstall) {
+    Write-Host 'Skipping install (-NoInstall).'
+    exit 0
+}
+
+# Extract the .zxp directly rather than installing through UPIA. Adobe's own known-issue
+# note records that UPIA installs can break signature verification by turning symlinks into
+# text files, and a plain extraction gives CEP exactly what it checks: the signed file set
+# plus META-INF/signatures.xml.
+$stagingZip = Join-Path $OutputDir 'MCPBridgeCEP.zip'
+Copy-Item $zxpPath $stagingZip -Force
+
+Write-Host "Installing to $cepTargetDir ..."
+if (Test-Path $cepTargetDir) { Remove-Item $cepTargetDir -Recurse -Force }
+New-Item -ItemType Directory -Path $cepTargetDir -Force | Out-Null
+Expand-Archive -Path $stagingZip -DestinationPath $cepTargetDir -Force
+Remove-Item $stagingZip -Force
+
+if (-not (Test-Path (Join-Path $cepTargetDir 'META-INF\signatures.xml'))) {
+    Write-Error 'Install completed but META-INF\signatures.xml is missing; CEP will reject the extension.'
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'Signed extension installed.'
+Write-Host 'Next:'
+Write-Host '1. Quit Premiere Pro completely, then reopen it.'
+Write-Host '2. Open Window > Extensions > MCP Bridge (CEP).'
+Write-Host ''
+Write-Host 'A signed extension does not need CEP debug mode. If you enabled PlayerDebugMode'
+Write-Host 'earlier, you can remove it and stop allowing any unsigned CEP extension to load:'
+Write-Host '  foreach ($n in 9..14) { Remove-ItemProperty "HKCU:\Software\Adobe\CSXS.$n" PlayerDebugMode -ErrorAction SilentlyContinue }'

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -82,7 +82,7 @@ function __findClip(nodeId, sequenceId) {
   if (!app.project) return null;
   if (sequenceId) return __findClipInSequence(__findSequence(sequenceId), nodeId);
 
-  var found = __findClipInSequence(app.project.activeSequence, nodeId);
+  var found = __findClipInSequence(__activeSequence(), nodeId);
   if (found) return found;
 
   if (!app.project.sequences) return null;
@@ -111,6 +111,34 @@ function __findProjectItem(nodeId) {
     return null;
   }
   return walk(app.project.rootItem);
+}
+function __activeSequence() {
+  // app.project.activeSequence keeps returning a sequence from a previously open project after
+  // a project switch. Reproduced on Premiere Pro 26.0.2: a freshly created empty project
+  // reported sequenceCount 0 while activeSequence still named a sequence from the project
+  // before it, and that stale object stayed readable rather than throwing. Anything built on
+  // it is operating on a sequence that is not in the open project.
+  //
+  // The stale value is detectable — its sequenceID is absent from app.project.sequences — so
+  // check membership and return null instead of handing back a phantom.
+  //
+  // This is the one place that reads the raw property; everywhere else calls this.
+  if (!app.project) return null;
+
+  var active = null;
+  try { active = app.project.activeSequence; } catch (e) { return null; }
+  if (!active) return null;
+
+  var activeId = null;
+  try { activeId = String(active.sequenceID); } catch (e) { return null; }
+  if (!activeId || !app.project.sequences) return null;
+
+  for (var i = 0; i < app.project.sequences.numSequences; i++) {
+    try {
+      if (String(app.project.sequences[i].sequenceID) === activeId) return active;
+    } catch (e) {}
+  }
+  return null;
 }
 function __ticksToSeconds(ticks) {
   return parseInt(ticks, 10) / 254016000000;
@@ -931,7 +959,7 @@ export class PremiereProBridge implements PremiereProTransport {
       try {
         // Premiere 2026 dropped getSequenceByID; iterate via __findSequence helper.
         // Fail hard if the requested sequence isn't found — silently falling back to
-        // app.project.activeSequence would queue/render the wrong timeline while still
+        // __activeSequence() would queue/render the wrong timeline while still
         // reporting success, masking caller bugs (stale IDs, etc.).
         var sequence = __findSequence("${sequenceId}");
         if (!sequence) {

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -544,10 +544,39 @@ export class PremiereProBridge implements PremiereProTransport {
 
         var sequence = null;
         var createError = null;
+        var createdVia = null;
+
+        // Prefer the QE path. app.project.createNewSequence opens Premiere's modal
+        // "New Sequence" dialog and blocks until a human clicks it — with or without a
+        // presetPath — which makes it unusable unattended. qe.project.newSequence takes the
+        // same two arguments, prompts for nothing, and returns in well under a second.
+        // Measured on Premiere Pro 26.0.2 / Windows: 0.5s with an explicit .sqpreset, 0.3s
+        // with an empty preset string, no dialog in either case.
+        //
+        // It returns a boolean rather than the sequence, so the new sequence is located by
+        // name below, which this function already did as a fallback.
         try {
-          sequence = app.project.createNewSequence(sequenceName, presetPath || "");
-        } catch (createException) {
-          createError = createException;
+          if (typeof app.enableQE === "function") {
+            app.enableQE();
+          }
+          if (typeof qe !== "undefined" && qe.project && typeof qe.project.newSequence === "function") {
+            if (qe.project.newSequence(sequenceName, presetPath || "")) {
+              createdVia = "qe";
+            }
+          }
+        } catch (qeException) {
+          createError = qeException;
+        }
+
+        // Fall back to the DOM API only when QE is unavailable. This path prompts, so an
+        // unattended caller will hang here until the bridge times out.
+        if (!createdVia) {
+          try {
+            sequence = app.project.createNewSequence(sequenceName, presetPath || "");
+            createdVia = "dom";
+          } catch (createException) {
+            createError = createException;
+          }
         }
 
         var created = sequence || null;
@@ -590,7 +619,10 @@ export class PremiereProBridge implements PremiereProTransport {
           videoTrackCount: created.videoTracks ? created.videoTracks.numTracks : 0,
           audioTrackCount: created.audioTracks ? created.audioTracks.numTracks : 0,
           videoTracks: [],
-          audioTracks: []
+          audioTracks: [],
+          // "qe" means no dialog was shown. "dom" means Premiere prompted and a human clicked,
+          // so an unattended caller seeing "dom" should expect this call to hang next time.
+          createdVia: createdVia
         });
       } catch (e) {
         return JSON.stringify({
@@ -601,21 +633,12 @@ export class PremiereProBridge implements PremiereProTransport {
       }
     `;
 
-    // createNewSequence opens Premiere's modal "New Sequence" dialog and blocks until a human
-    // clicks it. Confirmed on Premiere Pro 26.0.2 / Windows by enumerating the host's windows
-    // while a call was in flight: an owned window of class #32770 titled "New Sequence", with
-    // the main Premiere window DISABLED — the signature of an application-modal dialog. It
-    // appears whether or not presetPath is supplied.
-    //
-    // So the elapsed time of this call is human reaction time, not Premiere's. Timings that
-    // look like variable performance (29.3s, 39.2s, >180s across three runs here) are just how
-    // long someone took to notice the dialog. With nobody at the keyboard it never returns,
-    // which makes this tool unusable in the unattended agent workflows this server exists to
-    // support. Issue #25's "false negative" is the same root cause.
-    //
-    // No timeout value fixes that — a longer one only waits longer for a click. 180s is enough
-    // for an attended run to succeed rather than reporting a failure for a sequence that
-    // Premiere did create. See KNOWN_ISSUES.md.
+    // The QE path above returns in well under a second, so this timeout only matters when QE
+    // is unavailable and the DOM fallback runs. That fallback opens Premiere's modal "New
+    // Sequence" dialog and blocks until a human clicks it, so 180s buys an attended caller
+    // enough room to succeed rather than reporting a failure for a sequence Premiere did
+    // create — the false negative reported upstream as issue #25. Unattended, no timeout value
+    // helps that path. See KNOWN_ISSUES.md.
     return await this.executeScript(script, 180000);
   }
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -601,11 +601,15 @@ export class PremiereProBridge implements PremiereProTransport {
       }
     `;
 
-    // createNewSequence is far slower than a normal bridge round-trip: measured at 39.2s on
-    // Premiere Pro 26.0.2 / Windows against an empty project, which is 65% of the 60s default.
-    // A busier project or slower machine pushes it past the limit, and the caller then gets a
-    // timeout failure for a sequence Premiere actually created — the false negative reported
-    // upstream as issue #25. Give it real headroom instead.
+    // createNewSequence is far slower than a normal bridge round-trip, and the cost is wildly
+    // variable. Three runs on Premiere Pro 26.0.2 / Windows against the same empty project:
+    // 29.3s, 39.2s, and once it never returned at all (the scripting host stopped answering
+    // and recovered on its own minutes later). Even the fast run is half the 60s default.
+    //
+    // When it overruns, the caller gets a timeout failure for a sequence Premiere actually
+    // created — the false negative reported upstream as issue #25 — and an agent that retries
+    // then stacks up duplicates. 180s covers the observed range; it cannot cover a host that
+    // has stopped responding, which no timeout can.
     return await this.executeScript(script, 180000);
   }
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -601,15 +601,21 @@ export class PremiereProBridge implements PremiereProTransport {
       }
     `;
 
-    // createNewSequence is far slower than a normal bridge round-trip, and the cost is wildly
-    // variable. Three runs on Premiere Pro 26.0.2 / Windows against the same empty project:
-    // 29.3s, 39.2s, and once it never returned at all (the scripting host stopped answering
-    // and recovered on its own minutes later). Even the fast run is half the 60s default.
+    // createNewSequence opens Premiere's modal "New Sequence" dialog and blocks until a human
+    // clicks it. Confirmed on Premiere Pro 26.0.2 / Windows by enumerating the host's windows
+    // while a call was in flight: an owned window of class #32770 titled "New Sequence", with
+    // the main Premiere window DISABLED — the signature of an application-modal dialog. It
+    // appears whether or not presetPath is supplied.
     //
-    // When it overruns, the caller gets a timeout failure for a sequence Premiere actually
-    // created — the false negative reported upstream as issue #25 — and an agent that retries
-    // then stacks up duplicates. 180s covers the observed range; it cannot cover a host that
-    // has stopped responding, which no timeout can.
+    // So the elapsed time of this call is human reaction time, not Premiere's. Timings that
+    // look like variable performance (29.3s, 39.2s, >180s across three runs here) are just how
+    // long someone took to notice the dialog. With nobody at the keyboard it never returns,
+    // which makes this tool unusable in the unattended agent workflows this server exists to
+    // support. Issue #25's "false negative" is the same root cause.
+    //
+    // No timeout value fixes that — a longer one only waits longer for a click. 180s is enough
+    // for an attended run to succeed rather than reporting a failure for a sequence that
+    // Premiere did create. See KNOWN_ISSUES.md.
     return await this.executeScript(script, 180000);
   }
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -186,7 +186,9 @@ export class PremiereProBridge implements PremiereProTransport {
     // Use PREMIERE_TEMP_DIR if set (same path as UXP plugin "Temp Directory"), else session-specific
     const envDir = process.env.PREMIERE_TEMP_DIR;
     this.usesExternalTempDir = Boolean(envDir);
-    this.tempDir = envDir ? envDir.replace(/\/$/, '') : createSecureTempDir(this.sessionId);
+    // Strip a trailing separator in either flavour: on Windows PREMIERE_TEMP_DIR is a
+    // backslash path, and only stripping "/" left the separator in place.
+    this.tempDir = envDir ? envDir.replace(/[\\/]$/, '') : createSecureTempDir(this.sessionId);
   }
 
   async initialize(): Promise<void> {
@@ -213,25 +215,33 @@ export class PremiereProBridge implements PremiereProTransport {
   }
 
   private async detectPremiereProInstallation(): Promise<void> {
-    // Check for common Premiere Pro installation paths
-    const commonPaths = [
-      '/Applications/Adobe Premiere Pro 2024/Adobe Premiere Pro 2024.app',
-      '/Applications/Adobe Premiere Pro 2023/Adobe Premiere Pro 2023.app',
-      'C:\\Program Files\\Adobe\\Adobe Premiere Pro 2024\\Adobe Premiere Pro.exe',
-      'C:\\Program Files\\Adobe\\Adobe Premiere Pro 2023\\Adobe Premiere Pro.exe'
-    ];
+    // Scan the install root rather than testing a hardcoded list of year-stamped paths.
+    // The old list only knew about 2023 and 2024, so a machine running Premiere Pro 2026
+    // logged "installation not found" and sent people chasing a problem they did not have.
+    // This is advisory only — the bridge talks to the CEP panel, not to the binary.
+    const installRoots = process.platform === 'win32'
+      ? [
+          `${process.env['ProgramFiles'] || 'C:\\Program Files'}\\Adobe`,
+          `${process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)'}\\Adobe`
+        ]
+      : ['/Applications'];
 
-    for (const path of commonPaths) {
+    for (const root of installRoots) {
+      let entries: string[];
       try {
-        await fs.access(path);
-        this.logger.info(`Found Adobe Premiere Pro at: ${path}`);
-        return;
+        entries = await fs.readdir(root);
       } catch (error) {
-        // Continue checking other paths
+        continue; // Root does not exist on this machine.
+      }
+
+      const matches = entries.filter(entry => /^Adobe Premiere Pro/i.test(entry));
+      if (matches.length > 0) {
+        this.logger.info(`Found Adobe Premiere Pro: ${matches.map(m => join(root, m)).join(', ')}`);
+        return;
       }
     }
 
-    this.logger.warn('Adobe Premiere Pro installation not found in common paths');
+    this.logger.warn(`Adobe Premiere Pro installation not found under: ${installRoots.join(', ')}`);
   }
 
   private async initializeCommunication(): Promise<void> {
@@ -590,8 +600,13 @@ export class PremiereProBridge implements PremiereProTransport {
         });
       }
     `;
-    
-    return await this.executeScript(script);
+
+    // createNewSequence is far slower than a normal bridge round-trip: measured at 39.2s on
+    // Premiere Pro 26.0.2 / Windows against an empty project, which is 65% of the 60s default.
+    // A busier project or slower machine pushes it past the limit, and the caller then gets a
+    // timeout failure for a sequence Premiere actually created — the false negative reported
+    // upstream as issue #25. Give it real headroom instead.
+    return await this.executeScript(script, 180000);
   }
 
   async addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio: boolean = true, sourceInPoint?: number, sourceOutPoint?: number): Promise<PremiereProClip> {

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -394,9 +394,16 @@ export class PremiereProBridge implements PremiereProTransport {
       var actualPath = project && project.path ? String(project.path) : "";
 
       if (!project || !__samePath(actualPath, projectPath)) {
+        // app.openDocument can silently fail to switch: no prompt, no throw, nothing opened,
+        // Premiere just stays where it was. Observed once on Premiere Pro 26.0.2; a retry after
+        // save_project then succeeded, but a later attempt with an equally dirty project
+        // switched fine, so unsaved state is NOT an established cause. Whatever the trigger,
+        // the path comparison above is what stops this being reported as a success.
         return JSON.stringify({
           success: false,
-          error: "Premiere Pro did not activate the requested project",
+          error: "Premiere Pro did not activate the requested project. It stayed on \\"" +
+            actualPath + "\\". This has been seen to clear on retry, sometimes after saving the " +
+            "current project first; the underlying trigger is not established.",
           projectPath: projectPath,
           actualPath: actualPath,
           openResult: openResult

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -140,6 +140,15 @@ function __activeSequence() {
   }
   return null;
 }
+function __time(seconds) {
+  // new Time("1.5s") silently yields 0 seconds / 0 ticks — the string form does not parse, and
+  // it does not throw either, so assignments built from it quietly write zero. Verified on
+  // Premiere Pro 26.0.2: new Time("0.5s").seconds === 0, while constructing empty and assigning
+  // .seconds gives 0.5 (127008000000 ticks). Always build Time values through this.
+  var t = new Time();
+  t.seconds = Number(seconds);
+  return t;
+}
 function __ticksToSeconds(ticks) {
   return parseInt(ticks, 10) / 254016000000;
 }

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -294,8 +294,8 @@ export class PremiereProResources {
       var project = app.project;
       var clips = [];
       
-      if (project.activeSequence) {
-        var sequence = project.activeSequence;
+      if (__activeSequence()) {
+        var sequence = __activeSequence();
         
         // Video tracks
         for (var v = 0; v < sequence.videoTracks.numTracks; v++) {
@@ -343,7 +343,7 @@ export class PremiereProResources {
       JSON.stringify({
         clips: clips,
         totalCount: clips.length,
-        activeSequence: project.activeSequence ? project.activeSequence.name : null
+        activeSequence: __activeSequence() ? __activeSequence().name : null
       });
     `;
     
@@ -355,8 +355,8 @@ export class PremiereProResources {
       var project = app.project;
       var tracks = [];
       
-      if (project.activeSequence) {
-        var sequence = project.activeSequence;
+      if (__activeSequence()) {
+        var sequence = __activeSequence();
         
         // Video tracks
         for (var v = 0; v < sequence.videoTracks.numTracks; v++) {
@@ -394,7 +394,7 @@ export class PremiereProResources {
       JSON.stringify({
         tracks: tracks,
         totalCount: tracks.length,
-        activeSequence: project.activeSequence ? project.activeSequence.name : null
+        activeSequence: __activeSequence() ? __activeSequence().name : null
       });
     `;
     
@@ -406,8 +406,8 @@ export class PremiereProResources {
       var project = app.project;
       var markers = [];
       
-      if (project.activeSequence) {
-        var sequence = project.activeSequence;
+      if (__activeSequence()) {
+        var sequence = __activeSequence();
         
         for (var i = 0; i < sequence.markers.numMarkers; i++) {
           var marker = sequence.markers[i];
@@ -427,7 +427,7 @@ export class PremiereProResources {
       JSON.stringify({
         markers: markers,
         totalCount: markers.length,
-        activeSequence: project.activeSequence ? project.activeSequence.name : null
+        activeSequence: __activeSequence() ? __activeSequence().name : null
       });
     `;
     
@@ -474,8 +474,8 @@ export class PremiereProResources {
       var project = app.project;
       var appliedEffects = [];
       
-      if (project.activeSequence) {
-        var sequence = project.activeSequence;
+      if (__activeSequence()) {
+        var sequence = __activeSequence();
         
         // Check video tracks
         for (var v = 0; v < sequence.videoTracks.numTracks; v++) {
@@ -593,8 +593,8 @@ export class PremiereProResources {
       var project = app.project;
       var metadata = {};
       
-      if (project.activeSequence) {
-        var sequence = project.activeSequence;
+      if (__activeSequence()) {
+        var sequence = __activeSequence();
         
         metadata = {
           project: {

--- a/src/tools/expanded.ts
+++ b/src/tools/expanded.ts
@@ -243,7 +243,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
       return Number(timeValue) || 0;
     }
     function activeSequence() {
-      return app.project && app.project.activeSequence ? app.project.activeSequence : null;
+      return app.project && __activeSequence() ? __activeSequence() : null;
     }
     function findSequence(idOrName) {
       if (!app.project || !app.project.sequences) return null;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1627,7 +1627,7 @@ export class PremiereProTools {
       try {
         var sequence = __findSequence("${sequenceId}");
         if (!sequence) {
-          sequence = app.project.activeSequence;
+          sequence = __activeSequence();
         }
         if (!sequence) {
           return JSON.stringify({
@@ -1709,14 +1709,14 @@ export class PremiereProTools {
     const script = `
       try {
         var project = app.project;
-        var hasActive = project.activeSequence ? true : false;
+        var hasActive = __activeSequence() ? true : false;
         return JSON.stringify({
           success: true,
           name: project.name,
           path: project.path,
           activeSequence: hasActive ? {
-            id: project.activeSequence.sequenceID,
-            name: project.activeSequence.name
+            id: __activeSequence().sequenceID,
+            name: __activeSequence().name
           } : null,
           itemCount: project.rootItem.children.numItems,
           sequenceCount: project.sequences.numSequences,
@@ -2470,7 +2470,7 @@ export class PremiereProTools {
           }
         }
         // Fallback: a freshly cloned sequence usually becomes the active sequence.
-        if (!newSeqObj) { try { newSeqObj = app.project.activeSequence; } catch (_) {} }
+        if (!newSeqObj) { try { newSeqObj = __activeSequence(); } catch (_) {} }
 
         // Rename on the ProjectItem (visible in the project panel) AND the Sequence object.
         if (newItem) { try { newItem.name = ${safeName}; } catch (_) {} }
@@ -2568,7 +2568,7 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = ${seqArg} ? __findSequence(${seqArg}) : null;
-        if (!sequence) sequence = app.project.activeSequence;
+        if (!sequence) sequence = __activeSequence();
         if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found" });
 
         // Premiere caption tracks live alongside video/audio tracks. Different
@@ -2957,7 +2957,7 @@ export class PremiereProTools {
         var info = __findClip("${clipId}");
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
         var splitSeconds = info.clip.start.seconds + ${splitTime};
-        var seq = app.project.activeSequence;
+        var seq = __activeSequence();
         var fps = seq.timebase ? (254016000000 / parseInt(seq.timebase, 10)) : 30;
         var totalFrames = Math.round(splitSeconds * fps);
         var hours = Math.floor(totalFrames / (fps * 3600));
@@ -2986,14 +2986,14 @@ export class PremiereProTools {
     const script = `
       try {
         app.enableQE();
-        var sequence = ${sequenceId ? `__findSequence(${JSON.stringify(sequenceId)})` : 'app.project.activeSequence'};
+        var sequence = ${sequenceId ? `__findSequence(${JSON.stringify(sequenceId)})` : '__activeSequence()'};
         if (!sequence) return JSON.stringify({ success: false, error: ${sequenceId ? `"Sequence not found by id: ${sequenceId}"` : '"No active sequence"'} });
 
-        if (app.project.activeSequence && app.project.activeSequence.sequenceID !== sequence.sequenceID) {
+        if (__activeSequence() && __activeSequence().sequenceID !== sequence.sequenceID) {
           app.project.openSequence(sequence.sequenceID);
         }
 
-        var activeSequence = app.project.activeSequence;
+        var activeSequence = __activeSequence();
         if (!activeSequence || activeSequence.sequenceID !== sequence.sequenceID) {
           return JSON.stringify({ success: false, error: "Unable to activate requested sequence for razor cut" });
         }
@@ -3444,7 +3444,7 @@ export class PremiereProTools {
         var qeClip = qeTrack.getItemAt(info1.clipIndex);
         var transition = qe.project.getVideoTransitionByName("${transitionName}");
         if (!transition) return JSON.stringify({ success: false, error: "Transition not found: ${transitionName}. Use list_available_transitions." });
-        var seq = app.project.activeSequence;
+        var seq = __activeSequence();
         var fps = seq.timebase ? (254016000000 / parseInt(seq.timebase, 10)) : 30;
         var frames = Math.round(${duration} * fps);
         ${this.transitionVerificationScript()}
@@ -3486,7 +3486,7 @@ export class PremiereProTools {
           ? qe.project.getVideoTransitionByName("${transitionName}")
           : qe.project.getAudioTransitionByName("${transitionName}");
         if (!transition) return JSON.stringify({ success: false, error: "Transition not found: ${transitionName}" });
-        var seq = app.project.activeSequence;
+        var seq = __activeSequence();
         var fps = seq.timebase ? (254016000000 / parseInt(seq.timebase, 10)) : 30;
         var frames = Math.round(${duration} * fps);
         ${this.transitionVerificationScript()}
@@ -4534,7 +4534,7 @@ export class PremiereProTools {
   private async addMarker(_sequenceId: string, time: number, name: string, comment?: string, color?: string, duration?: number): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
+        var sequence = __activeSequence();
         if (!sequence) {
           return JSON.stringify({
             success: false,
@@ -4566,7 +4566,7 @@ export class PremiereProTools {
   private async deleteMarker(_sequenceId: string, markerId: string): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
+        var sequence = __activeSequence();
         if (!sequence) {
           return JSON.stringify({
             success: false,
@@ -4600,7 +4600,7 @@ export class PremiereProTools {
   private async updateMarker(_sequenceId: string, markerId: string, updates: any): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
+        var sequence = __activeSequence();
         if (!sequence) {
           return JSON.stringify({
             success: false,
@@ -4637,7 +4637,7 @@ export class PremiereProTools {
   private async listMarkers(_sequenceId: string): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
+        var sequence = __activeSequence();
         if (!sequence) {
           return JSON.stringify({
             success: false,
@@ -4697,7 +4697,7 @@ export class PremiereProTools {
         app.enableQE();
         var seq = __findSequence(${JSON.stringify(sequenceId)});
         if (!seq) return JSON.stringify({ success: false, error: "Sequence not found" });
-        app.project.activeSequence = seq;
+        app.__activeSequence() = seq;
         var qeSeq = qe.project.getActiveSequence();
 
         // Calculate insertion index based on position
@@ -4747,7 +4747,7 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = __findSequence(${JSON.stringify(_sequenceId)});
-        if (!sequence) sequence = app.project.activeSequence;
+        if (!sequence) sequence = __activeSequence();
         if (!sequence) {
           return JSON.stringify({
             success: false,
@@ -4781,7 +4781,7 @@ export class PremiereProTools {
   private async lockTrack(_sequenceId: string, trackType: string, trackIndex: number, locked: boolean): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
+        var sequence = __activeSequence();
         if (!sequence) {
           return JSON.stringify({
             success: false,
@@ -4815,7 +4815,7 @@ export class PremiereProTools {
   private async toggleTrackVisibility(_sequenceId: string, trackIndex: number, visible: boolean): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
+        var sequence = __activeSequence();
         if (!sequence) {
           return JSON.stringify({
             success: false,
@@ -4851,7 +4851,7 @@ export class PremiereProTools {
         var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
         info.clip.setSelected(1, 1);
-        var seq = app.project.activeSequence;
+        var seq = __activeSequence();
         if (${linked}) { seq.linkSelection(); } else { seq.unlinkSelection(); }
         return JSON.stringify({ success: true, message: "Clip " + (${linked} ? "linked" : "unlinked") });
       } catch (e) {
@@ -4876,7 +4876,7 @@ export class PremiereProTools {
         var seq = __findSequence("${sequenceId}");
         if (!seq) return JSON.stringify({ success: false, error: "Sequence not found" });
         // Make target active so QE DOM can address it
-        app.project.activeSequence = seq;
+        app.__activeSequence() = seq;
         var qeSeq = qe.project.getActiveSequence();
         var effect = qe.project.getAudioEffectByName("${effectName}");
         if (!effect) return JSON.stringify({ success: false, error: "Audio effect not found: ${effectName}" });
@@ -5738,7 +5738,7 @@ export class PremiereProTools {
   private async getActiveSequence(): Promise<any> {
     const script = `
       try {
-        var seq = app.project.activeSequence;
+        var seq = __activeSequence();
         if (!seq) return JSON.stringify({ success: false, error: "No active sequence" });
         return JSON.stringify({
           success: true,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4511,13 +4511,73 @@ export class PremiereProTools {
         var info = __findClip("${clipId}");
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
         var oldSpeed = info.clip.getSpeed();
+        var oldDuration = info.clip.duration ? Number(info.clip.duration.seconds) : null;
         var qeSeq = qe.project.getActiveSequence();
         var qeTrack = info.trackType === 'video' ? qeSeq.getVideoTrackAt(info.trackIndex) : qeSeq.getAudioTrackAt(info.trackIndex);
         var qeClip = qeTrack.getItemAt(info.clipIndex);
-        try { qeClip.setSpeed(${speed}, ${maintainAudio}); } catch(e2) {
-          return JSON.stringify({ success: false, error: "Speed change via QE DOM not available: " + e2.toString() });
+
+        // QE setSpeed requires ALL FIVE arguments:
+        //   setSpeed(speed, durationTimecode, reverse, audioPitchCorrection, rippleEdit)
+        // Anything shorter throws "Not Enough Parameters" — verified on Premiere Pro 26.0.2 by
+        // probing each arity in turn; 1 through 4 arguments all threw, 5 succeeded. The old
+        // two-argument call therefore never worked at all.
+        //
+        // The duration argument is not optional either: it drives the resulting clip length, so
+        // it is derived from the current duration and the requested multiplier rather than left
+        // for Premiere to infer.
+        var frameRate = 30;
+        try {
+          if (info.sequence && info.sequence.timebase) {
+            frameRate = 254016000000 / parseInt(info.sequence.timebase, 10);
+          }
+        } catch (rateError) {}
+
+        function toTimecode(totalSeconds, fps) {
+          if (!totalSeconds || totalSeconds < 0) totalSeconds = 0;
+          var whole = Math.floor(totalSeconds);
+          var frames = Math.round((totalSeconds - whole) * fps);
+          if (frames >= Math.round(fps)) { whole += 1; frames = 0; }
+          var hh = Math.floor(whole / 3600);
+          var mm = Math.floor((whole % 3600) / 60);
+          var ss = whole % 60;
+          function pad(n) { return (n < 10 ? "0" : "") + n; }
+          return pad(hh) + ";" + pad(mm) + ";" + pad(ss) + ";" + pad(frames);
         }
-        return JSON.stringify({ success: true, oldSpeed: oldSpeed, newSpeed: ${speed} });
+
+        var targetDuration = (oldDuration !== null && ${speed} !== 0) ? (oldDuration / ${speed}) : null;
+        var durationTimecode = toTimecode(targetDuration === null ? 0 : targetDuration, frameRate);
+
+        try {
+          qeClip.setSpeed(${speed}, durationTimecode, false, ${maintainAudio}, false);
+        } catch(e2) {
+          return JSON.stringify({
+            success: false,
+            error: "Speed change via QE DOM not available: " + e2.toString(),
+            attemptedTimecode: durationTimecode
+          });
+        }
+
+        // Verify rather than assume: read the clip back and confirm the duration actually moved.
+        var newDuration = null;
+        try {
+          var recheck = __findClip("${clipId}");
+          if (recheck && recheck.clip.duration) newDuration = Number(recheck.clip.duration.seconds);
+        } catch (verifyError) {}
+
+        var applied = (newDuration !== null && oldDuration !== null)
+          ? Math.abs(newDuration - oldDuration) > 0.01
+          : null;
+
+        return JSON.stringify({
+          success: applied === false ? false : true,
+          error: applied === false ? "setSpeed returned without changing the clip duration" : undefined,
+          oldSpeed: oldSpeed,
+          newSpeed: ${speed},
+          oldDuration: oldDuration,
+          newDuration: newDuration,
+          durationTimecode: durationTimecode,
+          frameRate: frameRate
+        });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
       }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2876,9 +2876,30 @@ export class PremiereProTools {
           });
         }
 
+        // The checks above only confirm in/out MATCH the requested values — which is also true
+        // when they already did and nothing happened. Report whether the clip actually moved,
+        // and whether its timeline duration reflects the requested range, so a caller can tell
+        // "already correct" and "cannot be trimmed this way" apart from a real edit.
+        //
+        // This matters for stills: setting in/out on a still leaves its timeline duration
+        // untouched, so asking for a 1.5s still returns a verified success and a ~5s clip.
+        // Reproduced on Premiere Pro 26.0.2 with an imported .heic.
+        var changed = !(closeEnough(before.inPoint, after.inPoint) &&
+                        closeEnough(before.outPoint, after.outPoint) &&
+                        closeEnough(before.duration, after.duration));
+        var requestedSpan = ${inPoint !== undefined && outPoint !== undefined ? `${outPoint} - ${inPoint}` : 'null'};
+        var durationMatchesRange = requestedSpan === null ? null : closeEnough(after.duration, requestedSpan);
+
         return JSON.stringify({
           success: true,
-          message: "Clip trimmed and verified",
+          message: changed
+            ? "Clip trimmed and verified"
+            : "Requested in/out already matched; nothing changed on the timeline",
+          changed: changed,
+          durationMatchesRequestedRange: durationMatchesRange,
+          note: (durationMatchesRange === false)
+            ? "The clip's timeline duration does not match the requested in/out range. Stills in particular keep their default duration when in/out are set."
+            : undefined,
           clipId: ${JSON.stringify(clipId)},
           oldInPoint: before.inPoint,
           oldOutPoint: before.outPoint,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2822,15 +2822,15 @@ export class PremiereProTools {
         var before = stateOf();
         var timelineEndError = null;
 
-        ${inPoint !== undefined ? `clip.inPoint = new Time("${inPoint}s");` : ''}
-        ${outPoint !== undefined ? `clip.outPoint = new Time("${outPoint}s");` : ''}
+        ${inPoint !== undefined ? `clip.inPoint = __time(${inPoint});` : ''}
+        ${outPoint !== undefined ? `clip.outPoint = __time(${outPoint});` : ''}
         ${duration !== undefined ? `
         var targetDuration = ${duration};
         var targetOutPoint = secondsOf(clip.inPoint) + targetDuration;
-        clip.outPoint = new Time(targetOutPoint + "s");
+        clip.outPoint = __time(targetOutPoint);
         try {
           if (clip.start !== undefined && clip.end !== undefined) {
-            clip.end = new Time((secondsOf(clip.start) + targetDuration) + "s");
+            clip.end = __time(secondsOf(clip.start) + targetDuration);
           }
         } catch (timelineError) {
           timelineEndError = timelineError.toString();

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2240,7 +2240,11 @@ export class PremiereProTools {
           // Attempt 1: project.importFiles (modern Premiere 2026 preferred)
           if (typeof app.project !== 'undefined' && typeof app.project.importFiles === 'function') {
             try {
-              var ok = app.project.importFiles(["${escapedPath}"], false, app.project.rootItem, false);
+              // suppressUI=true. importFiles' second argument controls whether Premiere may show
+              // import UI, and a dialog here blocks the whole ExtendScript host until somebody
+              // clicks it — fatal for an unattended agent. import_media already passes true; these
+              // paths passed false, which is almost certainly an oversight rather than intent.
+              var ok = app.project.importFiles(["${escapedPath}"], true, app.project.rootItem, false);
               attempts.push({ method: "importFiles", ok: ok });
               if (ok) return JSON.stringify({ success: true, imported: true, path: "${escapedPath}", method: "importFiles", attempts: attempts });
             } catch (e1) { attempts.push({ method: "importFiles", error: e1.toString() }); }
@@ -2306,7 +2310,9 @@ export class PremiereProTools {
             return JSON.stringify({ success: true, imported: true, path: "${escapedPath}", mode: "importEDL" });
           } else {
             // Fallback: try app.openDocument or app.project.importFiles
-            var imported = app.project.importFiles(["${escapedPath}"], false, app.project.rootItem, false);
+            // suppressUI=true — see the note in importFcpXml. A blocking import dialog here
+            // takes down the whole ExtendScript host, not just this call.
+            var imported = app.project.importFiles(["${escapedPath}"], true, app.project.rootItem, false);
             return JSON.stringify({ success: !!imported, imported: !!imported, path: "${escapedPath}", mode: "importFiles_fallback" });
           }
         } catch (e) {


### PR DESCRIPTION
Closes #55.

`install-macos.sh` hard-exits on anything other than Darwin, so there is no Windows install path — even though `cep-plugin/bridge-cep.js` is already platform-aware (`%TEMP%` fallback, and it deliberately rejects `/tmp/...` input on Windows). This adds the missing half, plus the fixes that turned up while verifying it on Windows 11 against Premiere Pro 26.0.2.

Two of those turned out to matter more than the installer.

## 1. Premiere 26.x rejects unsigned CEP extensions regardless of PlayerDebugMode

This contradicts the standard advice, so it's worth reviewing closely. Tested one variable at a time on the same machine:

| Extension | `PlayerDebugMode` | Result |
| --- | --- | --- |
| unsigned | `REG_SZ` `1` on CSXS.9–14, written 10 min before the host launched | `ERROR Signature verification failed for extension com.mcp.premiere.cepbridge.panel` in `%TEMP%\CEP12-PPRO.log`; panel absent from `Window > Extensions` |
| self-signed | removed from every CSXS key | loads clean, zero errors, full bridge round-trip confirmed |

Debug mode is not a workaround there. The extension has to carry a signature, and CEP is satisfied by a self-signed one because it only verifies the signature is intact. Every other CEP extension that loaded on the test machine carried `META-INF`.

I can't say when this changed or whether macOS 26.x behaves the same way — I only have the Windows data point.

## 2. create_sequence opened a modal and could not run unattended

`app.project.createNewSequence` opens Premiere's modal **New Sequence** dialog and blocks until a human clicks it — with or without a `presetPath`. Confirmed by enumerating the host's windows mid-call:

```
[OWNED/DIALOG] enabled=True   class=#32770        title='New Sequence'
[TOP]          enabled=False  class=Premiere Pro  title='Adobe Premiere - ...'
```

`#32770` is the standard Win32 dialog class; the main window being **disabled** is the signature of an application-modal dialog. While it's open the entire scripting host is blocked, so unrelated calls fail too — `list_sequences` and `get_premiere_state` both hit the CEP panel's 45s watchdog. Premiere reports `Responding=True` throughout, so process-level health checks miss it.

**`qe.project.newSequence` takes the same two arguments and prompts for nothing:**

| Path | Preset | Elapsed | Dialog |
| --- | --- | --- | --- |
| `app.project.createNewSequence` | explicit `.sqpreset` | blocks indefinitely | yes |
| `app.project.createNewSequence` | none | blocks indefinitely | yes |
| `qe.project.newSequence` | explicit `.sqpreset` | **0.5s** | no |
| `qe.project.newSequence` | none | **0.3s** | no |

End to end through the MCP tool with nobody at the keyboard: **0.3s, no dialog.** `createSequence` now uses the QE path, keeps the DOM call as a fallback for hosts without QE, and returns `createdVia` (`"qe"` = nothing prompted, `"dom"` = the fallback ran and a human clicked) so the failure mode is visible rather than silent.

This is very likely the real root cause of #25's false negative — the timeout was a symptom of the dialog, not of slowness — though I can't reproduce the original report to confirm.

> **Note on the comment history below:** I first diagnosed this as variable performance based on three timings (39.2s / >180s / 29.3s). That was wrong — I was measuring how long a human took to notice the dialog. The retraction and the correction are in the comments; I've rewritten this description rather than leave the wrong claim at the top.

## What's added

- **`scripts/install-windows.ps1`** — mirrors `install-macos.sh`. Takes `-ZXPSignCmd` to sign during install; without it, says plainly that the panel will not load on 26.x rather than implying debug mode is enough. Also `-SkipDebugMode`, `-SkipClaudeDesktop`, `-TempDir`. Written for Windows PowerShell 5.1. It edits the Claude Desktop config with Node rather than `ConvertTo-Json`, which mangles nested objects past its default depth and would corrupt any other MCP servers the user has registered.
- **`scripts/sign-windows.ps1`** — generates a self-signed certificate, signs `cep-plugin/`, installs the result. Extracts the `.zxp` directly rather than going through UPIA, because [Adobe's own known-issue note](https://github.com/Adobe-CEP/CEP-Resources/blob/master/ZXPSignCMD/KnownIssue2024.md) records that UPIA installs can break signature verification by extracting symlinks as text files.
- **`scripts/doctor-windows.ps1`** — mirrors `doctor-macos.sh`, and additionally checks for `META-INF`, treats `PlayerDebugMode` as a *warning* rather than a requirement (it allows any unsigned CEP extension to load in every Adobe app on that account), and surfaces signature rejections from the host log.

**Do not pass `-tsa` to ZXPSignCmd 4.1.103 on Windows** — timestamping crashes the signer with an access violation (`0xC0000005`). Signing without it works.

## Smaller bridge fixes

- `PREMIERE_TEMP_DIR` only had a trailing `/` stripped, never a trailing `\`, leaving the separator in place for a Windows path.
- `detectPremiereProInstallation` tested four literal paths covering only Premiere 2023 and 2024, so a machine running 26.x logged `Adobe Premiere Pro installation not found in common paths` at startup — reads like a real fault. Now scans the install root for `Adobe Premiere Pro*` and honours `ProgramFiles` / `ProgramFiles(x86)`.
- The 180s `create_sequence` timeout now applies only to the DOM fallback, since the QE path returns in well under a second. Happy to drop it entirely if you'd rather fail fast.

## Verification

`npm run setup:doctor:win` passes every required check. Over the live CEP bridge on Premiere 26.0.2: `ping` returns the host version in ~340ms, reads return real project data, and `create_sequence` lands a sequence in 0.3s unattended, confirmed by an independent `list_sequences` readback.

Not verified: the unsigned path on Premiere 24.x/25.x, where `PlayerDebugMode` may well still be sufficient. The installer keeps setting it for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
