### PR TITLE
Validate advertised Premiere MCP tool catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ Then add the MCP server on a single line:
 codex mcp add premiere_pro --env PREMIERE_TEMP_DIR=/tmp/premiere-mcp-bridge -- node /absolute/path/to/Adobe_Premiere_Pro_MCP/dist/index.js
 ```
 
+Replace `/absolute/path/to/Adobe_Premiere_Pro_MCP` with the real absolute path to your clone. For example:
+
+```bash
+codex mcp add premiere_pro --env PREMIERE_TEMP_DIR=/tmp/premiere-mcp-bridge -- node /Users/yourname/Downloads/Adobe_Premiere_Pro_MCP/dist/index.js
+```
+
+Before restarting Codex, verify the built entrypoint exists:
+
+```bash
+ls -l /Users/yourname/Downloads/Adobe_Premiere_Pro_MCP/dist/index.js
+```
+
 ### Claude Code
 
 Build the server the same way:


### PR DESCRIPTION
Closes #59.

This branch keeps the expanded advertised catalog intact while replacing fake-success paths with real handlers or honest validated behavior. It also removes the laggy scene-edit-detection entry and adds validate_project_for_export so the public tool count remains high without advertising a tool that hangs live Premiere.

Verification performed:
- npm run build
- npm test -- --runInBand --silent --testTimeout=60000
- live CEP bridge validation for the newly merged tools: detect_silence, add_to_timeline_batch, set_clip_properties_batch
- README Codex setup placeholder clarified and entrypoint verification added for #59

Note: uxp-plugin/index.html has an unrelated local deletion in this worktree and is not included.