### PR TITLE
fix: support Premiere Pro 2025/2026 (CEP panel not loading)

### DIFF
--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -5,7 +5,7 @@
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>
-      <Host Name="PPRO" Version="14.0"/>
+      <Host Name="PPRO" Version="[14.0,99.9]"/>
     </HostList>
     <LocaleList>
       <Locale Code="All"/>

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -213,21 +213,36 @@ export class PremiereProBridge implements PremiereProTransport {
   }
 
   private async detectPremiereProInstallation(): Promise<void> {
-    // Check for common Premiere Pro installation paths
-    const commonPaths = [
-      '/Applications/Adobe Premiere Pro 2024/Adobe Premiere Pro 2024.app',
-      '/Applications/Adobe Premiere Pro 2023/Adobe Premiere Pro 2023.app',
-      'C:\\Program Files\\Adobe\\Adobe Premiere Pro 2024\\Adobe Premiere Pro.exe',
-      'C:\\Program Files\\Adobe\\Adobe Premiere Pro 2023\\Adobe Premiere Pro.exe'
-    ];
+    // Scan the install root instead of hardcoding release years, so new
+    // versions (2025, 2026, ...) are detected without a code change.
+    const searchDirs = process.platform === 'win32'
+      ? [join(process.env['ProgramFiles'] || 'C:\\Program Files', 'Adobe')]
+      : ['/Applications'];
 
-    for (const path of commonPaths) {
+    for (const dir of searchDirs) {
+      let entries: string[] = [];
       try {
-        await fs.access(path);
-        this.logger.info(`Found Adobe Premiere Pro at: ${path}`);
-        return;
+        const listing = await fs.readdir(dir);
+        entries = Array.isArray(listing) ? listing : [];
       } catch (error) {
-        // Continue checking other paths
+        continue; // Install root is missing on this machine
+      }
+
+      // Newest release first, e.g. "Adobe Premiere Pro 2026" before "... 2024"
+      const candidates = entries
+        .filter(entry => entry.startsWith('Adobe Premiere Pro'))
+        .sort()
+        .reverse();
+
+      for (const candidate of candidates) {
+        const path = join(dir, candidate);
+        try {
+          await fs.access(path);
+          this.logger.info(`Found Adobe Premiere Pro at: ${path}`);
+          return;
+        } catch (error) {
+          // Continue checking other candidates
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

On Premiere Pro 2025/2026 the CEP bridge never comes up. `Window > Extensions` does not list **MCP Bridge (CEP)**, and every tool call fails with:

```
Bridge response timeout. Ensure Premiere Pro is open, MCP Bridge (CEP or UXP)
panel is open, Temp Directory is set to /tmp/premiere-mcp-bridge, and Start Bridge is clicked.
```

Two independent causes, one commit each.

### 1. CEP manifest host range

`cep-plugin/CSXS/manifest.xml` declared:

```xml
<Host Name="PPRO" Version="14.0"/>
```

CEP matches a bare version as an exact host version rather than a floor, so the panel is filtered out before registration on 26.x. `~/Library/Logs/CSXS/CEP12-PPRO.log` showed no mention of `com.mcp.premiere.cepbridge.panel` at all.

With the documented range the extension registers and the menu entry appears:

```
INFO  Adding extension with id 'com.mcp.premiere.cepbridge.panel'
INFO  Register Extension called for Extension : com.mcp.premiere.cepbridge.panel, ExtensionType : Trusted
INFO  PlugPlugSetMenu() ... {menuId: '8', nameUtf8: 'MCP Bridge (CEP)', extensionId: 'com.mcp.premiere.cepbridge.panel'}
```

### 2. Installation detection

`detectPremiereProInstallation()` checked four hardcoded paths (2023/2024 only), so any newer release logged `Adobe Premiere Pro installation not found in common paths`. This one is cosmetic — the bridge falls back to file communication regardless — but it is misleading while diagnosing the first problem.

Now the install root is scanned and the newest `Adobe Premiere Pro *` entry wins, which covers 2025, 2026 and future years without another edit.

The `readdir` result is guarded with `Array.isArray` because `src/__tests__/bridge/index.test.ts` mocks `fs.promises` and leaves `readdir` returning `undefined`.

## Verification

Premiere Pro **26.3.2** on macOS 15 (Darwin 25.5.0), Node 24.18.0.

- `npm test` — 158/158 passing
- `npm run setup:doctor` — all checks ok
- Bridge log now reports `Found Adobe Premiere Pro at: /Applications/Adobe Premiere Pro 2026`
- Live calls against an open project:

```json
// verify_premiere_connection
{ "success": true, "status": "connected", "bridge": "responsive",
  "premiere": { "version": "26.3.2", "build": "2" },
  "project": { "name": "Untitled.prproj", "sequenceCount": 1 },
  "activeSequence": { "name": "Sequence 01" } }

// list_sequences
{ "success": true, "count": 1, "sequences": [
  { "name": "Sequence 01", "width": 1920, "height": 1080,
    "duration": 35.2018333333333, "videoTrackCount": 3, "audioTrackCount": 3 } ] }
```

No behaviour change for 2023/2024 installs: the manifest range still starts at 14.0, and the scan finds the same directories the old path list covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
