### PR TITLE
Fix export ranges and encoder preset discovery

### DIFF
--- a/src/__tests__/bridge/index.test.ts
+++ b/src/__tests__/bridge/index.test.ts
@@ -109,6 +109,31 @@ describe('PremiereProBridge', () => {
     expect(result.id).toBe('item-123');
   });
 
+  it('generates renderSequence JSX that selects the requested source range constant', async () => {
+    const bridge = new PremiereProBridge();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.access.mockRejectedValue(new Error('Not found'));
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ success: true }));
+    mockFs.unlink.mockResolvedValue(undefined);
+
+    await bridge.initialize();
+    await bridge.renderSequence('seq-"quoted"', '/tmp/out.mp4', '/tmp/preset.epr', {
+      sourceRange: 'in_out',
+      removeOnCompletion: false,
+    });
+
+    const commandFile = JSON.parse(String(mockFs.writeFile.mock.calls[0]?.[1] ?? '{}'));
+    const command = String(commandFile.script ?? '');
+    expect(command).toContain('var sequenceId = "seq-\\"quoted\\""');
+    expect(command).toContain('encoderRangeConstant = "ENCODE_IN_TO_OUT"');
+    expect(command).toContain('encoderRangeConstant = "ENCODE_WORKAREA"');
+    expect(command).toContain('encoderRangeConstant = "ENCODE_ENTIRE"');
+    expect(command).toContain('var removeOnCompletion = 0;');
+    expect(command).toContain('app.encoder[encoderRangeConstant]');
+    expect(command).not.toContain('__findSequence("seq-"quoted"")');
+  });
+
   it('blocks modal-prone unsupported subtitle imports before writing a command', async () => {
     const bridge = new PremiereProBridge();
     mockFs.mkdir.mockResolvedValue(undefined);

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -4,6 +4,9 @@
 
 import { EventEmitter } from 'events';
 import { spawn } from 'child_process';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { PremiereProTools, evaluateTextInjectionResult } from '../../tools/index.js';
 import { PremiereProBridge } from '../../bridge/index.js';
 import { executeExpandedTool, expandedToolNames, unimplementedExpandedToolNames } from '../../tools/expanded.js';
@@ -30,6 +33,13 @@ function fakeMissingFfmpegProcess(): any {
   proc.stderr = new EventEmitter();
   process.nextTick(() => proc.emit('error', new Error('ENOENT')));
   return proc;
+}
+
+async function createTempPreset(name = 'Test Preset'): Promise<{ root: string; presetPath: string; outputPath: string }> {
+  const root = await fs.mkdtemp(join(tmpdir(), 'premiere-tools-test-'));
+  const presetPath = join(root, `${name}.epr`);
+  await fs.writeFile(presetPath, `<Preset><PresetName>${name}</PresetName></Preset>`, 'utf8');
+  return { root, presetPath, outputPath: join(root, 'out.mp4') };
 }
 
 describe('PremiereProTools', () => {
@@ -67,6 +77,7 @@ describe('PremiereProTools', () => {
       expect(toolNames).toContain('ripple_delete');
       expect(toolNames).toContain('capture_frame');
       expect(toolNames).toContain('add_tracks');
+      expect(toolNames).toContain('get_encoder_presets');
       expect(toolNames).not.toContain('import_ae_comps');
       expect(availableTools).toHaveLength(281);
       expect(unimplementedExpandedToolNames).toEqual([]);
@@ -1255,6 +1266,46 @@ describe('PremiereProTools', () => {
     });
   });
 
+  describe('get_encoder_presets', () => {
+    it('discovers readable user .epr presets from supplied AME preset directories', async () => {
+      const root = await fs.mkdtemp(join(tmpdir(), 'premiere-presets-test-'));
+      const presetDir = join(root, '26.0', 'Presets');
+      await fs.mkdir(presetDir, { recursive: true });
+      const presetPath = join(presetDir, 'YouTube UHD 4K.epr');
+      await fs.writeFile(presetPath, '<Preset><PresetName>YouTube UHD 4K Custom</PresetName></Preset>', 'utf8');
+      await fs.writeFile(join(presetDir, 'ignore.txt'), 'not a preset', 'utf8');
+
+      const result = await tools.executeTool('get_encoder_presets', {
+        directories: [presetDir],
+      });
+
+      expect(result).toMatchObject({
+        success: true,
+        count: 1,
+        presets: [{
+          name: 'YouTube UHD 4K Custom',
+          path: presetPath,
+          source: 'user',
+          ameVersion: '26.0',
+        }],
+        factoryPresets: {
+          supported: false,
+        },
+      });
+    });
+
+    it('returns an empty list for missing preset directories', async () => {
+      const result = await tools.executeTool('get_encoder_presets', {
+        directories: ['/tmp/premiere-missing-presets-for-test'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.presets).toEqual([]);
+      expect(result.count).toBe(0);
+      expect(result.errors).toEqual([]);
+    });
+  });
+
   describe('export_sequence', () => {
     // Pre-fix bugs (commit 6 of PR #14):
     //   1. Wrapper accepted no presetPath and silently substituted "H.264" / "ProRes"
@@ -1269,7 +1320,7 @@ describe('PremiereProTools', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toMatch(/presetPath required/);
+      expect(result.error).toMatch(/presetPath or presetName required/);
       expect(result.hint).toMatch(/\.epr/);
       expect(mockBridge.renderSequence).not.toHaveBeenCalled();
     });
@@ -1283,22 +1334,23 @@ describe('PremiereProTools', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toMatch(/presetPath required/);
+      expect(result.error).toMatch(/presetPath or presetName required/);
       expect(mockBridge.renderSequence).not.toHaveBeenCalled();
     });
 
     it('propagates bridge {success:false} response instead of claiming success', async () => {
+      const { presetPath, outputPath } = await createTempPreset();
       mockBridge.renderSequence.mockResolvedValue({
         success: false,
         error: 'encodeSequence returned no jobID — preset path may be invalid or AME not connected',
-        outputPath: '/tmp/out.mp4',
-        presetPath: '/path/that/does/not/exist.epr',
+        outputPath,
+        presetPath,
       });
 
       const result = await tools.executeTool('export_sequence', {
         sequenceId: 'seq-1',
-        outputPath: '/tmp/out.mp4',
-        presetPath: '/path/that/does/not/exist.epr',
+        outputPath,
+        presetPath,
       });
 
       expect(result.success).toBe(false);
@@ -1307,29 +1359,132 @@ describe('PremiereProTools', () => {
     });
 
     it('returns success with jobID when bridge confirms AME queue accepted', async () => {
+      const { presetPath, outputPath } = await createTempPreset();
       mockBridge.renderSequence.mockResolvedValue({
         success: true,
         queued: true,
+        queueStarted: true,
+        status: 'queued',
         jobID: 'job-abc-123',
-        outputPath: '/tmp/out.mp4',
-        presetPath: '/Users/me/preset.epr',
+        outputPath,
+        presetPath,
+        sourceRange: 'entire',
+        resolvedRange: { in: 0, out: 10, inMarked: false, outMarked: false },
+        encoderRangeConstant: 'ENCODE_ENTIRE',
       });
 
       const result = await tools.executeTool('export_sequence', {
         sequenceId: 'seq-1',
-        outputPath: '/tmp/out.mp4',
-        presetPath: '/Users/me/preset.epr',
+        outputPath,
+        presetPath,
       });
 
       expect(result.success).toBe(true);
       expect(result.jobID).toBe('job-abc-123');
       expect(result.queued).toBe(true);
+      expect(result.queueStarted).toBe(true);
+      expect(result.sourceRange).toBe('entire');
+      expect(result.encoderRangeConstant).toBe('ENCODE_ENTIRE');
       expect(result.message).toMatch(/queued in Adobe Media Encoder/);
       expect(mockBridge.renderSequence).toHaveBeenCalledWith(
         'seq-1',
-        '/tmp/out.mp4',
-        '/Users/me/preset.epr',
+        outputPath,
+        presetPath,
+        { sourceRange: 'entire', removeOnCompletion: true },
       );
+    });
+
+    it('passes requested sourceRange and removeOnCompletion to the bridge', async () => {
+      const { presetPath, outputPath } = await createTempPreset();
+      mockBridge.renderSequence.mockResolvedValue({
+        success: true,
+        queued: true,
+        queueStarted: false,
+        jobID: 'job-in-out',
+        sourceRange: 'in_out',
+        resolvedRange: { in: 0, out: 5, inMarked: false, outMarked: true },
+        encoderRangeConstant: 'ENCODE_IN_TO_OUT',
+      });
+
+      const result = await tools.executeTool('export_sequence', {
+        sequenceId: 'seq-1',
+        outputPath,
+        presetPath,
+        sourceRange: 'in_out',
+        removeOnCompletion: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.resolvedRange).toEqual({ in: 0, out: 5, inMarked: false, outMarked: true });
+      expect(mockBridge.renderSequence).toHaveBeenCalledWith(
+        'seq-1',
+        outputPath,
+        presetPath,
+        { sourceRange: 'in_out', removeOnCompletion: false },
+      );
+    });
+
+    it('rejects non-absolute, unreadable, and existing output paths before queueing', async () => {
+      const { presetPath, outputPath } = await createTempPreset();
+      await fs.writeFile(outputPath, 'already here', 'utf8');
+
+      const result = await tools.executeTool('export_sequence', {
+        sequenceId: 'seq-1',
+        outputPath,
+        presetPath,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(expect.arrayContaining([
+        expect.objectContaining({ code: 'OUTPUT_EXISTS' }),
+      ]));
+      expect(mockBridge.renderSequence).not.toHaveBeenCalled();
+    });
+
+    it('resolves a unique presetName exactly and rejects ambiguous names', async () => {
+      const { presetPath, outputPath } = await createTempPreset('Named Preset');
+      const toolsAny = tools as any;
+      jest.spyOn(toolsAny, 'getEncoderPresets').mockResolvedValue({
+        success: true,
+        presets: [
+          { name: 'Named Preset', path: presetPath, source: 'user', ameVersion: '26.0' },
+        ],
+        count: 1,
+        searchedDirectories: ['/presets'],
+        errors: [],
+        factoryPresets: { supported: false, note: 'unsupported' },
+      });
+      mockBridge.renderSequence.mockResolvedValue({ success: true, queued: true, jobID: 'job-name' });
+
+      const result = await tools.executeTool('export_sequence', {
+        sequenceId: 'seq-1',
+        outputPath,
+        presetName: 'Named Preset',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.presetPath).toBe(presetPath);
+
+      toolsAny.getEncoderPresets.mockResolvedValue({
+        success: true,
+        presets: [
+          { name: 'Duplicate', path: presetPath, source: 'user', ameVersion: '26.0' },
+          { name: 'Duplicate', path: presetPath.replace('.epr', '-2.epr'), source: 'user', ameVersion: '26.0' },
+        ],
+        count: 2,
+        searchedDirectories: ['/presets'],
+        errors: [],
+        factoryPresets: { supported: false, note: 'unsupported' },
+      });
+
+      const ambiguous = await tools.executeTool('export_sequence', {
+        sequenceId: 'seq-1',
+        outputPath,
+        presetName: 'Duplicate',
+      });
+
+      expect(ambiguous.success).toBe(false);
+      expect(ambiguous.error).toMatch(/ambiguous/);
     });
   });
 
@@ -1342,11 +1497,12 @@ describe('PremiereProTools', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toMatch(/presetPath required/);
+      expect(result.error).toMatch(/presetPath or presetName required/);
       expect(mockBridge.renderSequence).not.toHaveBeenCalled();
     });
 
     it('propagates bridge failure responses through the delegation', async () => {
+      const { presetPath, outputPath } = await createTempPreset();
       mockBridge.renderSequence.mockResolvedValue({
         success: false,
         error: 'app.encoder not available in this Premiere build',
@@ -1354,8 +1510,8 @@ describe('PremiereProTools', () => {
 
       const result = await tools.executeTool('add_to_render_queue', {
         sequenceId: 'seq-1',
-        outputPath: '/tmp/out.mp4',
-        presetPath: '/Users/me/preset.epr',
+        outputPath,
+        presetPath,
       });
 
       expect(result.success).toBe(false);

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -869,56 +869,184 @@ export class PremiereProBridge implements PremiereProTransport {
     return await this.executeScript(script, 300000);
   }
 
-  async renderSequence(sequenceId: string, outputPath: string, presetPath: string): Promise<any> {
-    // Escape backslashes and quotes in paths so JSX string-eval is safe
-    const safePath = (s: string) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  async renderSequence(
+    sequenceId: string,
+    outputPath: string,
+    presetPath: string,
+    options: { sourceRange?: 'entire' | 'in_out' | 'work_area'; removeOnCompletion?: boolean } = {}
+  ): Promise<any> {
+    const sourceRange = options.sourceRange ?? 'entire';
+    const removeOnCompletion = options.removeOnCompletion ?? true;
     const script = `
       try {
+        var sequenceId = ${JSON.stringify(sequenceId)};
+        var outputPath = ${JSON.stringify(outputPath)};
+        var presetPath = ${JSON.stringify(presetPath)};
+        var sourceRange = ${JSON.stringify(sourceRange)};
+        var removeOnCompletion = ${removeOnCompletion ? 1 : 0};
+        var warnings = [];
+
+        function secondsOf(value) {
+          if (value === null || typeof value === "undefined") return 0;
+          try {
+            if (typeof value.ticks !== "undefined") return Number(value.ticks) / 254016000000.0;
+            if (typeof value.seconds !== "undefined") {
+              var secondsValue = Number(value.seconds);
+              return Math.abs(secondsValue) > 1000000 ? secondsValue / 254016000000.0 : secondsValue;
+            }
+          } catch (_) {}
+          var numeric = Number(value);
+          if (Math.abs(numeric) > 1000000) return numeric / 254016000000.0;
+          return isNaN(numeric) ? 0 : numeric;
+        }
+
+        function rangeFailure(code, message, details) {
+          var payload = {
+            success: false,
+            status: "failed",
+            code: code,
+            error: message,
+            sourceRange: sourceRange,
+            outputPath: outputPath,
+            presetPath: presetPath,
+            warnings: warnings
+          };
+          if (details) {
+            for (var key in details) {
+              if (details.hasOwnProperty(key)) payload[key] = details[key];
+            }
+          }
+          return JSON.stringify(payload);
+        }
+
         // Premiere 2026 dropped getSequenceByID; iterate via __findSequence helper.
         // Fail hard if the requested sequence isn't found — silently falling back to
         // app.project.activeSequence would queue/render the wrong timeline while still
         // reporting success, masking caller bugs (stale IDs, etc.).
-        var sequence = __findSequence("${sequenceId}");
+        var sequence = __findSequence(sequenceId);
         if (!sequence) {
-          return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+          return rangeFailure("SEQUENCE_NOT_FOUND", "Sequence not found by id: " + sequenceId);
         }
         if (typeof app.encoder === "undefined") {
-          return JSON.stringify({ success: false, error: "app.encoder not available in this Premiere build" });
+          return rangeFailure("ENCODER_UNAVAILABLE", "app.encoder not available in this Premiere build");
         }
 
         // Boot AME if not already running so it can pick up the queue
-        try { app.encoder.launchEncoder(); } catch (e1) {}
+        try { app.encoder.launchEncoder(); }
+        catch (e1) {
+          warnings.push({ code: "LAUNCH_ENCODER_FAILED", message: e1.toString() });
+        }
 
-        // Queue range constants on app.encoder: ENCODE_ENTIRE / ENCODE_IN_TO_OUT / ENCODE_WORKAREA
-        var range = (typeof app.encoder.ENCODE_ENTIRE !== "undefined") ? app.encoder.ENCODE_ENTIRE : 0;
+        var sequenceEnd = secondsOf(sequence.end);
+        var sequenceIn = 0;
+        var sequenceOut = 0;
+        try { sequenceIn = secondsOf(sequence.getInPointAsTime()); } catch (inReadError) {}
+        try { sequenceOut = secondsOf(sequence.getOutPointAsTime()); } catch (outReadError) {}
+        var inMarked = sequenceIn > 0;
+        var outMarked = sequenceOut > 0;
+        var range = null;
+        var encoderRangeConstant = "";
+        var resolvedRange = {
+          in: 0,
+          out: sequenceEnd,
+          inMarked: inMarked,
+          outMarked: outMarked,
+          sequenceEnd: sequenceEnd
+        };
 
-        // 5th arg "removeOnCompletion": 1=remove, 0=keep. We use 1 to avoid AME queue clutter.
+        if (sourceRange === "in_out") {
+          if (!inMarked && !outMarked) {
+            return rangeFailure("IN_OUT_UNSET", "sourceRange in_out requested, but sequence In and Out are both unset.", { resolvedRange: resolvedRange });
+          }
+          if (!outMarked) {
+            return rangeFailure("OUT_POINT_UNSET", "sourceRange in_out requested, but sequence Out is unset.", { resolvedRange: resolvedRange });
+          }
+          resolvedRange.in = inMarked ? sequenceIn : 0;
+          resolvedRange.out = sequenceOut;
+          if (resolvedRange.out <= resolvedRange.in) {
+            return rangeFailure("INVALID_IN_OUT_RANGE", "sourceRange in_out requires Out to be greater than In.", { resolvedRange: resolvedRange });
+          }
+          if (sequenceEnd > 0 && resolvedRange.out > sequenceEnd + 0.001) {
+            return rangeFailure("OUT_POINT_BEYOND_SEQUENCE_END", "Sequence Out exceeds the physical sequence end.", { resolvedRange: resolvedRange });
+          }
+          encoderRangeConstant = "ENCODE_IN_TO_OUT";
+        } else if (sourceRange === "work_area") {
+          var workIn = 0;
+          var workOut = 0;
+          try { workIn = secondsOf(sequence.getWorkAreaInPointAsTime()); } catch (workInReadError) {}
+          try { workOut = secondsOf(sequence.getWorkAreaOutPointAsTime()); } catch (workOutReadError) {}
+          resolvedRange = {
+            in: workIn,
+            out: workOut,
+            inMarked: workIn > 0,
+            outMarked: workOut > 0,
+            sequenceEnd: sequenceEnd
+          };
+          if (workOut <= workIn) {
+            return rangeFailure("INVALID_WORK_AREA_RANGE", "sourceRange work_area requires Work Area Out to be greater than Work Area In.", { resolvedRange: resolvedRange });
+          }
+          if (sequenceEnd > 0 && workOut > sequenceEnd + 0.001) {
+            return rangeFailure("WORK_AREA_BEYOND_SEQUENCE_END", "Work Area Out exceeds the physical sequence end.", { resolvedRange: resolvedRange });
+          }
+          encoderRangeConstant = "ENCODE_WORKAREA";
+        } else if (sourceRange === "entire") {
+          encoderRangeConstant = "ENCODE_ENTIRE";
+        } else {
+          return rangeFailure("INVALID_SOURCE_RANGE", "Unsupported sourceRange: " + sourceRange);
+        }
+
+        if (typeof app.encoder[encoderRangeConstant] === "undefined") {
+          return rangeFailure("ENCODER_RANGE_UNAVAILABLE", "Requested encoder range constant is unavailable: " + encoderRangeConstant, {
+            encoderRangeConstant: encoderRangeConstant,
+            resolvedRange: resolvedRange
+          });
+        }
+        range = app.encoder[encoderRangeConstant];
+
         var jobID = app.encoder.encodeSequence(
           sequence,
-          "${safePath(outputPath)}",
-          "${safePath(presetPath)}",
+          outputPath,
+          presetPath,
           range,
-          1
+          removeOnCompletion
         );
 
         if (!jobID) {
           return JSON.stringify({
             success: false,
+            status: "failed",
             error: "encodeSequence returned no jobID — preset path may be invalid or AME not connected",
-            outputPath: "${safePath(outputPath)}",
-            presetPath: "${safePath(presetPath)}"
+            outputPath: outputPath,
+            presetPath: presetPath,
+            sourceRange: sourceRange,
+            resolvedRange: resolvedRange,
+            encoderRangeConstant: encoderRangeConstant,
+            warnings: warnings
           });
         }
 
         // Trigger AME to actually start processing the queued job
-        try { app.encoder.startBatch(); } catch (e2) {}
+        var queueStarted = false;
+        try {
+          var startBatchResult = app.encoder.startBatch();
+          queueStarted = startBatchResult !== false;
+        } catch (e2) {
+          warnings.push({ code: "START_BATCH_FAILED", message: e2.toString() });
+        }
 
         return JSON.stringify({
           success: true,
+          status: "queued",
           queued: true,
+          queueStarted: queueStarted,
           jobID: String(jobID),
-          outputPath: "${safePath(outputPath)}",
-          presetPath: "${safePath(presetPath)}"
+          outputPath: outputPath,
+          presetPath: presetPath,
+          sourceRange: sourceRange,
+          resolvedRange: resolvedRange,
+          encoderRangeConstant: encoderRangeConstant,
+          removeOnCompletion: !!removeOnCompletion,
+          warnings: warnings
         });
       } catch (e) {
         return JSON.stringify({ success: false, error: "encodeSequence threw: " + e.toString() });

--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -14,12 +14,21 @@ export interface PremiereProTransport {
   createSequence(name: string, presetPath?: string): Promise<PremiereProSequence>;
   addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio?: boolean, sourceInPoint?: number, sourceOutPoint?: number): Promise<PremiereProClip>;
   addToTimelineBatch(sequenceId: string, clips: Array<{ projectItemId: string; trackIndex: number; time: number; linkAudio?: boolean; sourceInPoint?: number; sourceOutPoint?: number }>): Promise<any>;
-  renderSequence(sequenceId: string, outputPath: string, presetPath: string): Promise<{
+  renderSequence(sequenceId: string, outputPath: string, presetPath: string, options?: {
+    sourceRange?: 'entire' | 'in_out' | 'work_area';
+    removeOnCompletion?: boolean;
+  }): Promise<{
     success: boolean;
+    status?: string;
     queued?: boolean;
+    queueStarted?: boolean;
     jobID?: string;
     outputPath?: string;
     presetPath?: string;
+    sourceRange?: string;
+    resolvedRange?: unknown;
+    encoderRangeConstant?: string;
+    warnings?: Array<{ code: string; message: string }>;
     error?: string;
   }>;
 }

--- a/src/tools/expanded.ts
+++ b/src/tools/expanded.ts
@@ -149,7 +149,6 @@ export const expandedToolNames = [
   'batch_rename_clips',
   'batch_enable_disable',
   'clear_sequence_in_out',
-  'get_encoder_presets',
   'get_qe_clip_info',
   'set_poster_frame',
   'move_items_to_bin',
@@ -2052,28 +2051,6 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           if (!frameExported) return fail(frameExportError || "Frame export failed");
           return ok({ exported: true, outputPath: framePath, method: frameMethod, seconds: frameSeconds });
 
-        case "get_encoder_presets":
-          if (!app.encoder) return fail("app.encoder is unavailable");
-          var presetResult = tryCall(app.encoder, ["getPresets", "getEncoderPresets"], []);
-          if (!presetResult.called) {
-            var presetFolders = args.folders || [
-              "/Applications/Adobe Premiere Pro 2026/Adobe Premiere Pro 2026.app/Contents/Settings/EncoderPresets",
-              "/Applications/Adobe Premiere Pro 2025/Adobe Premiere Pro 2025.app/Contents/Settings/EncoderPresets"
-            ];
-            var presetFiles = [];
-            for (var pfi = 0; pfi < presetFolders.length; pfi++) {
-              try {
-                var presetFolder = new Folder(String(presetFolders[pfi]));
-                if (!presetFolder.exists) continue;
-                var files = presetFolder.getFiles("*.epr");
-                for (var pfj = 0; pfj < files.length; pfj++) presetFiles.push({ name: files[pfj].name, path: files[pfj].fsName });
-              } catch (presetScanError) {}
-            }
-            if (presetFiles.length) return ok({ presets: presetFiles, count: presetFiles.length, method: "filesystem scan" });
-            return fail(presetResult.error, { available: false });
-          }
-          return ok({ presets: presetResult.result });
-
         case "nest_clips":
           if (!app.project || !app.project.createNewSequenceFromClips) return commandByName("Nest...");
           var nestSeq = targetSequence() || activeSequence();
@@ -2299,7 +2276,6 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ matched: true, clipId: matchClip.clip.nodeId, item: matchClip.clip.projectItem.name, time: matchTime, method: "sourceMonitor.openProjectItem" });
 
         case "capture_frame":
-        case "get_encoder_presets":
         case "get_project_scratch_disks":
         case "get_project_panel_metadata":
         case "get_xmp_metadata":

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,6 +7,9 @@
 
 import { z } from 'zod';
 import { spawn } from 'child_process';
+import { constants as fsConstants, promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, dirname, extname, isAbsolute, join, parse } from 'node:path';
 import type { PremiereProTransport } from '../bridge/types.js';
 import { Logger } from '../utils/logger.js';
 import { createMotionDemoAssets } from '../utils/demoAssets.js';
@@ -20,6 +23,43 @@ export interface MCPTool {
 
 type MotionStyle = 'push_in' | 'pull_out' | 'alternate' | 'none';
 type InsertMode = 'overwrite' | 'insert';
+type ExportSourceRange = 'entire' | 'in_out' | 'work_area';
+
+interface EncoderPresetEntry {
+  name: string;
+  path: string;
+  source: 'user';
+  ameVersion: string;
+}
+
+interface EncoderPresetDiscovery {
+  success: true;
+  presets: EncoderPresetEntry[];
+  count: number;
+  searchedDirectories: string[];
+  errors: Array<{ path: string; error: string }>;
+  factoryPresets: {
+    supported: false;
+    note: string;
+  };
+}
+
+interface ExportSequenceArgs {
+  sequenceId: string;
+  outputPath: string;
+  presetPath?: string;
+  presetName?: string;
+  sourceRange?: ExportSourceRange;
+  allowOverwrite?: boolean;
+  removeOnCompletion?: boolean;
+  format?: string;
+  quality?: string;
+  resolution?: string;
+}
+
+interface AddToRenderQueueArgs extends ExportSequenceArgs {
+  startImmediately?: boolean;
+}
 
 interface ClipPlanTransition {
   name?: string;
@@ -233,6 +273,13 @@ export class PremiereProTools {
           presetPath: z.string().optional().describe('Optional Adobe Media Encoder .epr preset path. When provided, the file is checked.'),
           requireNonEmptyTimeline: z.boolean().optional().describe('When true, an empty timeline is an error. Defaults to true.'),
           checkGaps: z.boolean().optional().describe('When true, timeline gaps are reported as warnings. Defaults to true.')
+        })
+      },
+      {
+        name: 'get_encoder_presets',
+        description: 'Discovers readable user Adobe Media Encoder .epr presets from local AME preset folders. Factory preset enumeration is not claimed complete.',
+        inputSchema: z.object({
+          directories: z.array(z.string()).optional().describe('Optional absolute directories to scan instead of the default user AME preset folders. Intended for tests and advanced setups.')
         })
       },
       {
@@ -627,10 +674,14 @@ export class PremiereProTools {
         inputSchema: z.object({
           sequenceId: z.string().describe('The ID of the sequence to export'),
           outputPath: z.string().describe('The absolute path where the final video file will be saved'),
-          presetPath: z.string().optional().describe('Optional path to an export preset file (.epr) for specific settings'),
-          format: z.enum(['mp4', 'mov', 'avi', 'h264', 'prores']).optional().describe('The export format or codec'),
-          quality: z.enum(['low', 'medium', 'high', 'maximum']).optional().describe('Export quality setting'),
-          resolution: z.string().optional().describe('Export resolution (e.g., "1920x1080", "3840x2160")')
+          presetPath: z.string().optional().describe('Absolute path to an export preset file (.epr). Required unless presetName uniquely resolves through get_encoder_presets.'),
+          presetName: z.string().optional().describe('Exact user preset display name or filename stem. Must resolve to exactly one discovered .epr preset.'),
+          sourceRange: z.enum(['entire', 'in_out', 'work_area']).optional().describe('Export source range. Defaults to entire. Requested ranges are never silently substituted.'),
+          allowOverwrite: z.boolean().optional().describe('Allow writing to an existing output file. Defaults to false.'),
+          removeOnCompletion: z.boolean().optional().describe('Pass AME removeOnCompletion. Defaults to true to preserve existing queue behavior.'),
+          format: z.enum(['mp4', 'mov', 'avi', 'h264', 'prores']).optional().describe('Deprecated hint only; the .epr preset controls codec/container.'),
+          quality: z.enum(['low', 'medium', 'high', 'maximum']).optional().describe('Deprecated hint only; the .epr preset controls quality.'),
+          resolution: z.string().optional().describe('Deprecated hint only; the .epr preset controls resolution.')
         })
       },
       {
@@ -857,6 +908,10 @@ export class PremiereProTools {
           sequenceId: z.string().describe('The ID of the sequence to render'),
           outputPath: z.string().describe('Output file path'),
           presetPath: z.string().optional().describe('Export preset file path'),
+          presetName: z.string().optional().describe('Exact user preset display name or filename stem. Must resolve to exactly one discovered .epr preset.'),
+          sourceRange: z.enum(['entire', 'in_out', 'work_area']).optional().describe('Export source range. Defaults to entire.'),
+          allowOverwrite: z.boolean().optional().describe('Allow writing to an existing output file. Defaults to false.'),
+          removeOnCompletion: z.boolean().optional().describe('Pass AME removeOnCompletion. Defaults to true.'),
           startImmediately: z.boolean().optional().describe('Whether to start rendering immediately (default: false)')
         })
       },
@@ -1320,6 +1375,8 @@ export class PremiereProTools {
           return await this.getProjectInfo();
         case 'validate_project_for_export':
           return await this.validateProjectForExport(args.sequenceId, args.outputPath, args.presetPath, args.requireNonEmptyTimeline, args.checkGaps);
+        case 'get_encoder_presets':
+          return await this.getEncoderPresets(args.directories);
         case 'build_motion_graphics_demo':
           return await this.buildMotionGraphicsDemo(args.sequenceName);
         case 'assemble_product_spot':
@@ -1429,7 +1486,18 @@ export class PremiereProTools {
 
         // Export and Rendering
         case 'export_sequence':
-          return await this.exportSequence(args.sequenceId, args.outputPath, args.presetPath, args.format, args.quality, args.resolution);
+          return await this.exportSequence({
+            sequenceId: args.sequenceId,
+            outputPath: args.outputPath,
+            presetPath: args.presetPath,
+            presetName: args.presetName,
+            sourceRange: args.sourceRange,
+            allowOverwrite: args.allowOverwrite,
+            removeOnCompletion: args.removeOnCompletion,
+            format: args.format,
+            quality: args.quality,
+            resolution: args.resolution
+          });
         case 'export_frame':
           return await this.exportFrame(args.sequenceId, args.time, args.outputPath, args.format);
 
@@ -1490,7 +1558,16 @@ export class PremiereProTools {
 
         // Render Queue
         case 'add_to_render_queue':
-          return await this.addToRenderQueue(args.sequenceId, args.outputPath, args.presetPath, args.startImmediately);
+          return await this.addToRenderQueue({
+            sequenceId: args.sequenceId,
+            outputPath: args.outputPath,
+            presetPath: args.presetPath,
+            presetName: args.presetName,
+            sourceRange: args.sourceRange,
+            allowOverwrite: args.allowOverwrite,
+            removeOnCompletion: args.removeOnCompletion,
+            startImmediately: args.startImmediately
+          });
         case 'get_render_queue_status':
           return await this.getRenderQueueStatus();
 
@@ -5066,18 +5143,266 @@ export class PremiereProTools {
   }
 
   // Export and Rendering Implementation
-  private async exportSequence(sequenceId: string, outputPath: string, presetPath?: string, format?: string, quality?: string, resolution?: string): Promise<any> {
+  private decodeXmlEntities(value: string): string {
+    return value
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&')
+      .trim();
+  }
+
+  private displayNameFromPresetXml(xml: string): string | undefined {
+    const patterns = [
+      /<PresetName[^>]*>([^<]+)<\/PresetName>/i,
+      /<Name[^>]*>([^<]+)<\/Name>/i,
+      /\bPresetName="([^"]+)"/i,
+      /\bName="([^"]+)"/i,
+    ];
+    for (const pattern of patterns) {
+      const match = pattern.exec(xml);
+      const name = match?.[1] ? this.decodeXmlEntities(match[1]) : '';
+      if (name) return name;
+    }
+    return undefined;
+  }
+
+  private async defaultEncoderPresetDirectories(): Promise<string[]> {
+    const baseDirs = [
+      join(homedir(), 'Library', 'Application Support', 'Adobe', 'Common', 'AME'),
+    ];
+    if (process.env.APPDATA) {
+      baseDirs.push(join(process.env.APPDATA, 'Adobe', 'Common', 'AME'));
+    }
+
+    const presetDirs = new Set<string>();
+    for (const baseDir of baseDirs) {
+      let entries: Array<{ name: string; isDirectory(): boolean }>;
+      try {
+        entries = await fs.readdir(baseDir, { withFileTypes: true });
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code === 'ENOENT' || code === 'ENOTDIR') continue;
+        presetDirs.add(join(baseDir, 'Presets'));
+        continue;
+      }
+
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          presetDirs.add(join(baseDir, entry.name, 'Presets'));
+        }
+      }
+    }
+    return [...presetDirs].sort();
+  }
+
+  private ameVersionFromPresetDirectory(directory: string): string {
+    return basename(directory).toLowerCase() === 'presets'
+      ? basename(dirname(directory))
+      : basename(directory);
+  }
+
+  private async getEncoderPresets(directories?: string[]): Promise<EncoderPresetDiscovery> {
+    const searchedDirectories = directories && directories.length > 0
+      ? directories
+      : await this.defaultEncoderPresetDirectories();
+    const presets: EncoderPresetEntry[] = [];
+    const errors: Array<{ path: string; error: string }> = [];
+
+    for (const directory of searchedDirectories) {
+      let entries: Array<{ name: string; isFile(): boolean }>;
+      try {
+        entries = await fs.readdir(directory, { withFileTypes: true });
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+          errors.push({ path: directory, error: error instanceof Error ? error.message : String(error) });
+        }
+        continue;
+      }
+
+      for (const entry of entries) {
+        if (!entry.isFile() || extname(entry.name).toLowerCase() !== '.epr') continue;
+        const presetPath = join(directory, entry.name);
+        try {
+          await fs.access(presetPath, fsConstants.R_OK);
+          const xml = await fs.readFile(presetPath, 'utf8');
+          presets.push({
+            name: this.displayNameFromPresetXml(xml) ?? parse(entry.name).name,
+            path: presetPath,
+            source: 'user',
+            ameVersion: this.ameVersionFromPresetDirectory(directory),
+          });
+        } catch (error) {
+          errors.push({ path: presetPath, error: error instanceof Error ? error.message : String(error) });
+        }
+      }
+    }
+
+    presets.sort((a, b) => a.name.localeCompare(b.name) || a.path.localeCompare(b.path));
+    return {
+      success: true,
+      presets,
+      count: presets.length,
+      searchedDirectories,
+      errors,
+      factoryPresets: {
+        supported: false,
+        note: 'Factory preset enumeration is not complete or supported; save a user .epr preset in AME and rediscover it here.',
+      },
+    };
+  }
+
+  private async resolvePresetPath(presetPath?: string, presetName?: string): Promise<
+    { success: true; presetPath: string; presetName?: string; presetResolution?: any } |
+    { success: false; error: string; presetName?: string; matches?: EncoderPresetEntry[]; searchedDirectories?: string[] }
+  > {
+    if (presetPath && presetName) {
+      return { success: false, error: 'Provide either presetPath or presetName, not both.', presetName };
+    }
+
+    if (presetPath) {
+      return { success: true, presetPath };
+    }
+
+    if (!presetName) {
+      return {
+        success: false,
+        error: 'presetPath or presetName required — Adobe encodeSequence requires an absolute .epr preset file.',
+      };
+    }
+
+    const discovery = await this.getEncoderPresets();
+    const matches = discovery.presets.filter((preset) => preset.name === presetName || parse(preset.path).name === presetName);
+    if (matches.length === 1) {
+      const [match] = matches as [EncoderPresetEntry];
+      return {
+        success: true,
+        presetPath: match.path,
+        presetName,
+        presetResolution: {
+          method: 'exact_name',
+          name: match.name,
+          path: match.path,
+          ameVersion: match.ameVersion,
+        },
+      };
+    }
+    if (matches.length > 1) {
+      return {
+        success: false,
+        error: `presetName "${presetName}" is ambiguous; pass presetPath instead.`,
+        presetName,
+        matches,
+        searchedDirectories: discovery.searchedDirectories,
+      };
+    }
+    return {
+      success: false,
+      error: `presetName "${presetName}" was not found in user AME presets.`,
+      presetName,
+      searchedDirectories: discovery.searchedDirectories,
+    };
+  }
+
+  private async validateExportPaths(outputPath: string, presetPath: string, allowOverwrite = false): Promise<Array<{ code: string; message: string; path?: string }>> {
+    const errors: Array<{ code: string; message: string; path?: string }> = [];
+
+    if (!isAbsolute(presetPath)) {
+      errors.push({ code: 'PRESET_PATH_NOT_ABSOLUTE', message: 'presetPath must be an absolute .epr path.', path: presetPath });
+    } else if (extname(presetPath).toLowerCase() !== '.epr') {
+      errors.push({ code: 'PRESET_EXTENSION', message: 'presetPath must point to a .epr file.', path: presetPath });
+    } else {
+      try {
+        await fs.access(presetPath, fsConstants.R_OK);
+      } catch {
+        errors.push({ code: 'PRESET_NOT_READABLE', message: 'Export preset file does not exist or is not readable.', path: presetPath });
+      }
+    }
+
+    if (!isAbsolute(outputPath)) {
+      errors.push({ code: 'OUTPUT_PATH_NOT_ABSOLUTE', message: 'outputPath must be absolute.', path: outputPath });
+    } else {
+      const outputDirectory = dirname(outputPath);
+      try {
+        const stat = await fs.stat(outputDirectory);
+        if (!stat.isDirectory()) {
+          errors.push({ code: 'OUTPUT_FOLDER_NOT_DIRECTORY', message: 'Output parent path is not a directory.', path: outputDirectory });
+        }
+      } catch {
+        errors.push({ code: 'OUTPUT_FOLDER_NOT_FOUND', message: 'Output parent folder does not exist.', path: outputDirectory });
+      }
+
+      try {
+        await fs.access(outputPath, fsConstants.F_OK);
+        if (!allowOverwrite) {
+          errors.push({ code: 'OUTPUT_EXISTS', message: 'Output file already exists; pass allowOverwrite:true to replace it.', path: outputPath });
+        }
+      } catch {
+        // Missing output file is the normal export case.
+      }
+    }
+
+    return errors;
+  }
+
+  private deprecatedExportOptionWarnings(format?: string, quality?: string, resolution?: string): Array<{ code: string; message: string; value?: string }> {
+    const warnings: Array<{ code: string; message: string; value?: string }> = [];
+    if (format) warnings.push({ code: 'FORMAT_IGNORED', message: 'format is deprecated for export_sequence; the .epr preset controls the container and codec.', value: format });
+    if (quality) warnings.push({ code: 'QUALITY_IGNORED', message: 'quality is deprecated for export_sequence; the .epr preset controls export quality.', value: quality });
+    if (resolution) warnings.push({ code: 'RESOLUTION_IGNORED', message: 'resolution is deprecated for export_sequence; the .epr preset controls output dimensions.', value: resolution });
+    return warnings;
+  }
+
+  private async exportSequence(args: ExportSequenceArgs): Promise<any> {
+    const {
+      sequenceId,
+      outputPath,
+      presetName,
+      sourceRange = 'entire',
+      allowOverwrite = false,
+      removeOnCompletion = true,
+      format,
+      quality,
+      resolution,
+    } = args;
     // app.encoder.encodeSequence() expects an absolute path to a .epr preset file.
     // Passing a string name like "H.264" silently fails: encodeSequence returns
     // no jobID and the JSX bridge reports {success:false}. Reject early with a
     // clear error rather than letting the user think a queue happened.
-    if (!presetPath) {
+    const presetResolution = await this.resolvePresetPath(args.presetPath, presetName);
+    if (!presetResolution.success) {
       return {
         success: false,
-        error: 'presetPath required — must be absolute path to a .epr preset file (Adobe encodeSequence does not accept format names like "H.264" or "ProRes")',
+        error: presetResolution.error,
         hint: 'Create the preset in AME UI: File → Export Settings → configure → Save Preset → exports to ~/Library/Application Support/Adobe/Common/AME/<version>/Presets/. Pass that .epr path as presetPath.',
         sequenceId,
         outputPath,
+        presetName,
+        matches: presetResolution.matches,
+        searchedDirectories: presetResolution.searchedDirectories,
+        format,
+        quality,
+        resolution,
+      };
+    }
+    const presetPath = presetResolution.presetPath;
+
+    const pathErrors = await this.validateExportPaths(outputPath, presetPath, allowOverwrite);
+    const warnings = this.deprecatedExportOptionWarnings(format, quality, resolution);
+    if (pathErrors.length > 0) {
+      return {
+        success: false,
+        error: pathErrors.map((pathError) => pathError.message).join(' '),
+        errors: pathErrors,
+        warnings,
+        sequenceId,
+        outputPath,
+        presetPath,
+        presetName,
+        sourceRange,
+        allowOverwrite,
         format,
         quality,
         resolution,
@@ -5088,13 +5413,22 @@ export class PremiereProTools {
       // bridge.renderSequence returns a structured response; propagate it instead
       // of unconditionally claiming success. Pre-fix wrapper reported success even
       // when AME never received the job (false-success false positives).
-      const result = await this.bridge.renderSequence(sequenceId, outputPath, presetPath);
+      const result = await this.bridge.renderSequence(sequenceId, outputPath, presetPath, {
+        sourceRange,
+        removeOnCompletion,
+      });
 
       if (result && result.success === false) {
         return {
           ...result,
           sequenceId,
           outputPath,
+          presetPath,
+          presetName,
+          presetResolution: presetResolution.presetResolution,
+          sourceRange,
+          allowOverwrite,
+          warnings: [...warnings, ...(result.warnings ?? [])],
           format,
           quality,
           resolution,
@@ -5103,15 +5437,24 @@ export class PremiereProTools {
 
       return {
         success: true,
+        status: result?.status ?? 'queued',
         message: 'Sequence queued in Adobe Media Encoder. Render runs asynchronously — verify by checking the output file size growth.',
         sequenceId,
         outputPath,
         presetPath,
+        presetName,
+        presetResolution: presetResolution.presetResolution,
+        sourceRange,
+        resolvedRange: result?.resolvedRange,
+        encoderRangeConstant: result?.encoderRangeConstant,
+        removeOnCompletion,
         format,
         quality,
         resolution,
+        warnings: [...warnings, ...(result?.warnings ?? [])],
         jobID: result?.jobID,
         queued: result?.queued,
+        queueStarted: result?.queueStarted,
         verify: `ffprobe -show_entries format=duration,size '${outputPath}'`,
       };
     } catch (error) {
@@ -6196,8 +6539,8 @@ export class PremiereProTools {
   }
 
   // Render Queue
-  private async addToRenderQueue(sequenceId: string, outputPath: string, presetPath?: string, _startImmediately?: boolean): Promise<any> {
-    return await this.exportSequence(sequenceId, outputPath, presetPath);
+  private async addToRenderQueue(args: AddToRenderQueueArgs): Promise<any> {
+    return await this.exportSequence(args);
   }
 
   private async getRenderQueueStatus(): Promise<any> {


### PR DESCRIPTION
Fixes #71
Fixes #72

## Summary
- add sourceRange to export_sequence/add_to_render_queue and pass ENCODE_ENTIRE, ENCODE_IN_TO_OUT, or ENCODE_WORKAREA explicitly
- validate preset/output paths before queueing, reject accidental overwrites unless allowOverwrite is true, and surface queueStarted/startBatch warnings
- implement get_encoder_presets as a real Node filesystem discovery tool for user .epr presets instead of the expanded JSX placeholder
- support exact unique presetName resolution, with explicit ambiguous/unknown failures

## Verification
- npm run build
- npx jest --runInBand --silent: 149/149 passing
- live bridge probe: Premiere exposes ENCODE_ENTIRE, ENCODE_IN_TO_OUT, and ENCODE_WORKAREA
- live bridge probe: active sequence time readback resolved end to 8.00099999999606s after defensive tick conversion
- live Node tool probe: get_encoder_presets returned a real temporary .epr preset with parsed display name, source:user, and ameVersion

## Notes
- I did not start an actual AME render in live validation; the render path is covered by generated-script tests and live constant/API probes.
- Factory preset enumeration remains explicitly unsupported/incomplete per #72.
