### PR TITLE
fix: Premiere Pro 26.3 export compatibility (ExtendScript in/out keys, validation duration)

### DIFF
--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -932,6 +932,63 @@ describe('PremiereProTools', () => {
       expect(script).not.toContain('renderSequence');
     });
 
+    it('reads export validation duration from tick strings while keeping ZERO_DURATION', async () => {
+      mockBridge.executeScript.mockResolvedValue({
+        success: true,
+        readyForExport: true,
+        errors: [],
+        warnings: [],
+        summary: { videoClipCount: 1 }
+      });
+
+      await tools.executeTool('validate_project_for_export', {
+        sequenceId: 'seq-1',
+        outputPath: '/tmp/output.mp4',
+        presetPath: '/tmp/export.epr'
+      });
+
+      const script = mockBridge.executeScript.mock.calls[0][0] as string;
+
+      // The readiness gate itself must be untouched: still an error, still keyed
+      // off a non-positive duration, still sourced from the active sequence.
+      expect(script).toContain('durationSeconds: sequence ? secondsOf(sequence.end) : 0');
+      expect(script).toContain('if (summary.durationSeconds <= 0)');
+      expect(script).toContain('code: "ZERO_DURATION"');
+
+      const extracted = script.match(/ {8}function secondsOf\(value\) \{[\s\S]*?\n {8}\}/);
+      expect(extracted).not.toBeNull();
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      const secondsOf = new Function(`${extracted![0]}\nreturn secondsOf;`)() as (value: unknown) => number;
+
+      const TICKS_PER_SECOND = 254016000000;
+
+      // A real sequence holding clips: Premiere 26.3 hands back a tick string.
+      expect(secondsOf(String(Math.round(3.211 * TICKS_PER_SECOND)))).toBeCloseTo(3.211, 6);
+      // A genuinely empty sequence still reports zero, so ZERO_DURATION survives.
+      expect(secondsOf('0')).toBe(0);
+      // No active sequence resolves to zero through the ternary above.
+      expect(secondsOf(undefined)).toBe(0);
+      expect(secondsOf(null)).toBe(0);
+      // Legacy Time object shapes keep working unchanged.
+      expect(secondsOf({ seconds: 5 })).toBe(5);
+      expect(secondsOf({ ticks: String(TICKS_PER_SECOND) })).toBe(1);
+      expect(secondsOf(2.5)).toBe(2.5);
+      // Malformed host values fail safe to zero rather than leaking NaN, which
+      // would slip past the `<= 0` comparison and disable the guard entirely.
+      expect(secondsOf('not-a-number')).toBe(0);
+      expect(secondsOf(NaN)).toBe(0);
+      expect(secondsOf({ seconds: 'oops' })).toBe(0);
+      expect(secondsOf({ ticks: 'oops' })).toBe(0);
+    });
+
+    it('keeps timeline inspection tools reading sequence end as ticks', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true, sequences: [], count: 0 });
+
+      await tools.executeTool('list_sequences', {});
+
+      expect(mockBridge.executeScript.mock.calls[0][0] as string).toContain('__ticksToSeconds(seq.end)');
+    });
+
     it('uses verifiable QE transition calls for add_transition', async () => {
       mockBridge.executeScript.mockResolvedValue({
         success: true,

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -947,8 +947,8 @@ export class PremiereProBridge implements PremiereProTransport {
         var range = null;
         var encoderRangeConstant = "";
         var resolvedRange = {
-          in: 0,
-          out: sequenceEnd,
+          "in": 0,
+          "out": sequenceEnd,
           inMarked: inMarked,
           outMarked: outMarked,
           sequenceEnd: sequenceEnd
@@ -976,8 +976,8 @@ export class PremiereProBridge implements PremiereProTransport {
           try { workIn = secondsOf(sequence.getWorkAreaInPointAsTime()); } catch (workInReadError) {}
           try { workOut = secondsOf(sequence.getWorkAreaOutPointAsTime()); } catch (workOutReadError) {}
           resolvedRange = {
-            in: workIn,
-            out: workOut,
+            "in": workIn,
+            "out": workOut,
             inMarked: workIn > 0,
             outMarked: workOut > 0,
             sequenceEnd: sequenceEnd

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1902,9 +1902,23 @@ export class PremiereProTools {
 
         function secondsOf(value) {
           if (value === undefined || value === null) return 0;
-          if (typeof value === "number") return value;
-          if (value.seconds !== undefined) return Number(value.seconds);
-          if (value.ticks !== undefined) return Number(value.ticks) / 254016000000.0;
+          if (typeof value === "number") return isFinite(value) ? value : 0;
+          // Premiere Pro 26.3 returns sequence.end as a plain tick string rather
+          // than a Time object, which previously fell through to 0 and produced a
+          // spurious ZERO_DURATION. The timeline inspection tools already read the
+          // same value as ticks, so interpret it the same way here.
+          if (typeof value === "string") {
+            var stringTicks = parseInt(value, 10);
+            return isFinite(stringTicks) ? stringTicks / 254016000000.0 : 0;
+          }
+          if (value.seconds !== undefined) {
+            var seconds = Number(value.seconds);
+            return isFinite(seconds) ? seconds : 0;
+          }
+          if (value.ticks !== undefined) {
+            var ticks = Number(value.ticks);
+            return isFinite(ticks) ? ticks / 254016000000.0 : 0;
+          }
           return 0;
         }
 


### PR DESCRIPTION
Two independent Premiere Pro 26.3 compatibility defects that together prevent `export_sequence` from ever completing. Both were found while driving a real Premiere 26.3.0 install through the MCP bridge; each is a minimal, behaviour-preserving change.

---

## 1. ExtendScript cannot parse the `in` / `out` keys

`src/bridge/index.ts` builds two `resolvedRange` object literals that are injected into Premiere as ExtendScript, both using bare `in:` and `out:` keys.

ExtendScript is an ES3 engine, and ES3 does not permit reserved words as unquoted property names. `in` is reserved (the relational operator), so the literal fails to parse inside Premiere.

**Symptom:** `export_sequence` fails at runtime — the payload never parses, so export range resolution cannot complete.

**Fix:** quote the keys.

```diff
-          in: 0,
-          out: sequenceEnd,
+          "in": 0,
+          "out": sequenceEnd,
```

Four insertions, four deletions. The resulting objects are identical, and quoted keys are valid on every JS engine, so nothing outside ExtendScript changes.

---

## 2. `validate_project_for_export` reports a spurious `ZERO_DURATION`

With the parse error fixed, export is still blocked one step earlier by the readiness gate.

`sequence.end` arrives from Premiere 26.3 as a plain **tick string**. The `secondsOf` helper inside the export readiness script handled numbers and `Time` objects only:

```js
if (typeof value === "number") return value;
if (value.seconds !== undefined) return Number(value.seconds);
if (value.ticks   !== undefined) return Number(value.ticks) / 254016000000.0;
return 0;   // <- a string lands here
```

A string falls through to `return 0`, so `summary.durationSeconds` is `0` and `ZERO_DURATION` fires on a sequence that demonstrably holds clips.

`list_sequences` and `get_timeline_summary` read the *same* `sequence.end` through `__ticksToSeconds(...)` and report the correct duration. Observed on one sequence in a single run:

| Source | `durationSeconds` |
|---|---|
| `list_sequences` | 3.21129166666667 |
| `get_timeline_summary` | 3.21129166666667 |
| `validate_project_for_export` | **0** |

**Fix:** interpret a numeric string as ticks, matching the inspection tools, and clamp non-finite results to `0`.

The clamp matters: without it a malformed host value yields `NaN`, and `NaN <= 0` is `false`, which would silently disable the guard rather than trip it.

The gate itself is unchanged — `ZERO_DURATION` is still an error, still keyed off a non-positive duration read from the active sequence. A genuinely empty sequence, and a missing active sequence, both still resolve to `0` and still fail.

### Adjacent, deliberately not touched

Two further copies of `secondsOf` exist in `src/tools/index.ts`, in scripts belonging to other tools. They carry the same latent string-handling gap, but those tools are outside the export path and were not exercised here, so they are left for a separate change rather than modified untested.

---

## Tests

`npm test` — **151 passed, 151 total** (2 added).

The added test extracts `secondsOf` from the generated readiness script and covers:

- tick string from a real sequence → positive duration
- `"0"` (empty sequence) → `0`, so `ZERO_DURATION` still fires
- `undefined` / `null` (no active sequence) → `0`
- `Time` object shapes (`.seconds`, `.ticks`) and plain numbers → unchanged
- malformed values (`"not-a-number"`, `NaN`, `{seconds:'oops'}`, `{ticks:'oops'}`) → `0`, failing safe
- the gate still asserts `durationSeconds <= 0` and still sources from `sequence.end`

A second test pins `list_sequences` to `__ticksToSeconds(seq.end)` to catch regressions in the reference source.

Verified failing before the fix, with exactly the production symptom:

```
Expected: 3.211
Received: 0
```

`tsc --noEmit` and `npm run build` are clean. `npm run lint` cannot run — the repository contains no ESLint configuration, which is pre-existing and unrelated to this change.

## End-to-end

Verified against Adobe Premiere Pro 26.3.0 (build 93) on macOS 15.0 arm64 with Adobe Media Encoder, exporting through a user-saved H.264 `.epr` preset: create project, create sequence, import media, add to timeline, `move_clip`, validate, export.

FFprobe on the resulting file: h264 Main 1920x1080, 24000/1001 (23.976 fps), aac LC 48000 Hz stereo, 3.42 s, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
