### PR TITLE
Make MCP bridge undoable and auto-start, fix marker colors

### DIFF
--- a/cep-plugin/bridge-cep.js
+++ b/cep-plugin/bridge-cep.js
@@ -140,6 +140,14 @@
         this.loadConfig();
         this.updateUI();
         this.startCommandPolling();
+        // Auto-start so agents can talk without a manual "Start Bridge" click.
+        // Stop Bridge still works; a reload of the panel will start again.
+        try {
+            this.startBridge();
+            this.log('Bridge auto-started on panel load.', 'info');
+        } catch (e) {
+            this.log('Bridge auto-start failed: ' + e.message, 'error');
+        }
     };
 
     MCPPremiereBridge.prototype.getTempDirectory = function() {
@@ -235,6 +243,29 @@
         }, command.timeoutMs);
     };
 
+    /**
+     * Wrap host scripts in a Premiere undo group so every MCP mutation is one Ctrl+Z.
+     * Skips when the script already manages beginUndoGroup itself.
+     */
+    MCPPremiereBridge.prototype.wrapScriptWithUndoGroup = function(script, label) {
+        if (!script || /beginUndoGroup\s*\(/.test(script)) return script;
+        var safeLabel = String(label || 'MCP Bridge').replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        return [
+            '(function(){',
+            '  var __mcpUndoOpened = false;',
+            '  try { app.beginUndoGroup("' + safeLabel + '"); __mcpUndoOpened = true; }',
+            '  catch (e0) { try { app.project.beginUndoGroup("' + safeLabel + '"); __mcpUndoOpened = true; } catch (e1) {} }',
+            '  try {',
+            script,
+            '  } finally {',
+            '    if (__mcpUndoOpened) {',
+            '      try { app.endUndoGroup(); } catch (e2) { try { app.project.endUndoGroup(); } catch (e3) {} }',
+            '    }',
+            '  }',
+            '})();'
+        ].join('\n');
+    };
+
     MCPPremiereBridge.prototype.executeExtendScript = function(script, callback, requestedTimeoutMs) {
         var self = this;
         try {
@@ -250,7 +281,8 @@
                 return;
             }
 
-            var fullScript = EXTENDSCRIPT_COMPAT_HELPERS + '\n' + script;
+            var undoWrapped = this.wrapScriptWithUndoGroup(script, 'MCP Bridge');
+            var fullScript = EXTENDSCRIPT_COMPAT_HELPERS + '\n' + undoWrapped;
             var settled = false;
             // Honor a per-command timeout from the server (batch operations request up to 300s).
             // Fall back to 45s when the server does not specify one, and never go below it.

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5737,7 +5737,17 @@ export class PremiereProTools {
           var marker = sequence.markers.createMarker(${time});
           marker.name = ${JSON.stringify(name)};
           ${comment ? `marker.comments = ${JSON.stringify(comment)};` : ''}
-          ${color ? `marker.setColorByIndex(${color === 'red' ? '5' : color === 'green' ? '3' : color === 'blue' ? '1' : '0'});` : ''}
+          // Color indices: 0 green, 1 red, 2 purple, 3 orange, 4 yellow, 5 white, 6 blue, 7 cyan
+          ${color ? `marker.setColorByIndex(${
+            color === 'red' ? '1' :
+            color === 'purple' ? '2' :
+            color === 'orange' ? '3' :
+            color === 'yellow' || color === 'tan' ? '4' :
+            color === 'white' ? '5' :
+            color === 'blue' ? '6' :
+            color === 'cyan' || color === 'turquoise' || color === 'aquamarine' ? '7' :
+            color === 'green' ? '0' : '0'
+          });` : ''}
           ${duration && duration > 0 ? `marker.end = ${time + duration};` : ''}
 
           return JSON.stringify({
@@ -5814,7 +5824,16 @@ export class PremiereProTools {
             if (marker.guid === ${JSON.stringify(markerId)}) {
               ${updates.name ? `marker.name = ${JSON.stringify(updates.name)};` : ''}
               ${updates.comment ? `marker.comments = ${JSON.stringify(updates.comment)};` : ''}
-              ${updates.color ? `marker.setColorByIndex(${updates.color === 'red' ? '5' : updates.color === 'green' ? '3' : updates.color === 'blue' ? '1' : '0'});` : ''}
+              ${updates.color ? `marker.setColorByIndex(${
+                updates.color === 'red' ? '1' :
+                updates.color === 'purple' ? '2' :
+                updates.color === 'orange' ? '3' :
+                updates.color === 'yellow' || updates.color === 'tan' ? '4' :
+                updates.color === 'white' ? '5' :
+                updates.color === 'blue' ? '6' :
+                updates.color === 'cyan' || updates.color === 'turquoise' || updates.color === 'aquamarine' ? '7' :
+                updates.color === 'green' ? '0' : '0'
+              });` : ''}
               found = true;
               break;
             }


### PR DESCRIPTION
## Summary
- Wrap every CEP ExtendScript call in `beginUndoGroup` / `endUndoGroup` so MCP timeline edits are a single Ctrl+Z (skips if the script already opens its own group).
- Auto-start the MCP Bridge when the CEP panel loads (Stop Bridge still works; panel reload starts again).
- Fix `add_marker` / `update_marker` color name mapping to Premiere `setColorByIndex` values (red was incorrectly mapped to white/index 5).

## Test plan
- [ ] Reload MCP Bridge CEP panel — confirm it auto-starts without clicking Start Bridge
- [ ] Run a mutating MCP tool (e.g. razor or add_marker) — confirm Ctrl+Z undoes it as one step
- [ ] `add_marker` with `color: "red"` and `color: "white"` — confirm red and white swatches match Premiere indices 1 and 5
- [ ] Stop Bridge still disconnects; panel reload auto-starts again

Made with [Cursor](https://cursor.com)