### PR TITLE
Fix #64: fail closed when MOGRT text injection fails

### DIFF
--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -4,7 +4,7 @@
 
 import { EventEmitter } from 'events';
 import { spawn } from 'child_process';
-import { PremiereProTools } from '../../tools/index.js';
+import { PremiereProTools, evaluateTextInjectionResult } from '../../tools/index.js';
 import { PremiereProBridge } from '../../bridge/index.js';
 import { executeExpandedTool, expandedToolNames, unimplementedExpandedToolNames } from '../../tools/expanded.js';
 
@@ -394,6 +394,208 @@ describe('PremiereProTools', () => {
   });
 
   describe('script-backed tools', () => {
+    it('fails add_text_overlay when every requested text write fails', async () => {
+      mockBridge.executeScript.mockResolvedValue({
+        success: true,
+        clipId: 'graphic-123',
+        premiereVersion: '26.0',
+        premiereBuild: '12',
+        textRequestedCount: 1,
+        textInjectionResults: [
+          { _strategy: 'components_fallback', textCompsFound: 1 },
+          {
+            textIndex: 0,
+            compIndex: 3,
+            propIndex: 0,
+            requestedText: 'TREETOP TRANSMISSIONS',
+            ok: false,
+            error: 'Both JSON parse strategies failed'
+          }
+        ]
+      });
+
+      const result = await tools.executeTool('add_text_overlay', {
+        sequenceId: 'seq-123',
+        trackIndex: 1,
+        startTime: 1,
+        duration: 7,
+        mogrtPath: '/templates/Basic Title.mogrt',
+        text: 'TREETOP TRANSMISSIONS'
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.textInjectionStatus).toBe('failed');
+      expect(result.textInjectionSummary).toEqual({ requested: 1, succeeded: 0, failed: 1 });
+      expect(result.error).toContain('Premiere Pro 26.0 (build 12)');
+      expect(result.error).toContain('remains on the timeline');
+      expect(mockBridge.executeScript).toHaveBeenCalledTimes(1);
+    });
+
+    it('optionally removes the timeline Graphic after total text injection failure', async () => {
+      mockBridge.executeScript
+        .mockResolvedValueOnce({
+          success: true,
+          clipId: 'graphic-rollback',
+          premiereVersion: '26.0',
+          textRequestedCount: 1,
+          textInjectionResults: [{ textIndex: 0, compIndex: 3, propIndex: 0, ok: false }]
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          timelineGraphicRemoved: true,
+          note: 'The imported project item may remain in the Project panel.'
+        });
+
+      const result = await tools.executeTool('add_text_overlay', {
+        sequenceId: 'seq-123',
+        trackIndex: 1,
+        startTime: 1,
+        duration: 7,
+        mogrtPath: '/templates/Basic Title.mogrt',
+        text: 'TREETOP TRANSMISSIONS',
+        rollbackOnTextFailure: true
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.rollback.timelineGraphicRemoved).toBe(true);
+      expect(result.error).toContain('timeline Graphic was removed');
+      expect(result.clipId).toBeUndefined();
+      expect(result.removedClipId).toBe('graphic-rollback');
+      expect(mockBridge.executeScript).toHaveBeenCalledTimes(2);
+      expect(mockBridge.executeScript.mock.calls[1][0]).toContain(
+        '__findClip("graphic-rollback", "seq-123")'
+      );
+      expect(mockBridge.executeScript.mock.calls[1][0]).toContain('info.clip.remove(false, true)');
+    });
+
+    it('reports partial add_text_overlay writes without treating strategy markers as attempts', async () => {
+      mockBridge.executeScript.mockResolvedValue({
+        success: true,
+        clipId: 'graphic-partial',
+        textRequestedCount: 2,
+        textInjectionResults: [
+          { _strategy: 'getMGTComponent', textCompsFound: 2 },
+          { textIndex: 0, ok: true },
+          { textIndex: 1, ok: false, error: 'readback mismatch' }
+        ]
+      });
+
+      const result = await tools.executeTool('add_text_overlay', {
+        sequenceId: 'seq-123',
+        trackIndex: 1,
+        startTime: 1,
+        duration: 7,
+        mogrtPath: '/templates/Lower Third.mogrt',
+        text: 'Title',
+        text2: 'Subtitle'
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.textInjectionStatus).toBe('partial');
+      expect(result.textInjectionSummary).toEqual({ requested: 2, succeeded: 1, failed: 1 });
+      expect(result.warning).toContain('1 of 2');
+    });
+
+    it('does not roll back an imported Graphic when at least one requested text write succeeds', async () => {
+      mockBridge.executeScript.mockResolvedValue({
+        success: true,
+        clipId: 'graphic-partial',
+        textRequestedCount: 2,
+        textInjectionResults: [
+          { textIndex: 0, ok: true },
+          { textIndex: 1, ok: false }
+        ]
+      });
+
+      const result = await tools.executeTool('add_text_overlay', {
+        sequenceId: 'seq-123',
+        trackIndex: 1,
+        startTime: 1,
+        duration: 7,
+        mogrtPath: '/templates/Lower Third.mogrt',
+        text: 'Title',
+        text2: 'Subtitle',
+        rollbackOnTextFailure: true
+      });
+
+      expect(result.textInjectionStatus).toBe('partial');
+      expect(mockBridge.executeScript).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports rollback failure while preserving the original text injection failure', async () => {
+      mockBridge.executeScript
+        .mockResolvedValueOnce({
+          success: true,
+          clipId: 'graphic-stuck',
+          premiereVersion: '26.0',
+          textRequestedCount: 1,
+          textInjectionResults: [{ textIndex: 0, ok: false }]
+        })
+        .mockResolvedValueOnce({
+          success: false,
+          timelineGraphicRemoved: false,
+          error: 'Track item is locked'
+        });
+
+      const result = await tools.executeTool('add_text_overlay', {
+        sequenceId: 'seq-123',
+        trackIndex: 1,
+        startTime: 1,
+        duration: 7,
+        mogrtPath: '/templates/Basic Title.mogrt',
+        text: 'Title',
+        rollbackOnTextFailure: true
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Text injection failed');
+      expect(result.error).toContain('Rollback of the imported timeline Graphic also failed');
+      expect(result.rollback.error).toBe('Track item is locked');
+      expect(result.clipId).toBe('graphic-stuck');
+      expect(result.removedClipId).toBeUndefined();
+    });
+
+    it('rolls back a Graphic surfaced by a hard post-import script failure', async () => {
+      mockBridge.executeScript
+        .mockResolvedValueOnce({
+          success: false,
+          error: 'Unexpected property access failure',
+          clipId: 'graphic-hard-failure'
+        })
+        .mockResolvedValueOnce({
+          success: true,
+          timelineGraphicRemoved: true
+        });
+
+      const result = await tools.executeTool('add_text_overlay', {
+        sequenceId: 'seq-123',
+        trackIndex: 1,
+        startTime: 1,
+        duration: 7,
+        mogrtPath: '/templates/Basic Title.mogrt',
+        text: 'Title',
+        rollbackOnTextFailure: true
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unexpected property access failure');
+      expect(result.error).toContain('timeline Graphic was removed');
+      expect(result.removedClipId).toBe('graphic-hard-failure');
+      expect(mockBridge.executeScript).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps import-only text overlay results distinct from failed injection', () => {
+      const result = evaluateTextInjectionResult({
+        success: true,
+        textRequestedCount: 0,
+        textInjectionResults: [{ _strategy: 'components_fallback', textCompsFound: 0 }]
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.textInjectionStatus).toBe('not_requested');
+      expect(result.textInjectionSummary).toEqual({ requested: 0, succeeded: 0, failed: 0 });
+    });
+
     it('executes list_project_items', async () => {
       mockBridge.executeScript.mockResolvedValue({
         success: true,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -83,6 +83,72 @@ interface BuildBrandSpotArgs extends AssembleProductSpotArgs {
   applyDefaultPolish?: boolean;
 }
 
+interface TextInjectionEntry {
+  textIndex?: number;
+  ok?: boolean;
+  [key: string]: any;
+}
+
+export function evaluateTextInjectionResult(result: any): any {
+  if (!result || result.success === false) return result;
+
+  const requestedCount = Number(result.textRequestedCount || 0);
+  if (requestedCount === 0) {
+    return {
+      ...result,
+      textInjectionStatus: 'not_requested',
+      textInjectionSummary: { requested: 0, succeeded: 0, failed: 0 }
+    };
+  }
+
+  const attempts = Array.isArray(result.textInjectionResults)
+    ? result.textInjectionResults.filter(
+        (entry: TextInjectionEntry) => typeof entry.textIndex === 'number'
+      )
+    : [];
+  const succeededCount = attempts.filter((entry: TextInjectionEntry) => entry.ok === true).length;
+  const failedCount = requestedCount - succeededCount;
+  const summary = {
+    requested: requestedCount,
+    succeeded: succeededCount,
+    failed: failedCount
+  };
+
+  if (succeededCount === 0) {
+    const version = result.premiereVersion || 'unknown';
+    const build = result.premiereBuild ? ` (build ${result.premiereBuild})` : '';
+    return {
+      ...result,
+      success: false,
+      message: 'MOGRT imported, but requested text was not written',
+      error:
+        `Text injection failed for all ${requestedCount} requested field(s) in ` +
+        `Premiere Pro ${version}${build}.`,
+      textInjectionStatus: 'failed',
+      textInjectionSummary: summary
+    };
+  }
+
+  if (succeededCount < requestedCount) {
+    return {
+      ...result,
+      success: true,
+      message: 'MOGRT imported; some requested text was written and read back',
+      warning: `${failedCount} of ${requestedCount} requested text field(s) could not be written`,
+      textInjectionStatus: 'partial',
+      textInjectionSummary: summary
+    };
+  }
+
+  return {
+    ...result,
+    success: true,
+    message: 'MOGRT imported; all requested text was written and read back',
+    textInjectionStatus: 'complete',
+    textInjectionSummary: summary
+  };
+}
+
 const motionStyleSchema = z.enum(['push_in', 'pull_out', 'alternate', 'none']);
 
 const clipPlanSchema = z.object({
@@ -521,7 +587,8 @@ export class PremiereProTools {
           startTime: z.number().describe('The time in seconds when the text should appear'),
           duration: z.number().describe('How long the text should remain on screen in seconds (best-effort; the MOGRT\'s natural duration may take precedence)'),
           mogrtPath: z.string().optional().describe('Absolute path to a .mogrt template file (required for text overlays)'),
-          textPropertyName: z.string().optional().describe('Override: explicit displayName of the property to write into. When set, only `text` is written (text2/text3/text4 are ignored) and the call fails if no property with that displayName exists. Use only when auto-detection picks the wrong field.')
+          textPropertyName: z.string().optional().describe('Override: explicit displayName of the property to write into. When set, only `text` is written (text2/text3/text4 are ignored) and the call fails if no property with that displayName exists. Use only when auto-detection picks the wrong field.'),
+          rollbackOnTextFailure: z.boolean().optional().describe('If true, remove the imported timeline Graphic when every requested text write fails. Defaults to false; the imported project item may remain in the Project panel.')
         })
       },
 
@@ -4302,6 +4369,14 @@ export class PremiereProTools {
 
           // First, probe ALL plausible MGT-access APIs (so we know what's available)
           var apiProbe = {};
+          var premiereVersion = "unknown";
+          var premiereBuild = "";
+          try {
+            if (typeof app.version !== "undefined" && app.version !== null) premiereVersion = String(app.version);
+          } catch (eVersion) {}
+          try {
+            if (typeof app.build !== "undefined" && app.build !== null) premiereBuild = String(app.build);
+          } catch (eBuild) {}
           apiProbe.hasGetMGTComponent = (typeof trackItem.getMGTComponent === "function");
           apiProbe.hasGetMGT = (typeof trackItem.getMGT === "function");
           apiProbe.hasGetMogrtComponent = (typeof trackItem.getMogrtComponent === "function");
@@ -4498,7 +4573,7 @@ export class PremiereProTools {
                     parseStrategy = "pure_json";
                   } catch (eP2) {
                     setResults.push({
-                      textIndex: ti2, compIndex: tc.compIndex, requestedText: newText,
+                      textIndex: ti2, compIndex: tc.compIndex, propIndex: tc.propIndex, requestedText: newText,
                       ok: false,
                       error: "Both JSON parse strategies failed",
                       rawValLength: rawValLen,
@@ -4523,7 +4598,7 @@ export class PremiereProTools {
                 }
                 if (mutated.length === 0) {
                   setResults.push({
-                    textIndex: ti2, compIndex: tc.compIndex, requestedText: newText,
+                    textIndex: ti2, compIndex: tc.compIndex, propIndex: tc.propIndex, requestedText: newText,
                     ok: false,
                     error: "Parsed JSON but no known text field found",
                     parseStrategy: parseStrategy,
@@ -4552,6 +4627,7 @@ export class PremiereProTools {
                 setResults.push({
                   textIndex: ti2,
                   compIndex: tc.compIndex,
+                  propIndex: tc.propIndex,
                   requestedText: newText,
                   parseStrategy: parseStrategy,
                   fieldsMutated: mutated,
@@ -4562,7 +4638,7 @@ export class PremiereProTools {
                   ok: (afterText === newText)
                 });
               } catch (eS) {
-                setResults.push({ textIndex: ti2, compIndex: tc.compIndex, requestedText: newText, ok: false, error: eS.toString() });
+                setResults.push({ textIndex: ti2, compIndex: tc.compIndex, propIndex: tc.propIndex, requestedText: newText, ok: false, error: eS.toString() });
               }
             }
             if (textComps.length === 0) {
@@ -4576,17 +4652,69 @@ export class PremiereProTools {
             success: true,
             message: "MOGRT imported as text overlay",
             clipId: trackItem.nodeId,
+            premiereVersion: premiereVersion,
+            premiereBuild: premiereBuild,
             apiProbe: apiProbe,
             componentCount: componentsDump.length,
             components: componentsDump,
             textPropsAutoDetected: textPropsFound,
+            textRequestedCount: textsByIndex.length,
             textInjectionResults: setResults
           });
         } catch (e) {
-          return JSON.stringify({ success: false, error: e.toString() });
+          var failedClipId = null;
+          try {
+            if (typeof trackItem !== "undefined" && trackItem) failedClipId = trackItem.nodeId;
+          } catch (eClipId) {}
+          return JSON.stringify({ success: false, error: e.toString(), clipId: failedClipId });
         }
       `;
-      return await this.bridge.executeScript(script);
+      const bridgeResult = await this.bridge.executeScript(script);
+      const evaluatedResult = evaluateTextInjectionResult(bridgeResult);
+      if (
+        (evaluatedResult?.textInjectionStatus === 'failed' ||
+          (evaluatedResult?.success === false && evaluatedResult?.clipId)) &&
+        args.rollbackOnTextFailure === true &&
+        evaluatedResult.clipId
+      ) {
+        const rollbackScript = `
+          try {
+            var info = __findClip(${JSON.stringify(evaluatedResult.clipId)}, ${JSON.stringify(args.sequenceId)});
+            if (!info) return JSON.stringify({ success: false, error: "Imported Graphic was not found for rollback" });
+            info.clip.remove(false, true);
+            return JSON.stringify({
+              success: true,
+              timelineGraphicRemoved: true,
+              note: "The timeline Graphic was removed; the imported project item may remain in the Project panel."
+            });
+          } catch (e) {
+            return JSON.stringify({ success: false, timelineGraphicRemoved: false, error: e.toString() });
+          }
+        `;
+        const rollback = await this.bridge.executeScript(rollbackScript);
+        const rollbackSucceeded = rollback?.success === true;
+        if (rollbackSucceeded) {
+          const { clipId: removedClipId, ...failureResult } = evaluatedResult;
+          return {
+            ...failureResult,
+            error: `${evaluatedResult.error} The imported timeline Graphic was removed.`,
+            removedClipId,
+            rollback
+          };
+        }
+        return {
+          ...evaluatedResult,
+          error: `${evaluatedResult.error} Rollback of the imported timeline Graphic also failed.`,
+          rollback
+        };
+      }
+      if (evaluatedResult?.textInjectionStatus === 'failed') {
+        return {
+          ...evaluatedResult,
+          error: `${evaluatedResult.error} The imported Graphic remains on the timeline.`
+        };
+      }
+      return evaluatedResult;
     }
 
     // Fallback: try legacy title approach


### PR DESCRIPTION
Fixes #64

## What changed
- Return explicit complete, partial, or failed text-injection status.
- Return top-level failure when every requested MOGRT text write fails.
- Include Premiere version/build and component/property diagnostics.
- Add opt-in rollback for failed text injection, including hard post-import failures.
- Add focused success, partial, failure, and rollback tests.

## Why
The tool previously reported success while leaving template placeholder text in the timeline.

## Validation
- Full test suite: 136/136
- Focused tools tests
- TypeScript build
- `git diff --check`
- Claude Opus plan and final diff reviews