### PR TITLE
Add Windows installer and Copilot MCP config

### DIFF
--- a/.github/workflows/windows-setup.yml
+++ b/.github/workflows/windows-setup.yml
@@ -1,0 +1,52 @@
+name: Windows setup smoke
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'package*.json'
+      - 'src/**'
+      - '.github/workflows/windows-setup.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'scripts/**'
+      - 'package*.json'
+      - 'src/**'
+      - '.github/workflows/windows-setup.yml'
+
+jobs:
+  windows-setup:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test -- --runInBand --silent --testTimeout=60000
+
+      - name: Run Windows installer smoke
+        shell: powershell
+        run: >
+          powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/install-windows.ps1
+          -SkipBuild
+          -SkipAdobeDebugMode
+          -TempDir "$env:TEMP\premiere-mcp-bridge"
+
+      - name: Run Windows doctor
+        shell: powershell
+        run: >
+          powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/doctor-windows.ps1
+          -TempDir "$env:TEMP\premiere-mcp-bridge"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,14 @@ npm run setup:mac
 
 That installs the CEP extension, builds the server, enables CEP debug mode, and updates Claude Desktop config.
 
+For a full local install on Windows:
+
+```powershell
+npm run setup:win
+```
+
+That installs the CEP extension, builds the server, enables CEP debug mode, and updates GitHub Copilot in VS Code plus Claude Desktop config.
+
 ## Core Development Loop
 
 Use this order:
@@ -48,7 +56,9 @@ cep-plugin/
 
 scripts/
   install-macos.sh        macOS installer
+  install-windows.ps1     Windows installer for GitHub Copilot and Claude Desktop
   doctor-macos.sh         local installation verifier
+  doctor-windows.ps1      Windows installation verifier
   uninstall-macos.sh      macOS uninstall helper
   live-tool-sweep.mjs     end-to-end live tool verifier
 ```

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -33,6 +33,24 @@ What's my current Premiere Pro project info?
 
 For better editing behavior, attach `premiere://config/get_instructions` before asking the model to change a project.
 
+## GitHub Copilot / Claude Desktop (Windows)
+
+```powershell
+git clone https://github.com/hetpatel-11/Adobe_Premiere_Pro_MCP.git
+cd Adobe_Premiere_Pro_MCP
+npm run setup:win
+```
+
+Then do this once inside Premiere Pro:
+
+1. Open `Window > Extensions > MCP Bridge (CEP)`.
+2. Set `Temp Directory` to `%TEMP%\premiere-mcp-bridge`.
+3. Click `Save Configuration`.
+4. Click `Start Bridge`.
+5. Click `Test Connection`.
+
+Then restart VS Code and/or Claude Desktop. The Windows installer writes MCP config for GitHub Copilot in VS Code and Claude Desktop.
+
 ## Codex / Claude Code
 
 Build the server:
@@ -61,6 +79,12 @@ Run:
 
 ```bash
 npm run setup:doctor
+```
+
+On Windows, run:
+
+```powershell
+npm run setup:doctor:win
 ```
 
 For a real end-to-end verification, use a scratch project and run:

--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ Current CEP panel UI inside Premiere Pro, using the refreshed bridge controls an
 This repository is currently validated for:
 
 - macOS
+- Windows installer/config smoke checks through GitHub Actions
 - Adobe Premiere Pro 2020+ (actively used and tested on Premiere Pro 26.0)
 - Node.js 18+
 - the included macOS installer path for Claude Desktop
+- the included Windows installer path for GitHub Copilot in VS Code and Claude Desktop config
 - manual MCP registration for Codex, Claude Code, and similar MCP clients
 
 Current catalog status as of July 29, 2026:
@@ -142,6 +144,44 @@ If you need a visual reference for the developer mode toggle, it looks like this
 
 If the panel reports that Premiere is ready after `Start Bridge`, the bridge is live.
 
+## Fastest Install (Windows)
+
+```powershell
+git clone https://github.com/hetpatel-11/Adobe_Premiere_Pro_MCP.git
+cd Adobe_Premiere_Pro_MCP
+npm run setup:win
+```
+
+That installer will:
+
+- install dependencies
+- build `dist\index.js`
+- enable Adobe CEP debug mode under `HKCU:\Software\Adobe\CSXS.9` through `CSXS.15`
+- install the `MCP Bridge (CEP)` extension into `%APPDATA%\Adobe\CEP\extensions\MCPBridgeCEP`
+- create `%TEMP%\premiere-mcp-bridge`
+- add the `premiere-pro` MCP entry to GitHub Copilot in VS Code at `%APPDATA%\Code\User\mcp.json`
+- add the `premiere-pro` MCP entry to Claude Desktop at `%APPDATA%\Claude\claude_desktop_config.json`
+
+Optional flags:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-windows.ps1 -SkipCopilotConfig
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-windows.ps1 -SkipClaudeDesktopConfig
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install-windows.ps1 -SkipAdobeDebugMode
+```
+
+After the installer finishes:
+
+1. Quit and reopen VS Code and/or Claude Desktop.
+2. Quit and reopen Premiere Pro.
+3. Open `Window > Extensions > MCP Bridge (CEP)`.
+4. Set `Temp Directory` to `%TEMP%\premiere-mcp-bridge`.
+5. Click `Save Configuration`.
+6. Click `Start Bridge`.
+7. Click `Test Connection`.
+
+Windows note: the installer and config path are smoke-tested on GitHub Actions Windows runners. A full Windows Premiere validation still requires a real Windows machine with Premiere Pro installed, the CEP panel visible in Premiere, and a live bridge round trip.
+
 ## Install By Client
 
 ### Claude Desktop
@@ -152,7 +192,23 @@ On macOS, use:
 npm run setup:mac
 ```
 
-That is the only path in this repo that automatically writes the MCP entry for you.
+On Windows, use:
+
+```powershell
+npm run setup:win
+```
+
+Both installers automatically write the MCP entry for Claude Desktop.
+
+### GitHub Copilot in VS Code
+
+On Windows, use:
+
+```powershell
+npm run setup:win
+```
+
+The installer writes this server to VS Code's MCP config at `%APPDATA%\Code\User\mcp.json`. Restart VS Code after the installer finishes, then use VS Code's MCP server list to confirm `premiere-pro` is available.
 
 ### Codex
 
@@ -232,6 +288,14 @@ That validates:
 - Adobe CEP debug mode
 - the Claude Desktop config entry when you use the installer path
 - CEP panel diagnostics written to `/tmp/premiere-mcp-bridge/premiere-mcp-diagnostics-latest.json`
+
+On Windows, run:
+
+```powershell
+npm run setup:doctor:win
+```
+
+That validates the built server, CEP extension install, `%TEMP%\premiere-mcp-bridge`, Adobe CEP debug mode, the GitHub Copilot VS Code MCP config, and the Claude Desktop MCP config.
 
 For a deeper end-to-end check, use a disposable Premiere project and run:
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "start": "node dist/index.js",
     "setup:mac": "bash ./scripts/install-macos.sh",
     "setup:doctor": "bash ./scripts/doctor-macos.sh",
+    "setup:win": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/install-windows.ps1",
+    "setup:doctor:win": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/doctor-windows.ps1",
     "uninstall:mac": "bash ./scripts/uninstall-macos.sh",
     "test": "jest",
     "lint": "eslint src --ext .ts",

--- a/scripts/doctor-windows.ps1
+++ b/scripts/doctor-windows.ps1
@@ -1,0 +1,138 @@
+<#
+.SYNOPSIS
+    Verifies the Windows Premiere Pro MCP install.
+#>
+
+[CmdletBinding()]
+param(
+    [string] $TempDir = (Join-Path $env:TEMP 'premiere-mcp-bridge'),
+    [string] $VsCodeConfigPath = (Join-Path $env:APPDATA 'Code\User\mcp.json'),
+    [string] $ClaudeConfigPath = (Join-Path $env:APPDATA 'Claude\claude_desktop_config.json')
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if ($env:OS -ne 'Windows_NT') {
+    throw 'This doctor supports Windows only. Use npm run setup:doctor on macOS.'
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$cepTargetDir = Join-Path $env:APPDATA 'Adobe\CEP\extensions\MCPBridgeCEP'
+$distEntry = Join-Path $repoRoot 'dist\index.js'
+$failures = 0
+
+function Pass([string] $Message) {
+    Write-Host "  OK    $Message"
+}
+
+function Warn([string] $Message) {
+    Write-Host "  WARN  $Message"
+}
+
+function Fail([string] $Message) {
+    Write-Host "  FAIL  $Message"
+    $script:failures++
+}
+
+function Test-JsonServer([string] $Path, [string] $RootKey) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Warn "$Path not found"
+        return
+    }
+
+    $raw = Get-Content -LiteralPath $Path -Raw
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        Fail "$Path is empty"
+        return
+    }
+
+    try {
+        $json = $raw | ConvertFrom-Json
+    } catch {
+        Fail "$Path is not valid JSON"
+        return
+    }
+
+    $root = $json.PSObject.Properties[$RootKey]
+    if (-not $root) {
+        Fail "$Path missing $RootKey"
+        return
+    }
+
+    $server = $root.Value.PSObject.Properties['premiere-pro']
+    if (-not $server) {
+        Fail "$Path missing premiere-pro"
+        return
+    }
+
+    Pass "$Path contains premiere-pro"
+}
+
+Write-Host 'Premiere Pro MCP doctor (Windows)'
+Write-Host ''
+
+Write-Host 'Node.js'
+$node = Get-Command node -ErrorAction SilentlyContinue
+if (-not $node) {
+    Fail 'node not found on PATH'
+} else {
+    $nodeMajor = [int](& $node.Source -p "process.versions.node.split('.')[0]")
+    if ($nodeMajor -lt 18) {
+        Fail "Node.js 18+ required, found $(& $node.Source -v)"
+    } else {
+        Pass "$(& $node.Source -v)"
+    }
+}
+
+Write-Host 'MCP server build'
+if (Test-Path -LiteralPath $distEntry -PathType Leaf) {
+    Pass $distEntry
+} else {
+    Fail "$distEntry missing - run npm run build"
+}
+
+Write-Host 'CEP extension'
+if (Test-Path -LiteralPath (Join-Path $cepTargetDir 'CSXS\manifest.xml') -PathType Leaf) {
+    Pass $cepTargetDir
+} else {
+    Fail "$cepTargetDir missing or incomplete - run npm run setup:win"
+}
+
+Write-Host 'Bridge temp directory'
+if (Test-Path -LiteralPath $TempDir -PathType Container) {
+    Pass $TempDir
+} else {
+    Fail "$TempDir missing"
+}
+
+Write-Host 'Adobe CEP debug mode'
+$debugModeFound = $false
+foreach ($version in 9..15) {
+    $key = "HKCU:\Software\Adobe\CSXS.$version"
+    if (Test-Path -LiteralPath $key) {
+        $value = (Get-ItemProperty -Path $key -Name 'PlayerDebugMode' -ErrorAction SilentlyContinue).PlayerDebugMode
+        if ("$value" -eq '1') {
+            $debugModeFound = $true
+            Pass "CSXS.$version PlayerDebugMode=1"
+        }
+    }
+}
+if (-not $debugModeFound) {
+    Warn 'PlayerDebugMode=1 not found under CSXS.9 through CSXS.15'
+}
+
+Write-Host 'GitHub Copilot VS Code MCP config'
+Test-JsonServer -Path $VsCodeConfigPath -RootKey 'servers'
+
+Write-Host 'Claude Desktop MCP config'
+Test-JsonServer -Path $ClaudeConfigPath -RootKey 'mcpServers'
+
+Write-Host ''
+if ($failures -gt 0) {
+    Write-Host "$failures check(s) failed."
+    exit 1
+}
+
+Write-Host 'All required Windows install checks passed.'

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1,0 +1,238 @@
+<#
+.SYNOPSIS
+    Installs the Premiere Pro MCP server and CEP bridge panel on Windows.
+
+.DESCRIPTION
+    Builds the MCP server, installs the CEP bridge into the per-user Adobe CEP
+    extensions folder, enables CEP debug mode, creates the bridge temp directory,
+    and writes MCP client config for GitHub Copilot in VS Code and Claude Desktop.
+
+.PARAMETER TempDir
+    Bridge temp directory shared by the MCP server and CEP panel.
+
+.PARAMETER VsCodeConfigPath
+    VS Code MCP config used by GitHub Copilot.
+
+.PARAMETER ClaudeConfigPath
+    Claude Desktop MCP config path.
+
+.PARAMETER SkipBuild
+    Skip npm install and npm run build. Useful for CI after build has already run.
+
+.PARAMETER SkipCopilotConfig
+    Do not write the VS Code GitHub Copilot MCP config.
+
+.PARAMETER SkipClaudeDesktopConfig
+    Do not write Claude Desktop MCP config.
+
+.PARAMETER SkipAdobeDebugMode
+    Do not write Adobe CEP PlayerDebugMode registry values.
+#>
+
+[CmdletBinding()]
+param(
+    [string] $TempDir = (Join-Path $env:TEMP 'premiere-mcp-bridge'),
+    [string] $VsCodeConfigPath = (Join-Path $env:APPDATA 'Code\User\mcp.json'),
+    [string] $ClaudeConfigPath = (Join-Path $env:APPDATA 'Claude\claude_desktop_config.json'),
+    [switch] $SkipBuild,
+    [switch] $SkipCopilotConfig,
+    [switch] $SkipClaudeDesktopConfig,
+    [switch] $SkipAdobeDebugMode
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if ($env:OS -ne 'Windows_NT') {
+    throw 'This installer supports Windows only. Use npm run setup:mac on macOS.'
+}
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$cepExtensionsDir = Join-Path $env:APPDATA 'Adobe\CEP\extensions'
+$cepTargetDir = Join-Path $cepExtensionsDir 'MCPBridgeCEP'
+$distEntry = Join-Path $repoRoot 'dist\index.js'
+
+function Resolve-CommandPath([string] $Name) {
+    $command = Get-Command $Name -ErrorAction SilentlyContinue
+    if (-not $command) { return $null }
+    return $command.Source
+}
+
+function Update-JsonWithNode([string] $ConfigPath, [string] $Mode) {
+    $configDir = Split-Path -Parent $ConfigPath
+    if (-not (Test-Path -LiteralPath $configDir)) {
+        New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+    }
+
+    $helper = @'
+const fs = require("fs");
+
+const configPath = process.env.CONFIG_PATH;
+const mode = process.env.CONFIG_MODE;
+const nodePath = process.env.NODE_PATH_VALUE;
+const distPath = process.env.DIST_PATH;
+const tempPath = process.env.TEMP_PATH;
+
+let data = {};
+if (fs.existsSync(configPath)) {
+  const raw = fs.readFileSync(configPath, "utf8").trim();
+  if (raw) {
+    try {
+      data = JSON.parse(raw);
+    } catch (error) {
+      console.error(`${configPath} is not valid JSON: ${error.message}`);
+      process.exit(1);
+    }
+  }
+}
+
+if (!data || typeof data !== "object" || Array.isArray(data)) {
+  data = {};
+}
+
+if (mode === "copilot") {
+  if (!data.servers || typeof data.servers !== "object" || Array.isArray(data.servers)) {
+    data.servers = {};
+  }
+  data.servers["premiere-pro"] = {
+    type: "stdio",
+    command: nodePath,
+    args: [distPath],
+    env: {
+      PREMIERE_TEMP_DIR: tempPath
+    }
+  };
+} else if (mode === "claude") {
+  if (!data.mcpServers || typeof data.mcpServers !== "object" || Array.isArray(data.mcpServers)) {
+    data.mcpServers = {};
+  }
+  data.mcpServers["premiere-pro"] = {
+    command: nodePath,
+    args: [distPath],
+    env: {
+      PREMIERE_TEMP_DIR: tempPath
+    }
+  };
+} else {
+  console.error(`Unknown config mode: ${mode}`);
+  process.exit(1);
+}
+
+fs.writeFileSync(configPath, `${JSON.stringify(data, null, 2)}\n`);
+'@
+
+    $helperPath = Join-Path $env:TEMP 'premiere-mcp-config-update.cjs'
+    Set-Content -LiteralPath $helperPath -Value $helper -Encoding UTF8
+
+    $oldConfigPath = $env:CONFIG_PATH
+    $oldConfigMode = $env:CONFIG_MODE
+    $oldNodePathValue = $env:NODE_PATH_VALUE
+    $oldDistPath = $env:DIST_PATH
+    $oldTempPath = $env:TEMP_PATH
+    try {
+        $env:CONFIG_PATH = $ConfigPath
+        $env:CONFIG_MODE = $Mode
+        $env:NODE_PATH_VALUE = $script:nodePath
+        $env:DIST_PATH = $distEntry
+        $env:TEMP_PATH = $TempDir
+        & $script:nodePath $helperPath
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to update MCP config: $ConfigPath"
+        }
+    } finally {
+        $env:CONFIG_PATH = $oldConfigPath
+        $env:CONFIG_MODE = $oldConfigMode
+        $env:NODE_PATH_VALUE = $oldNodePathValue
+        $env:DIST_PATH = $oldDistPath
+        $env:TEMP_PATH = $oldTempPath
+        Remove-Item -LiteralPath $helperPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+$script:nodePath = Resolve-CommandPath 'node'
+if (-not $script:nodePath) {
+    throw "Node.js 18+ is required but 'node' was not found on PATH."
+}
+
+$nodeMajor = [int](& $script:nodePath -p "process.versions.node.split('.')[0]")
+if ($nodeMajor -lt 18) {
+    throw "Node.js 18+ is required. Found: $(& $script:nodePath -v)"
+}
+
+$npmPath = Resolve-CommandPath 'npm.cmd'
+if (-not $npmPath) { $npmPath = Resolve-CommandPath 'npm' }
+if (-not $npmPath) {
+    throw "npm was not found on PATH."
+}
+
+if ($SkipBuild) {
+    Write-Host 'Skipping npm install/build (-SkipBuild).'
+} else {
+    Write-Host 'Installing npm dependencies...'
+    & $npmPath install --prefix $repoRoot
+    if ($LASTEXITCODE -ne 0) { throw 'npm install failed.' }
+
+    Write-Host 'Building MCP server...'
+    & $npmPath run build --prefix $repoRoot
+    if ($LASTEXITCODE -ne 0) { throw 'npm run build failed.' }
+}
+
+if (-not (Test-Path -LiteralPath $distEntry -PathType Leaf)) {
+    throw "Built entrypoint not found: $distEntry"
+}
+
+if ($SkipAdobeDebugMode) {
+    Write-Host 'Skipping Adobe CEP debug mode (-SkipAdobeDebugMode).'
+} else {
+    Write-Host 'Enabling Adobe CEP debug mode...'
+    foreach ($version in 9..15) {
+        $key = "HKCU:\Software\Adobe\CSXS.$version"
+        if (-not (Test-Path -LiteralPath $key)) {
+            New-Item -Path $key -Force | Out-Null
+        }
+        New-ItemProperty -Path $key -Name 'PlayerDebugMode' -Value '1' -PropertyType String -Force | Out-Null
+    }
+}
+
+Write-Host 'Installing Premiere CEP extension...'
+if (-not (Test-Path -LiteralPath $cepExtensionsDir)) {
+    New-Item -ItemType Directory -Path $cepExtensionsDir -Force | Out-Null
+}
+if (Test-Path -LiteralPath $cepTargetDir) {
+    Remove-Item -LiteralPath $cepTargetDir -Recurse -Force
+}
+Copy-Item -LiteralPath (Join-Path $repoRoot 'cep-plugin') -Destination $cepTargetDir -Recurse -Force
+
+Write-Host "Preparing bridge temp directory: $TempDir"
+if (-not (Test-Path -LiteralPath $TempDir)) {
+    New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+}
+
+if ($SkipCopilotConfig) {
+    Write-Host 'Skipping GitHub Copilot VS Code MCP config (-SkipCopilotConfig).'
+} else {
+    Write-Host "Updating GitHub Copilot VS Code MCP config: $VsCodeConfigPath"
+    Update-JsonWithNode -ConfigPath $VsCodeConfigPath -Mode 'copilot'
+}
+
+if ($SkipClaudeDesktopConfig) {
+    Write-Host 'Skipping Claude Desktop MCP config (-SkipClaudeDesktopConfig).'
+} else {
+    Write-Host "Updating Claude Desktop MCP config: $ClaudeConfigPath"
+    Update-JsonWithNode -ConfigPath $ClaudeConfigPath -Mode 'claude'
+}
+
+Write-Host ''
+Write-Host 'Install complete.'
+Write-Host 'Next:'
+Write-Host '1. Restart VS Code and/or Claude Desktop so MCP config is reloaded.'
+Write-Host '2. Restart Premiere Pro.'
+Write-Host '3. Open Window > Extensions > MCP Bridge (CEP).'
+Write-Host "4. Set Temp Directory to $TempDir."
+Write-Host '5. Click Save Configuration, Start Bridge, then Test Connection.'
+Write-Host ''
+Write-Host 'Manual MCP entry:'
+Write-Host "  command: $script:nodePath"
+Write-Host "  args:    $distEntry"
+Write-Host "  env:     PREMIERE_TEMP_DIR=$TempDir"

--- a/src/__tests__/bridge/index.test.ts
+++ b/src/__tests__/bridge/index.test.ts
@@ -4,6 +4,7 @@
 
 import { PremiereProBridge } from '../../bridge/index.js';
 import { promises as fs } from 'fs';
+import path from 'path';
 
 jest.mock('fs', () => ({
   promises: {
@@ -22,10 +23,13 @@ jest.mock('uuid', () => ({
 
 describe('PremiereProBridge', () => {
   const mockFs = fs as jest.Mocked<typeof fs>;
+  const configuredTempDir = '/tmp/premiere-mcp-bridge-test';
+  const commandPath = path.join(configuredTempDir, 'command-test-uuid-1234.json');
+  const responsePath = path.join(configuredTempDir, 'response-test-uuid-1234.json');
 
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.PREMIERE_TEMP_DIR = '/tmp/premiere-mcp-bridge-test';
+    process.env.PREMIERE_TEMP_DIR = configuredTempDir;
   });
 
   afterEach(() => {
@@ -58,11 +62,11 @@ describe('PremiereProBridge', () => {
 
     expect(result).toEqual({ ok: true });
     expect(mockFs.writeFile).toHaveBeenCalledWith(
-      '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json',
+      commandPath,
       expect.stringContaining('return JSON.stringify')
     );
-    expect(mockFs.unlink).toHaveBeenCalledWith('/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json');
-    expect(mockFs.unlink).toHaveBeenCalledWith('/tmp/premiere-mcp-bridge-test/response-test-uuid-1234.json');
+    expect(mockFs.unlink).toHaveBeenCalledWith(commandPath);
+    expect(mockFs.unlink).toHaveBeenCalledWith(responsePath);
   });
 
   it('preserves self-invoking scripts instead of double-wrapping them', async () => {
@@ -77,11 +81,11 @@ describe('PremiereProBridge', () => {
     await bridge.executeScript('(function(){ return JSON.stringify({ ok: true }); })();');
 
     expect(mockFs.writeFile).toHaveBeenCalledWith(
-      '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json',
+      commandPath,
       expect.stringContaining('(function(){ return JSON.stringify({ ok: true }); })();')
     );
     expect(mockFs.writeFile).not.toHaveBeenCalledWith(
-      '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json',
+      commandPath,
       expect.stringContaining('(function(){\n(function(){ return JSON.stringify({ ok: true }); })();\n})();')
     );
   });
@@ -137,11 +141,11 @@ describe('PremiereProBridge', () => {
     expect(result.success).toBe(false);
     expect(result.projectPath).toBe('/tmp/projects/Test.prproj');
     expect(mockFs.writeFile).toHaveBeenCalledWith(
-      '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json',
+      commandPath,
       expect.stringContaining('app.newProject(projectPath)')
     );
     expect(mockFs.writeFile).toHaveBeenCalledWith(
-      '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json',
+      commandPath,
       expect.stringContaining('Premiere Pro did not create or activate the requested project')
     );
   });
@@ -165,11 +169,11 @@ describe('PremiereProBridge', () => {
     expect(result.success).toBe(false);
     expect(result.actualPath).toBe('/tmp/projects/AlreadyOpen.prproj');
     expect(mockFs.writeFile).toHaveBeenCalledWith(
-      '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json',
+      commandPath,
       expect.stringContaining('app.openDocument(projectPath)')
     );
     expect(mockFs.writeFile).toHaveBeenCalledWith(
-      '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json',
+      commandPath,
       expect.stringContaining('Premiere Pro did not activate the requested project')
     );
   });
@@ -265,6 +269,9 @@ describe('PremiereProBridge', () => {
     await bridge.initialize();
     await bridge.cleanup();
 
-    expect(mockFs.rm).toHaveBeenCalledWith('/tmp/premiere-bridge-test-uuid-1234', { recursive: true });
+    const generatedTempDir = process.platform === 'win32'
+      ? path.join(process.env.TEMP || 'C:\\Temp', 'premiere-bridge-test-uuid-1234')
+      : '/tmp/premiere-bridge-test-uuid-1234';
+    expect(mockFs.rm).toHaveBeenCalledWith(generatedTempDir, { recursive: true });
   });
 });


### PR DESCRIPTION
Closes #55.

Adds a focused Windows setup path for the feature request:

- `scripts/install-windows.ps1` installs/builds the MCP server, copies the CEP bridge to `%APPDATA%\Adobe\CEP\extensions\MCPBridgeCEP`, creates `%TEMP%\premiere-mcp-bridge`, enables CEP debug mode, and writes MCP config for GitHub Copilot in VS Code plus Claude Desktop.
- `scripts/doctor-windows.ps1` validates the Windows install artifacts and MCP config entries.
- package scripts expose `npm run setup:win` and `npm run setup:doctor:win`.
- README/Quick Start/Contributing document the Windows path and clearly state that GitHub Actions smoke-tests setup/config, while full live Windows Premiere validation still requires a real Windows Premiere host.
- Adds a `windows-latest` GitHub Actions smoke test for build, Jest, Windows installer, and Windows doctor.

Local verification on macOS:
- `npm run build`
- `npm test -- --runInBand --silent --testTimeout=60000`
- `git diff --cached --check`

Not claimed: live Windows Premiere/CEP bridge validation. This PR adds the install/config path and CI smoke coverage; live Premiere validation still needs a Windows machine with Premiere installed.