### PR TITLE
Fix #65: safely trim native Graphic duration

### DIFF
--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -530,11 +530,117 @@ describe('PremiereProTools', () => {
 
       expect(result.success).toBe(true);
       const script = mockBridge.executeScript.mock.calls[0][0];
-      expect(script).toContain('clip.outPoint = timeFromSeconds(targetOutPoint)');
+      expect(script).not.toContain('clip.outPoint = timeFromSeconds(targetOutPoint)');
       expect(script).toContain('clip.end = timeFromSeconds(secondsOf(clip.start) + targetDuration)');
       expect(script).not.toContain('new Time(clip.inPoint.seconds + 2.5)');
       expect(script).toContain('timeline duration did not change to requested value');
-      expect(script).toContain('Premiere Pro did not apply the requested trim');
+      expect(script).toContain('TRIM_UNSUPPORTED_FOR_CLIP');
+      expect(script).toContain('rollback("outPoint", original.outPoint)');
+    });
+
+    it('rejects conflicting trim_clip duration and outPoint arguments before calling Premiere', async () => {
+      const result = await tools.executeTool('trim_clip', {
+        clipId: 'clip-123',
+        outPoint: 8,
+        duration: 2.5
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('outPoint and duration cannot be used together');
+      expect(mockBridge.executeScript).not.toHaveBeenCalled();
+    });
+
+    it('does not mutate a source outPoint when a duration extension is unsupported', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+      await tools.executeTool('trim_clip', { clipId: 'graphic-1', duration: 7 });
+      const script = mockBridge.executeScript.mock.calls[0][0];
+      const ticksPerSecond = 254016000000;
+      class FakeTime {
+        private value = 0;
+        get seconds() { return this.value; }
+        set seconds(value: number) { this.value = value; }
+        get ticks() { return String(Math.round(this.value * ticksPerSecond)); }
+        set ticks(value: string) { this.value = Number(value) / ticksPerSecond; }
+      }
+      const at = (seconds: number) => {
+        const time = new FakeTime();
+        time.seconds = seconds;
+        return time;
+      };
+      let outPointWrites = 0;
+      const clip: any = {
+        inPoint: at(3599.9964),
+        start: at(0),
+        duration: at(4.97163333333333)
+      };
+      let sourceOut = at(3604.96803333333);
+      let timelineEnd = at(4.97163333333333);
+      Object.defineProperty(clip, 'outPoint', {
+        get: () => sourceOut,
+        set: (value) => { outPointWrites++; sourceOut = value; }
+      });
+      Object.defineProperty(clip, 'end', {
+        get: () => timelineEnd,
+        set: () => { /* Premiere silently ignores this native Graphic extension. */ }
+      });
+      const runScript = new Function('__findClip', 'Time', script);
+      const parsed = JSON.parse(runScript(
+        () => ({ clip, sequence: { timebase: String(Math.round(ticksPerSecond * 1001 / 30000)) } }),
+        FakeTime
+      ));
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.errorCode).toBe('TRIM_UNSUPPORTED_FOR_CLIP');
+      expect(parsed.attempted.outPoint).toBeCloseTo(3604.96803333333);
+      expect(parsed.restored.outPoint).toBeCloseTo(3604.96803333333);
+      expect(parsed.rolledBack).toBe(true);
+      expect(outPointWrites).toBe(0);
+    });
+
+    it('accepts a duration that Premiere quantizes to the nearest frame', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+      await tools.executeTool('trim_clip', { clipId: 'clip-123', duration: 7 });
+      const script = mockBridge.executeScript.mock.calls[0][0];
+      const ticksPerSecond = 254016000000;
+      class FakeTime {
+        private value = 0;
+        get seconds() { return this.value; }
+        set seconds(value: number) { this.value = value; }
+        get ticks() { return String(Math.round(this.value * ticksPerSecond)); }
+        set ticks(value: string) { this.value = Number(value) / ticksPerSecond; }
+      }
+      const at = (seconds: number) => {
+        const time = new FakeTime();
+        time.seconds = seconds;
+        return time;
+      };
+      const clip: any = { inPoint: at(0), outPoint: at(5), start: at(0) };
+      let timelineEnd = at(5);
+      Object.defineProperty(clip, 'end', {
+        get: () => timelineEnd,
+        set: () => { timelineEnd = at(7.007); }
+      });
+      Object.defineProperty(clip, 'duration', {
+        get: () => at(timelineEnd.seconds - clip.start.seconds)
+      });
+      const runScript = new Function('__findClip', 'Time', script);
+      const parsed = JSON.parse(runScript(
+        () => ({ clip, sequence: { timebase: String(Math.round(ticksPerSecond * 1001 / 30000)) } }),
+        FakeTime
+      ));
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.newDuration).toBeCloseTo(7.007);
+    });
+
+    it('writes a one-frame duration change instead of treating it as an idempotent no-op', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+      await tools.executeTool('trim_clip', { clipId: 'clip-123', duration: 5.0333666667 });
+      const script = mockBridge.executeScript.mock.calls[0][0];
+
+      expect(script).toContain('if (!exactEnough(before.duration, targetDuration))');
+      expect(script).not.toContain('if (!closeEnough(before.duration, targetDuration))');
+      expect(script).toContain('frameDurationSeconds / 2');
     });
 
     it('generates a non-destructive export readiness validation script', async () => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -364,8 +364,10 @@ export class PremiereProTools {
         inputSchema: z.object({
           clipId: z.string().describe('The ID of the clip on the timeline to trim'),
           inPoint: z.number().optional().describe('The new in point in seconds from the start of the clip'),
-          outPoint: z.number().optional().describe('The new out point in seconds from the start of the clip'),
-          duration: z.number().optional().describe('Alternative: set the desired duration in seconds')
+          outPoint: z.number().optional().describe('The new out point in seconds from the start of the clip; cannot be combined with duration'),
+          duration: z.number().optional().describe('Alternative: set the desired timeline duration in seconds; cannot be combined with outPoint')
+        }).refine((value) => value.outPoint === undefined || value.duration === undefined, {
+          message: 'outPoint and duration cannot be used together'
         })
       },
       {
@@ -3056,6 +3058,14 @@ export class PremiereProTools {
   }
 
   private async trimClip(clipId: string, inPoint?: number, outPoint?: number, duration?: number): Promise<any> {
+    if (outPoint !== undefined && duration !== undefined) {
+      return {
+        success: false,
+        error: 'outPoint and duration cannot be used together',
+        errorCode: 'INVALID_TRIM_ARGUMENTS'
+      };
+    }
+
     const script = `
       try {
         var info = __findClip(${JSON.stringify(clipId)});
@@ -3068,12 +3078,40 @@ export class PremiereProTools {
           if (value.ticks !== undefined) return Number(value.ticks) / 254016000000.0;
           return null;
         }
+        function frameDurationOf(sequence) {
+          try {
+            if (sequence && sequence.timebase !== undefined) {
+              var value = Number(sequence.timebase) / 254016000000.0;
+              if (value > 0 && isFinite(value)) return value;
+            }
+          } catch (frameError) {}
+          return 1 / 48;
+        }
+        var frameDurationSeconds = frameDurationOf(info.sequence);
+        function exactEnough(a, b) {
+          return a !== null && b !== null && Math.abs(a - b) < 0.000001;
+        }
         function closeEnough(a, b) {
-          return a !== null && b !== null && Math.abs(a - b) < 0.001;
+          return a !== null && b !== null && Math.abs(a - b) <= (frameDurationSeconds / 2) + 0.000001;
         }
         function timeFromSeconds(seconds) {
           var t = new Time();
           t.seconds = Number(seconds);
+          return t;
+        }
+        function capturedTime(value) {
+          if (value === undefined || value === null) return null;
+          var captured = { seconds: secondsOf(value), ticks: null };
+          try {
+            if (value.ticks !== undefined && value.ticks !== null) captured.ticks = String(value.ticks);
+          } catch (ticksError) {}
+          return captured;
+        }
+        function timeFromCaptured(captured) {
+          if (!captured) return null;
+          var t = new Time();
+          if (captured.ticks !== null) t.ticks = captured.ticks;
+          else t.seconds = Number(captured.seconds);
           return t;
         }
         function stateOf() {
@@ -3087,20 +3125,37 @@ export class PremiereProTools {
         }
 
         var before = stateOf();
-        var timelineEndError = null;
+        var original = {
+          inPoint: capturedTime(clip.inPoint),
+          outPoint: capturedTime(clip.outPoint),
+          start: capturedTime(clip.start),
+          end: capturedTime(clip.end)
+        };
+        var writeErrors = [];
+        function recordWriteError(propertyName, error) {
+          writeErrors.push({ property: propertyName, error: error.toString() });
+        }
 
-        ${inPoint !== undefined ? `clip.inPoint = timeFromSeconds(${inPoint});` : ''}
-        ${outPoint !== undefined ? `clip.outPoint = timeFromSeconds(${outPoint});` : ''}
+        ${inPoint !== undefined ? `
+        if (!exactEnough(before.inPoint, ${inPoint})) {
+          try { clip.inPoint = timeFromSeconds(${inPoint}); }
+          catch (inPointError) { recordWriteError("inPoint", inPointError); }
+        }
+        ` : ''}
+        ${outPoint !== undefined ? `
+        if (!exactEnough(before.outPoint, ${outPoint})) {
+          try { clip.outPoint = timeFromSeconds(${outPoint}); }
+          catch (outPointError) { recordWriteError("outPoint", outPointError); }
+        }
+        ` : ''}
         ${duration !== undefined ? `
         var targetDuration = ${duration};
-        var targetOutPoint = secondsOf(clip.inPoint) + targetDuration;
-        clip.outPoint = timeFromSeconds(targetOutPoint);
-        try {
-          if (clip.start !== undefined && clip.end !== undefined) {
+        if (!exactEnough(before.duration, targetDuration)) {
+          try {
             clip.end = timeFromSeconds(secondsOf(clip.start) + targetDuration);
+          } catch (timelineError) {
+            recordWriteError("end", timelineError);
           }
-        } catch (timelineError) {
-          timelineEndError = timelineError.toString();
         }
         ` : ''}
 
@@ -3127,9 +3182,36 @@ export class PremiereProTools {
         ` : ''}
 
         if (!verified) {
+          var attempted = after;
+          var rollbackErrors = [];
+          function rollback(propertyName, captured) {
+            try {
+              if (captured) clip[propertyName] = timeFromCaptured(captured);
+            } catch (rollbackError) {
+              rollbackErrors.push({ property: propertyName, error: rollbackError.toString() });
+            }
+          }
+          ${duration !== undefined ? 'if (!exactEnough(attempted.end, before.end)) rollback("end", original.end);' : ''}
+          ${outPoint !== undefined || duration !== undefined ? 'if (!exactEnough(attempted.outPoint, before.outPoint)) rollback("outPoint", original.outPoint);' : ''}
+          ${inPoint !== undefined ? 'if (!exactEnough(attempted.inPoint, before.inPoint)) rollback("inPoint", original.inPoint);' : ''}
+          var restored = stateOf();
+          var rolledBack =
+            exactEnough(restored.inPoint, before.inPoint) &&
+            exactEnough(restored.outPoint, before.outPoint) &&
+            exactEnough(restored.start, before.start) &&
+            exactEnough(restored.end, before.end);
+          var errorCode = "TRIM_NOT_APPLIED";
+          ${duration !== undefined ? `
+          if (${duration} > before.duration && closeEnough(attempted.duration, before.duration)) {
+            errorCode = "TRIM_UNSUPPORTED_FOR_CLIP";
+          }
+          ` : ''}
           return JSON.stringify({
             success: false,
-            error: "Premiere Pro did not apply the requested trim",
+            error: errorCode === "TRIM_UNSUPPORTED_FOR_CLIP"
+              ? "Premiere Pro does not support extending this clip to the requested duration"
+              : "Premiere Pro did not apply the requested trim",
+            errorCode: errorCode,
             clipId: ${JSON.stringify(clipId)},
             requested: {
               inPoint: ${inPoint !== undefined ? inPoint : 'null'},
@@ -3138,8 +3220,13 @@ export class PremiereProTools {
             },
             before: before,
             after: after,
+            attempted: attempted,
+            restored: restored,
+            rolledBack: rolledBack,
             verificationErrors: verificationErrors,
-            timelineEndError: timelineEndError
+            writeErrors: writeErrors,
+            rollbackErrors: rollbackErrors,
+            frameDurationSeconds: frameDurationSeconds
           });
         }
 
@@ -3155,7 +3242,8 @@ export class PremiereProTools {
           newDuration: after.duration,
           before: before,
           after: after,
-          timelineEndError: timelineEndError
+          writeErrors: writeErrors,
+          frameDurationSeconds: frameDurationSeconds
         });
       } catch (e) {
         return JSON.stringify({


### PR DESCRIPTION
Fixes #65

## What changed
- Change duration trims through the timeline end without mutating native Graphic source outPoint.
- Add frame-aware verification with exact idempotence checks.
- Add guarded writes, transactional rollback, and machine-readable error codes.
- Reject simultaneous outPoint and duration requests.
- Add behavioral coverage for native Graphics, frame quantization, rollback, and one-frame edits.

## Why
Writing source outPoint for Premiere-native Graphics can fail and produce inconsistent diagnostic readback while leaving timeline duration unchanged.

## Validation
- Focused tools tests: 53/53
- Full test suite: 133/133
- TypeScript build
- `git diff --check`
- Claude Opus plan and final diff reviews