### PR TITLE
Fix lock_track: setLocked() expects int (1/0), not JS boolean

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4205,7 +4205,7 @@ export class PremiereProTools {
         } else {
           var tracks = ${trackType === 'video' ? 'sequence.videoTracks' : 'sequence.audioTracks'};
           if (${trackIndex} >= 0 && ${trackIndex} < tracks.numTracks) {
-            tracks[${trackIndex}].setLocked(${locked});
+            tracks[${trackIndex}].setLocked(${locked ? 1 : 0});
             return JSON.stringify({
               success: true,
               message: "Track " + (${locked} ? "locked" : "unlocked")


### PR DESCRIPTION
### Problem

`lock_track` always failed with `Illegal Parameter type`.

Premiere's ExtendScript `Track.setLocked()` expects an int (1/0), but the generated script passed a JS boolean straight through.

### Fix

```diff
-            tracks[${trackIndex}].setLocked(${locked});
+            tracks[${trackIndex}].setLocked(${locked ? 1 : 0});
```

### Why it matters

Unblocks locking audio tracks before an `add_to_timeline` overwrite, i.e. replacing picture only while leaving the underlying audio intact.

### Testing

Verified on macOS with Premiere Pro 2026. Before the change every `lock_track` call threw `Illegal Parameter type`; after it, locking and unlocking both succeed, and the tool was then used in a real edit to lock A1-A3 while overwriting video clips on V1, leaving the locked audio untouched.

Scope: 1 commit, 1 file, +1/-1.