### PR TITLE
Act on the object the caller named, with the value they sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ All notable changes are documented here. Releases use semantic versioning.
   resolved, then renaming it and, with `clearContents`, emptying it.
 - Caller-supplied strings interpolated into generated ExtendScript are now serialised, closing an
   arbitrary-code-execution path and fixing ordinary names containing a double quote.
+- Fixed `set_sequence_settings` never writing anything. It compared the requested width and
+  height against the current ones, wrote no settings, and reported a match; a caller asking for
+  a different frame size got `success: true` and an unchanged sequence. It now applies the
+  settings and reports what it wrote. Frame size can be changed after creation — assigned
+  through `getSettings()`/`setSettings()` and confirmed by read-back on 26.0.2.
 ### Breaking
 
 - `move_clip` now rejects `newTrackIndex` instead of accepting and ignoring it. The parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes are documented here. Releases use semantic versioning.
 
+## [Unreleased]
+
+- Fixed `add_marker`, `update_marker`, `delete_marker`, `list_markers`, `lock_track` and
+  `toggle_track_visibility` ignoring the required `sequenceId` and always operating on the
+  active sequence. They now act on the requested sequence and return a truthful error when the
+  ID resolves to nothing, instead of reporting `success: true` against the wrong timeline.
+- Fixed `list_sequence_tracks` and `delete_track` silently falling back to the active sequence
+  when `sequenceId` did not resolve. `list_sequence_tracks` also no longer echoes the requested
+  ID back next to a different sequence's name.
+- `delete_track` now works across sequences. Premiere exposes no DOM track-deletion API, so it
+  falls through to the QE DOM, which reaches any sequence Premiere has open rather than only the
+  active one. A sequence QE cannot address is reported by name instead of having a track deleted
+  from whichever timeline is on screen.
+- Fixed `create_bin` and `import_folder` resolving a named parent with `children[name]`, which
+  never matches: `ProjectItemCollection` is index-only, so the lookup always fell through to the
+  project root while the response echoed the requested name back.
+- Fixed `add_to_timeline` reporting a pre-existing clip as the one it placed, and removing linked
+  audio matched against that clip's start time, whenever the placement could not be confirmed.
+- Fixed `insertMode` being accepted and echoed but never applied; `insert` now inserts and shifts
+  rather than overwriting.
+- Fixed `duplicate_sequence` falling back to the active sequence when the clone could not be
+  resolved, then renaming it and, with `clearContents`, emptying it.
+- Caller-supplied strings interpolated into generated ExtendScript are now serialised, closing an
+  arbitrary-code-execution path and fixing ordinary names containing a double quote.
+### Breaking
+
+- `move_clip` now rejects `newTrackIndex` instead of accepting and ignoring it. The parameter
+  never moved a clip between tracks; callers that passed it were silently getting a time-only
+  move. Use `move_clip_to_track`, which on this build is a remove-and-reinsert: it can overwrite
+  whatever occupies the destination and gives the clip a new id, so it is a separate call rather
+  than an option here.
+- `add_marker` and `update_marker` now reject a `color` outside the eight-name palette instead of
+  silently storing green. Any name Premiere does not have was previously accepted and produced a
+  green marker, so a caller asking for `magenta` got green and no error.
+- Tools that resolve a `sequenceId` now fail when it does not resolve, where many previously fell
+  back to the active sequence and reported success. Callers relying on a bad or stale id to mean
+  "use whatever is open" will now see an error; pass no id for that behaviour.
+
+- Sequence-scoped marker and track tools now reject an empty `sequenceId` at the schema layer
+  and report the resolved `sequenceId`/`sequenceName` they acted on.
+
 ## [1.1.6] - 2026-08-05
 
 - Added `get_capabilities`, a read-only report of local bridge installation, catalog coverage, and optional live connection status.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -2,11 +2,15 @@
 
 This file tracks current, confirmed limits. It is no longer a backlog of already-fixed prototype bugs.
 
-## Current State (May 16, 2026)
+## Current State (August 13, 2026)
 
 The current built tool catalog exposes:
 
-- `104` tools
+- `283` tools (`112` declared in `src/tools/index.ts`, `171` in `src/tools/expanded.ts`)
+
+Counted from the built catalog with `getAvailableTools().length`, not from this file.
+The previous figure of `104` was stale by a wide margin; check it against the build
+rather than trusting the number written here.
 
 The last broad live sweep in this repository was run on March 4, 2026:
 
@@ -35,6 +39,82 @@ Reason:
 - This is a detection-only tool -- it never cuts anything itself. Use the returned
   intervals with `split_clip`/`ripple_delete`/`razor_timeline_at_time` to actually remove
   silence from a sequence.
+
+### QE reaches sequences Premiere has open, not only the active one
+
+Status: corrects an earlier claim in this file
+
+An earlier revision stated that "QE only reaches `qe.project.getActiveSequence()`; there is
+no QE accessor for an arbitrary sequence", and that the resulting limit was "specific to the
+QE deletion path". Both statements are wrong, and the second one was wrong in a way that hid
+real bugs: the same pattern appeared at fourteen sites in `src/tools/index.ts` and seven in
+`src/tools/expanded.ts`.
+
+What is actually true, verified live against 26.0.2:
+
+- `qe.project.getSequenceAt(i)` exists and returns a QE sequence exposing `guid`, which equals
+  the DOM's `sequenceID`. Matching on it addresses an arbitrary sequence exactly, with no name
+  matching and no assumption that QE and DOM index orders agree.
+- A QE sequence resolved that way can be mutated while a *different* sequence is active. Proven
+  by adding a track to a non-active sequence and confirming the active one was untouched.
+- `qe.project.numSequences` over-reports. It counts sequences that `getSequenceAt()` then
+  refuses to return, throwing `Unknown error exception`, so each index must be guarded
+  separately or a throw partway through aborts the scan before the target is reached.
+- What QE genuinely restricts is which sequences it exposes at all. A sequence created by
+  `duplicate_sequence` and never opened in a timeline is invisible to `getSequenceAt()` — even
+  while it is the active sequence. `getActiveSequence()` still returns a working handle for it,
+  so it is used as a fallback, but only once its `guid` confirms it is the sequence the caller
+  asked for.
+
+Current behavior of `delete_track`:
+
+- the target does **not** have to be the active sequence, only addressable by QE
+- a sequence QE cannot reach is reported by name with `requiresOpenSequence: true`, replacing
+  the earlier and inaccurate `requiresActiveSequence`
+- Premiere still exposes no DOM track-deletion API: `sequence.videoTracks.deleteTrack` and
+  `sequence.audioTracks.deleteTrack` are both `undefined`. That part of the original note holds.
+
+### QE track items are not the DOM clip list
+
+Status: confirmed behavior, easy to get wrong
+
+A QE track's items include gaps and transitions, so `qeTrack.getItemAt(domClipIndex)` addresses
+a different item as soon as anything precedes the target. A test sequence holding three clips
+with one gap reports five QE items: DOM clip `2` is QE item `3`, and QE item `2` is the gap.
+
+Applying an effect through the DOM index therefore landed on the gap and returned
+`success: true` having modified nothing. Resolve QE items by matching `start.ticks` against the
+DOM clip and skipping anything whose `type` is not `"Clip"`.
+
+### The UXP panel does not load
+
+Status: confirmed non-functional
+
+`uxp-plugin/` is shipped and registers cleanly, but the panel body renders empty in
+Premiere Pro 26.0.2. Three independent faults, any one of which is sufficient:
+
+- `bridge.js` calls `require('premiere')`. The Premiere UXP module is `premierepro`;
+  there is no `premiere` module, so the require throws at load and nothing in the
+  file is ever defined.
+- Nothing calls `require('uxp').entrypoints.setup(...)`. A manifestVersion 5 panel
+  has to register its entrypoint or the body is never attached.
+- The manifest declares `permissions`; the key UXP reads is `requiredPermissions`.
+
+Confirmed by contrast with an unrelated UXP plugin that does load and run in the
+same Premiere install: it requires `premierepro`, calls `entrypoints.setup()`, and
+uses `requiredPermissions`.
+
+`index.html` is also CEP-style markup — 29 plain HTML elements, no Spectrum
+components, and a large `<style>` block. UXP supports a restricted subset and
+silently renders nothing for markup outside it, so the UI would need rebuilding
+even once the script loads.
+
+Practical consequence:
+
+- the CEP panel is the only working bridge
+- the file-queue race fixed on the server and CEP sides is still present in
+  `uxp-plugin/bridge.js`; it was left alone deliberately, because a fix there
+  cannot be executed or verified
 
 ### `get_render_queue_status`
 
@@ -118,6 +198,41 @@ These issues were real and are now resolved in the current code:
 - `export_frame` called a non-existent API and now uses the QE export path
 - `remove_effect` was advertised even though actual removal is not supported and has been removed from the tool catalog
 - the branded workflow response returned the wrong message due to object spread order
+- `add_marker`, `update_marker`, `delete_marker`, `list_markers`, `lock_track` and
+  `toggle_track_visibility` required a `sequenceId` and then ignored it, always operating on
+  `app.project.activeSequence`. A bogus sequence ID returned `success: true` while mutating the
+  wrong timeline. They now resolve the ID and return a truthful error when it matches nothing.
+- `list_sequence_tracks` and `delete_track` resolved `sequenceId` but silently fell back to the
+  active sequence when the lookup missed; `list_sequence_tracks` additionally echoed the
+  requested ID back beside the wrong sequence's name. Both now fail truthfully instead.
+- `duplicate_sequence` fell back to `app.project.activeSequence` whenever it could not resolve
+  the clone, then renamed it and, with `clearContents=true`, removed every clip from it. That
+  destroyed the user's open timeline and reported `success: true` with the clip count it had
+  just deleted. The fallback now has to prove the sequence is newly created, and refuses to
+  clear anything it cannot identify.
+- Fourteen tools resolved a clip by id — which searches every sequence in the project — and then
+  applied the change through `qe.project.getActiveSequence()`. `color_correct` on a clip in a
+  non-active sequence added Lumetri Color to the identically placed clip in the active one and
+  left the requested clip untouched, reporting success.
+- Five of those tools additionally indexed QE track items with the DOM clip index, so a clip
+  sitting behind a gap received nothing at all while the call reported success.
+- `export_frame` exported from whatever was on screen rather than the requested sequence, and
+  wrote to `shot.png.png` while reporting `shot.png`, because the QE export methods append the
+  format extension to the path they are given. It now addresses the requested sequence and
+  reports the path actually written. Its argument probe also treated "did not throw" as "did
+  export", so an accepted-but-inert call ended the probe and reported success over an empty disk.
+- A single control character anywhere in a clip or marker name made the entire tool response
+  unparseable, and a NUL truncated it. Premiere does ship a `JSON.stringify`, but it emits
+  control characters raw, so the conformant implementation is now installed unconditionally
+  rather than only as a fallback. U+2028 in an argument broke the generated script instead —
+  legal in JSON, but a line terminator to a JavaScript parser — and is re-escaped as the script
+  is assembled. Arguments carrying a NUL are refused by name, since Premiere truncates at one
+  when assigning and reports success for the shortened value.
+- `findClip()` and `markerCollectionForTool()` returned a `fail()` string when a `sequenceId`
+  could not be resolved. A string is truthy, so every `if (!x)` guard downstream was dead code:
+  `get_sequence_markers_by_type` with a bogus id answered "this sequence has no markers" with
+  `success: true`, and the clip tools reported a JavaScript TypeError instead of the resolver's
+  own message.
 
 ## Release Guidance
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -47,7 +47,7 @@ Status: corrects an earlier claim in this file
 An earlier revision stated that "QE only reaches `qe.project.getActiveSequence()`; there is
 no QE accessor for an arbitrary sequence", and that the resulting limit was "specific to the
 QE deletion path". Both statements are wrong, and the second one was wrong in a way that hid
-real bugs: the same pattern appeared at fourteen sites in `src/tools/index.ts` and seven in
+real bugs: the same pattern appeared at sixteen sites in `src/tools/index.ts` and nine in
 `src/tools/expanded.ts`.
 
 What is actually true, verified live against 26.0.2:
@@ -221,13 +221,11 @@ These issues were real and are now resolved in the current code:
   format extension to the path they are given. It now addresses the requested sequence and
   reports the path actually written. Its argument probe also treated "did not throw" as "did
   export", so an accepted-but-inert call ended the probe and reported success over an empty disk.
-- A single control character anywhere in a clip or marker name made the entire tool response
-  unparseable, and a NUL truncated it. Premiere does ship a `JSON.stringify`, but it emits
-  control characters raw, so the conformant implementation is now installed unconditionally
-  rather than only as a fallback. U+2028 in an argument broke the generated script instead —
-  legal in JSON, but a line terminator to a JavaScript parser — and is re-escaped as the script
-  is assembled. Arguments carrying a NUL are refused by name, since Premiere truncates at one
-  when assigning and reports success for the shortened value.
+- A single control character anywhere in a clip or marker name makes the entire tool response
+  unparseable, and a NUL truncates it. **Not addressed here.** The escaper, the U+2028 repair
+  and the NUL refusal all live in the bridge, and are covered by the separate change to
+  serialization and the file handoff; this file previously described them as done in this
+  branch, which they are not.
 - `findClip()` and `markerCollectionForTool()` returned a `fail()` string when a `sequenceId`
   could not be resolved. A string is truthy, so every `if (!x)` guard downstream was dead code:
   `get_sequence_markers_by_type` with a bogus id answered "this sequence has no markers" with

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
+    "acorn": "^8.15.0",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.2",

--- a/src/__tests__/bridge/bridge-injection.test.ts
+++ b/src/__tests__/bridge/bridge-injection.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The bridge builds scripts too, and no tool-side guard can see them.
+ *
+ * The injection sweep drives tools through a stub whose only member is
+ * `executeScript`, so any tool delegating to a real bridge method — `importMedia`,
+ * `createSequence`, `renderSequence` and the rest — throws before emitting and
+ * drops out of the sweep. Sixteen tools are in that position, and raw
+ * interpolation added inside those methods went unnoticed with the whole suite
+ * green.
+ *
+ * So the real bridge is driven here, with the filesystem stubbed, and whatever it
+ * writes to the command file is held to the same contract as a tool's script: it
+ * must parse as ES3 and must not run a payload.
+ *
+ * Methods are enumerated from the prototype rather than listed, so a new one is
+ * covered without anyone remembering to add it here.
+ */
+
+import vm from 'vm';
+import { parse } from 'acorn';
+import { PremiereProBridge } from '../../bridge/index.js';
+import { promises as fs } from 'fs';
+
+jest.mock('fs', () => ({
+  promises: {
+    mkdir: jest.fn(), access: jest.fn(), readdir: jest.fn(), writeFile: jest.fn(),
+    readFile: jest.fn(), unlink: jest.fn(), rename: jest.fn(), rm: jest.fn(),
+  }
+}));
+
+jest.mock('node:crypto', () => ({ randomUUID: jest.fn(() => 'test-uuid-1234') }));
+
+const BREAKOUT_DOUBLE = 'zz"); __OWNED = true; ("';
+const BREAKOUT_SINGLE = "zz'; __OWNED = true; var __x = '";
+const BREAKOUT_BACKSLASH = 'zz\\"); __OWNED = true; ("';
+const PAYLOADS = [BREAKOUT_DOUBLE, BREAKOUT_SINGLE, BREAKOUT_BACKSLASH];
+
+/** Lifecycle and transport; driving these tests the harness, not a script. */
+const NOT_SCRIPT_BUILDERS = new Set([
+  'constructor', 'initialize', 'cleanup', 'executeScript', 'waitForResponse',
+  'detectPremiereProInstallation', 'initializeCommunication', 'isConnected',
+  'getTempDir', 'runDiagnostics',
+]);
+
+function payloadRuns(script: string): boolean {
+  const sandbox: Record<string, unknown> = {
+    __OWNED: false,
+    app: {
+      enableQE() {},
+      project: {
+        name: 'p', sequences: { numSequences: 0 },
+        rootItem: { name: 'r', nodeId: 'r', children: { numItems: 0 }, createBin: () => ({ name: 'b', nodeId: 'n' }) },
+        activeSequence: null, importFiles: () => true, importSequences: () => true,
+        newSequence: () => ({ sequenceID: 's', name: 'n' }),
+      },
+      encoder: { encodeSequence: () => true, launchEncoder: () => true },
+    },
+    qe: { project: {} },
+    JSON,
+    File: function () { return { exists: false, fsName: '/tmp/x' }; },
+    Folder: function () { return { exists: false, create: () => false }; },
+  };
+  vm.createContext(sandbox);
+  try {
+    vm.runInContext(`(function(){${script}})()`, sandbox, { timeout: 2000 });
+  } catch {
+    // A missing DOM member is expected; only the flag matters.
+  }
+  return sandbox.__OWNED === true;
+}
+
+describe('scripts the bridge builds itself', () => {
+  const mockFs = fs as jest.Mocked<typeof fs>;
+
+  const readyBridge = async (): Promise<PremiereProBridge> => {
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.access.mockRejectedValue(new Error('Not found'));
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.rename.mockResolvedValue(undefined);
+    mockFs.unlink.mockResolvedValue(undefined);
+    // Answer immediately so nothing waits on a panel that is not there.
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ success: true, result: '{}' }));
+
+    const bridge = new PremiereProBridge();
+    await bridge.initialize();
+    return bridge;
+  };
+
+  /** Every script written during one call. */
+  const scriptsWritten = (): string[] =>
+    mockFs.writeFile.mock.calls
+      .map(([, payload]) => payload)
+      .filter((payload): payload is string => typeof payload === 'string' && payload.includes('"script"'))
+      .map((payload) => JSON.parse(payload).script as string);
+
+  const scriptBuilders = (bridge: PremiereProBridge): string[] =>
+    Object.getOwnPropertyNames(Object.getPrototypeOf(bridge))
+      .filter((name) => !NOT_SCRIPT_BUILDERS.has(name))
+      .filter((name) => typeof (bridge as unknown as Record<string, unknown>)[name] === 'function');
+
+  it('cannot be broken out of through any method that builds one', async () => {
+    const probe = await readyBridge();
+    const methods = scriptBuilders(probe);
+
+    const escaped: string[] = [];
+    const unparseable: string[] = [];
+    let checked = 0;
+
+    for (const method of methods) {
+      for (const payload of PAYLOADS) {
+        // Arity is unknown and varies; the payload is passed in every position a
+        // method might read a string from.
+        for (const arity of [1, 2, 3, 4]) {
+          jest.clearAllMocks();
+          const bridge = await readyBridge();
+          const call = (bridge as unknown as Record<string, (...args: unknown[]) => Promise<unknown>>)[method];
+          try {
+            await call.apply(bridge, Array.from({ length: arity }, () => payload));
+          } catch {
+            // Argument validation and missing DOM members are fine; anything the
+            // method wrote before failing is still inspected below.
+          }
+
+          for (const script of scriptsWritten()) {
+            checked++;
+            try {
+              parse(script, { ecmaVersion: 3, allowReturnOutsideFunction: true });
+            } catch {
+              unparseable.push(`${method}/${arity}`);
+              continue;
+            }
+            if (payloadRuns(script)) escaped.push(`${method}/${arity}`);
+          }
+        }
+      }
+    }
+
+    // A floor, so a harness that stopped driving anything cannot pass silently.
+    expect(methods.length).toBeGreaterThan(10);
+    expect(checked).toBeGreaterThan(20);
+
+    // Execution is the contract: no caller value may run as code.
+    expect([...new Set(escaped)]).toEqual([]);
+
+    // Parse failures are NOT asserted, and the reason is worth stating rather than
+    // hiding. Arity and parameter types are unknown here, so the payload also
+    // lands in positions a method interpolates as a number (`var t = ${time};`).
+    // A string there cannot parse, which is a property of passing the wrong type
+    // rather than of quoting -- the tool layer's schema makes it unreachable, and
+    // `addToTimeline` is the only method that shows it. Asserting on it would fail
+    // for a defect that does not exist. Recorded so a reader can see the shape.
+    expect(unparseable.every((site) => site.startsWith('addToTimeline'))).toBe(true);
+  }, 300_000);
+});

--- a/src/__tests__/bridge/injection.test.ts
+++ b/src/__tests__/bridge/injection.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The highest-severity fix in this branch had no test at all.
+ *
+ * Reverting `JSON.stringify(sequenceId)` to `"${sequenceId}"` in
+ * bridge.addToTimeline re-opens arbitrary ExtendScript execution, and without
+ * these tests the entire suite stays green. Against the unescaped version a
+ * caller-supplied id can run `app.project.saveAs(...)` and return a forged
+ * `{success: true}` while no clip is placed.
+ *
+ * These tests execute the generated script against a mock host, so they fail on
+ * the behaviour rather than on the shape of the source.
+ */
+
+import vm from 'vm';
+import { PremiereProBridge } from '../../bridge/index.js';
+import { promises as fs } from 'fs';
+
+jest.mock('fs', () => ({
+  promises: {
+    mkdir: jest.fn(), access: jest.fn(), readdir: jest.fn(),
+    writeFile: jest.fn(), readFile: jest.fn(), unlink: jest.fn(),
+    rename: jest.fn(), rm: jest.fn(),
+  }
+}));
+jest.mock('node:crypto', () => ({ randomUUID: jest.fn(() => 'test-uuid-1234') }));
+
+/** Closes the string, runs code, and returns a forged success payload. */
+const HOSTILE = 'zz"); __OWNED = true; return JSON.stringify({success:true,forged:true}); ("';
+
+describe('ExtendScript injection', () => {
+  const mockFs = fs as jest.Mocked<typeof fs>;
+  // Written straight to the polled name here. Publishing via a scratch file and
+  // a rename is a separate change to the transport and is not part of this one.
+  const commandPath = '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.PREMIERE_TEMP_DIR = '/tmp/premiere-mcp-bridge-test';
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.access.mockRejectedValue(new Error('Not found'));
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.unlink.mockResolvedValue(undefined);
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ result: { ok: true } }));
+  });
+  afterEach(() => { delete process.env.PREMIERE_TEMP_DIR; });
+
+  const emittedFor = async (sequenceId: string, projectItemId = 'item'): Promise<string> => {
+    const bridge = new PremiereProBridge();
+    await bridge.initialize();
+    await bridge.addToTimeline(sequenceId, projectItemId, 0, 1, false);
+    const call = mockFs.writeFile.mock.calls.find(
+      ([, payload]) => typeof payload === 'string' && payload.includes('"script"'),
+    );
+    return JSON.parse(call![1] as string).script as string;
+  };
+
+  /**
+   * Runs the emitted script against a mock host.
+   *
+   * `withSequence` matters: __findSequence runs first and returns early when it
+   * finds nothing, so a projectItemId payload is never reached unless the id
+   * before it resolves. Without this the projectItemId test passes vacuously —
+   * it did, until the revert check caught it.
+   */
+  const runAgainstMockHost = (script: string, withSequence = false) => {
+    const sequences: Record<string, unknown> = withSequence
+      ? { numSequences: 1, 0: { sequenceID: 'seq', name: 'Mock', videoTracks: { numTracks: 0 }, audioTracks: { numTracks: 0 } } }
+      : { numSequences: 0 };
+    const sandbox: Record<string, unknown> = {
+      __OWNED: false,
+      app: {
+        project: {
+          sequences,
+          rootItem: { nodeId: 'root', children: { numItems: 0 } },
+          saveAs: () => { (sandbox as { __SAVED?: boolean }).__SAVED = true; },
+        },
+      },
+      qe: undefined,
+      $: { writeln: () => {} },
+    };
+    vm.createContext(sandbox);
+    let returned: unknown;
+    try {
+      returned = vm.runInContext(script, sandbox, { timeout: 5000 });
+    } catch (error) {
+      returned = { threw: String(error) };
+    }
+    return { sandbox, returned };
+  };
+
+  it('does not execute code smuggled through sequenceId', async () => {
+    const script = await emittedFor(HOSTILE);
+    const { sandbox } = runAgainstMockHost(script);
+
+    expect(sandbox.__OWNED).toBe(false);
+  });
+
+  it('does not let a hostile id forge a success response', async () => {
+    const script = await emittedFor(HOSTILE);
+    const { returned } = runAgainstMockHost(script);
+
+    const parsed = typeof returned === 'string' ? JSON.parse(returned) : returned;
+    expect(parsed).not.toHaveProperty('forged');
+    expect(parsed.success).toBe(false);
+  });
+
+  it('does not execute code smuggled through projectItemId', async () => {
+    // The second interpolated id on the same path, missed by the first sweep.
+    const script = await emittedFor('seq', HOSTILE);
+    const { sandbox } = runAgainstMockHost(script, true);
+
+    expect(sandbox.__OWNED).toBe(false);
+  });
+
+  it('carries the hostile id through as inert data', async () => {
+    // Escaping must not silently drop the value: the error still names what was
+    // asked for, it just cannot execute.
+    const script = await emittedFor(HOSTILE);
+    const { returned } = runAgainstMockHost(script);
+
+    const parsed = typeof returned === 'string' ? JSON.parse(returned) : returned;
+    expect(String(parsed.error)).toContain('zz');
+  });
+
+  it('emits a quoted literal rather than a bare interpolation', async () => {
+    const script = await emittedFor(HOSTILE);
+
+    expect(script).toContain(JSON.stringify(HOSTILE));
+    expect(script).not.toContain(`__findSequence("${HOSTILE}")`);
+  });
+
+  it('survives an ordinary name containing a double quote', async () => {
+    // The benign half of the same defect: a bin called 12" produced a script that
+    // would not parse at all.
+    const script = await emittedFor('a "quoted" name');
+    const { returned } = runAgainstMockHost(script);
+
+    const parsed = typeof returned === 'string' ? JSON.parse(returned) : returned;
+    expect(parsed).not.toHaveProperty('threw');
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/src/__tests__/bridge/prelude-helpers.test.ts
+++ b/src/__tests__/bridge/prelude-helpers.test.ts
@@ -1,0 +1,170 @@
+/**
+ * __qeSequenceFor and __findQeClipByDomClip, executed rather than greped.
+ *
+ * Sixteen tools rely on these two to reach the right sequence and the right clip.
+ * Gutting either one — deleting the guid check, or reducing the item match to
+ * getItemAt(0) — used to leave the full suite green, because the only coverage
+ * was a source-text assertion on the expanded.ts copy.
+ *
+ * The helpers live in the prelude the bridge prepends to every script, so the
+ * script has to be captured on its way to the command file to get at them.
+ */
+
+import vm from 'vm';
+import { PremiereProBridge } from '../../bridge/index.js';
+import { promises as fs } from 'fs';
+
+jest.mock('fs', () => ({
+  promises: {
+    mkdir: jest.fn(), access: jest.fn(), readdir: jest.fn(),
+    writeFile: jest.fn(), readFile: jest.fn(), unlink: jest.fn(),
+    rename: jest.fn(), rm: jest.fn(),
+  }
+}));
+jest.mock('node:crypto', () => ({ randomUUID: jest.fn(() => 'test-uuid-1234') }));
+
+describe('prelude QE helpers', () => {
+  const mockFs = fs as jest.Mocked<typeof fs>;
+  const commandPath = '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.PREMIERE_TEMP_DIR = '/tmp/premiere-mcp-bridge-test';
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.access.mockRejectedValue(new Error('Not found'));
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.unlink.mockResolvedValue(undefined);
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ result: { ok: true } }));
+  });
+  afterEach(() => { delete process.env.PREMIERE_TEMP_DIR; });
+
+  /** Runs the prelude's helper definitions, then `extra`, in an isolated context. */
+  const runWithPrelude = async (extra: string): Promise<Record<string, unknown>> => {
+    const bridge = new PremiereProBridge();
+    await bridge.initialize();
+    await bridge.executeScript('return 1;');
+    const call = mockFs.writeFile.mock.calls.find(
+      ([, payload]) => typeof payload === 'string' && payload.includes('"script"'),
+    );
+    const full = JSON.parse(call![1] as string).script as string;
+
+    // Everything up to the first non-helper statement is the prelude.
+    const prelude = full.slice(0, full.indexOf('(function(){'));
+
+    const sandbox: Record<string, unknown> = { app: { enableQE: () => {} } };
+    vm.createContext(sandbox);
+    vm.runInContext(prelude + '\n' + extra, sandbox);
+    return sandbox;
+  };
+
+  describe('__qeSequenceFor', () => {
+    it('matches on guid, not on position', async () => {
+      const sandbox = await runWithPrelude(`
+        qe = { project: {
+          numSequences: 3,
+          getSequenceAt: function (i) { return [{guid:'other-a'}, {guid:'WANTED'}, {guid:'other-b'}][i]; },
+          getActiveSequence: function () { return {guid:'other-a'}; }
+        }};
+        __result = __qeSequenceFor({ sequenceID: 'WANTED' });
+      `);
+
+      expect((sandbox.__result as { guid: string }).guid).toBe('WANTED');
+    });
+
+    it('returns null rather than some other sequence', async () => {
+      const sandbox = await runWithPrelude(`
+        qe = { project: {
+          numSequences: 2,
+          getSequenceAt: function (i) { return [{guid:'a'}, {guid:'b'}][i]; },
+          getActiveSequence: function () { return {guid:'a'}; }
+        }};
+        __result = __qeSequenceFor({ sequenceID: 'NOT-PRESENT' });
+      `);
+
+      expect(sandbox.__result).toBeNull();
+    });
+
+    it('keeps scanning past an index that throws', async () => {
+      // numSequences over-reports: it counts sequences getSequenceAt then refuses
+      // to return, throwing "Unknown error exception". One try around the whole
+      // loop aborts the scan before the target index is ever reached.
+      const sandbox = await runWithPrelude(`
+        qe = { project: {
+          numSequences: 3,
+          getSequenceAt: function (i) {
+            if (i === 0) { throw new Error('Unknown error exception'); }
+            return [null, {guid:'x'}, {guid:'WANTED'}][i];
+          },
+          getActiveSequence: function () { return null; }
+        }};
+        __result = __qeSequenceFor({ sequenceID: 'WANTED' });
+      `);
+
+      expect((sandbox.__result as { guid: string }).guid).toBe('WANTED');
+    });
+
+    it('falls back to the active sequence only when its guid matches', async () => {
+      // The fallback exists because a duplicate never opened in a timeline is
+      // invisible to getSequenceAt even while active. The guid check is what stops
+      // it from becoming the original wrong-sequence bug again.
+      const sandbox = await runWithPrelude(`
+        qe = { project: {
+          numSequences: 0,
+          getSequenceAt: function () { return null; },
+          getActiveSequence: function () { return {guid:'ACTIVE-ONE'}; }
+        }};
+        __matching = __qeSequenceFor({ sequenceID: 'ACTIVE-ONE' });
+        __mismatched = __qeSequenceFor({ sequenceID: 'WANTED' });
+      `);
+
+      expect((sandbox.__matching as { guid: string }).guid).toBe('ACTIVE-ONE');
+      expect(sandbox.__mismatched).toBeNull();
+    });
+  });
+
+  describe('__findQeClipByDomClip', () => {
+    it('skips gaps instead of counting them as clips', async () => {
+      // Three DOM clips with one gap: DOM index 2 is QE item 3, and QE item 2 is
+      // the gap. Positional indexing lands on the gap and silently does nothing.
+      const sandbox = await runWithPrelude(`
+        var track = { numItems: 4, getItemAt: function (i) {
+          return [
+            { type: 'Clip',  start: { ticks: '0' } },
+            { type: 'Clip',  start: { ticks: '100' } },
+            { type: 'Empty', start: { ticks: '200' } },
+            { type: 'Clip',  start: { ticks: '300' } }
+          ][i];
+        }};
+        __result = __findQeClipByDomClip(track, { start: { ticks: '300' } });
+      `);
+
+      expect((sandbox.__result as { start: { ticks: string } }).start.ticks).toBe('300');
+    });
+
+    it('never returns a non-clip item', async () => {
+      const sandbox = await runWithPrelude(`
+        var track = { numItems: 2, getItemAt: function (i) {
+          return [{ type: 'Empty', start:{ticks:'0'} }, { type: 'Transition', start:{ticks:'5'} }][i];
+        }};
+        __result = __findQeClipByDomClip(track, { start: { ticks: '0' } });
+      `);
+
+      expect(sandbox.__result).toBeNull();
+    });
+
+    it('prefers an exact tick match over a nearer-looking index', async () => {
+      const sandbox = await runWithPrelude(`
+        var track = { numItems: 3, getItemAt: function (i) {
+          return [
+            { type: 'Clip', start: { ticks: '500' } },
+            { type: 'Clip', start: { ticks: '250' } },
+            { type: 'Clip', start: { ticks: '100' } }
+          ][i];
+        }};
+        __result = __findQeClipByDomClip(track, { start: { ticks: '100' } });
+      `);
+
+      expect((sandbox.__result as { start: { ticks: string } }).start.ticks).toBe('100');
+    });
+  });
+});

--- a/src/__tests__/bridge/unconfirmed-placement.test.ts
+++ b/src/__tests__/bridge/unconfirmed-placement.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Destructive fallbacks that acted on an object the code could not identify.
+ *
+ * Both defects below are present in upstream main and were not introduced by any
+ * of the fix work — they were found by an independent audit that executed the
+ * generated scripts against a mock host.
+ *
+ * add_to_timeline: when the identity check could not find the clip it had just
+ * placed, it fell back to `track.clips[numItems - 1]` — whatever happened to be
+ * last on the track. It then reported that clip's id, name and times back as the
+ * placement, AND used its start time to drive the linkAudio=false sweep, which
+ * removes audio clips matching that time. So a placement that did nothing could
+ * delete an unrelated audio clip and report success. Demonstrated on a mock host:
+ * asked to place at t=30, placed nothing, reported a pre-existing clip at t=0, and
+ * removed a voiceover from A1.
+ *
+ * create_bin / import_folder: a parentBinName that did not resolve fell through to
+ * the project root, so the bin or import landed somewhere the caller never asked
+ * for while the response echoed the parent name back as though it had been used.
+ */
+
+import { PremiereProBridge } from '../../bridge/index.js';
+import { PremiereProTools } from '../../tools/index.js';
+import { promises as fs } from 'fs';
+
+jest.mock('fs', () => ({
+  promises: {
+    mkdir: jest.fn(), access: jest.fn(), readdir: jest.fn(),
+    writeFile: jest.fn(), readFile: jest.fn(), unlink: jest.fn(),
+    rename: jest.fn(), rm: jest.fn(),
+  }
+}));
+jest.mock('node:crypto', () => ({ randomUUID: jest.fn(() => 'test-uuid-1234') }));
+
+describe('placement that cannot be confirmed', () => {
+  const mockFs = fs as jest.Mocked<typeof fs>;
+  // Written straight to the polled name here. Publishing via a scratch file and
+  // a rename is a separate change to the transport and is not part of this one.
+  const commandPath = '/tmp/premiere-mcp-bridge-test/command-test-uuid-1234.json';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.PREMIERE_TEMP_DIR = '/tmp/premiere-mcp-bridge-test';
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.access.mockRejectedValue(new Error('Not found'));
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.unlink.mockResolvedValue(undefined);
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ result: { ok: true } }));
+  });
+  afterEach(() => { delete process.env.PREMIERE_TEMP_DIR; });
+
+  const emitted = async (): Promise<string> => {
+    const bridge = new PremiereProBridge();
+    await bridge.initialize();
+    await bridge.addToTimeline('seq', 'item', 0, 30, false);
+    const call = mockFs.writeFile.mock.calls.find(
+      ([, payload]) => typeof payload === 'string' && payload.includes('"script"'),
+    );
+    return JSON.parse(call![1] as string).script as string;
+  };
+
+  it('never guesses at the last clip on the track', async () => {
+    const script = await emitted();
+
+    // The specific expression that made an unconfirmed placement destructive.
+    expect(script).not.toContain('track.clips[track.clips.numItems - 1]');
+  });
+
+  it('fails instead of reporting a clip it did not place', async () => {
+    const script = await emitted();
+
+    expect(script).toContain('Placement could not be confirmed');
+    expect(script).toContain('no linked audio was removed');
+    // Asserting the message alone passes even with the fallback restored, since
+    // the guard still exists below it and simply never runs. Pin the absence of
+    // any assignment to placedClip after the identity search.
+    expect(script).not.toMatch(/placedClip\s*=\s*track\.clips\[/);
+  });
+
+  it('reaches the audio sweep only through a confirmed clip', async () => {
+    // The sweep keys off placedClip.start.seconds, so it must be unreachable
+    // whenever placedClip could not be identified.
+    const script = await emitted();
+    const guard = script.indexOf('Placement could not be confirmed');
+    const sweep = script.indexOf('unlinkedAudioRemoved');
+
+    expect(guard).toBeGreaterThan(-1);
+    expect(sweep).toBeGreaterThan(guard);
+    // Ordering alone is not enough: with the fallback restored the guard still
+    // precedes the sweep and simply never fires.
+    expect(script).not.toMatch(/placedClip\s*=\s*track\.clips\[/);
+  });
+
+
+  describe('insertMode', () => {
+    /**
+     * The tool accepted insertMode, echoed it back in every response, and never
+     * passed it on: placement was unconditionally track.overwriteClip(). A caller
+     * asking to insert-and-shift had existing footage destroyed and was told the
+     * opposite. Both methods exist on video and audio tracks in 26.0.2.
+     */
+    const scriptFor = async (mode?: string): Promise<string> => {
+      mockFs.readFile.mockResolvedValue(JSON.stringify({ result: { ok: true } }));
+      const bridge = new PremiereProBridge();
+      await bridge.initialize();
+      await bridge.addToTimeline('seq', 'item', 0, 1, true, undefined, undefined, mode);
+      const call = mockFs.writeFile.mock.calls.find(
+      ([, payload]) => typeof payload === 'string' && payload.includes('"script"'),
+    );
+      return JSON.parse(call![1] as string).script as string;
+    };
+
+    it('inserts when asked to insert', async () => {
+      const script = await scriptFor('insert');
+
+      expect(script).toContain('track.insertClip(projectItem,');
+      expect(script).toContain('var requestedInsert = true;');
+    });
+
+    it('overwrites by default', async () => {
+      const script = await scriptFor();
+
+      expect(script).toContain('track.overwriteClip(projectItem,');
+      expect(script).toContain('var requestedInsert = false;');
+    });
+
+    it('refuses rather than falling back to the destructive method', async () => {
+      // Falling back to overwrite when insertClip is missing would delete the
+      // footage the caller was trying to shift.
+      const script = await scriptFor('insert');
+
+      expect(script).toContain('typeof track.insertClip !== "function"');
+      expect(script).toContain('Refusing rather than overwriting');
+    });
+
+    it('reports the mode actually used, not the mode requested', async () => {
+      const script = await scriptFor('insert');
+
+      expect(script).toContain('insertMode: "insert"');
+    });
+  });
+});
+
+describe('bins that do not resolve', () => {
+  let tools: PremiereProTools;
+  let bridge: { executeScript: jest.Mock };
+
+  beforeEach(() => {
+    bridge = { executeScript: jest.fn().mockResolvedValue({ success: true }) };
+    tools = new PremiereProTools(bridge as any);
+  });
+
+  it('create_bin refuses a parent it cannot find', async () => {
+    await tools.executeTool('create_bin', { name: 'B-Roll', parentBinName: 'Nope' });
+    const script = bridge.executeScript.mock.calls[0][0] as string;
+
+    expect(script).toContain('Parent bin not found');
+    expect(script).not.toContain('|| app.project.rootItem;');
+  });
+
+  it('create_bin still allows an explicit root-level bin', async () => {
+    await tools.executeTool('create_bin', { name: 'B-Roll' });
+    const script = bridge.executeScript.mock.calls[0][0] as string;
+
+    // With no parent named, the root default is correct and must survive.
+    expect(script).toContain('var parentBin = app.project.rootItem;');
+    expect(script).not.toContain('Parent bin not found');
+  });
+
+  it('import_folder refuses a destination it cannot find', async () => {
+    await tools.executeTool('import_folder', { folderPath: '/tmp/x', binName: 'Nope' });
+    const script = bridge.executeScript.mock.calls[0][0] as string;
+
+    expect(script).toContain('Destination bin not found');
+    expect(script).not.toContain('|| app.project.rootItem;');
+  });
+});
+
+describe('the tool layer, not just the bridge', () => {
+  /**
+   * The insertMode tests above call bridge.addToTimeline directly, which is why a
+   * tool layer that never forwarded the argument stayed invisible: the bridge did
+   * the right thing with a value it was never given.
+   */
+  it('forwards insertMode from the tool to the bridge', async () => {
+    let received: unknown = 'NOT PASSED';
+    const fake = {
+      addToTimeline: async (...args: unknown[]) => { received = args[7]; return { success: true }; },
+      executeScript: async () => ({ success: true }),
+    };
+    const tools = new PremiereProTools(fake as never);
+
+    await tools.executeTool('add_to_timeline', {
+      sequenceId: 'S', projectItemId: 'P', trackIndex: 0, time: 1, insertMode: 'insert',
+    });
+
+    expect(received).toBe('insert');
+  });
+
+  it('does not report a mode the bridge was never told about', async () => {
+    let received: unknown = 'NOT PASSED';
+    const fake = {
+      addToTimeline: async (...args: unknown[]) => { received = args[7]; return { success: true }; },
+      executeScript: async () => ({ success: true }),
+    };
+    const tools = new PremiereProTools(fake as never);
+
+    const result = await tools.executeTool('add_to_timeline', {
+      sequenceId: 'S', projectItemId: 'P', trackIndex: 0, time: 1, insertMode: 'insert',
+    });
+
+    // Echoing insert while the bridge overwrites is the defect itself.
+    expect(result.insertMode).toBe(received);
+  });
+});
+
+describe('bins are resolved by walking, not by string key', () => {
+  /**
+   * ProjectItemCollection is index-only: children["Name"] returns undefined even
+   * when a child of that name exists, verified against 26.0.2. Resolving that way
+   * means a named parent never matches, so failing on a falsy result would turn
+   * "created in the wrong place" into "never created at all".
+   */
+  let tools: PremiereProTools;
+  let bridge: { executeScript: jest.Mock };
+
+  beforeEach(() => {
+    bridge = { executeScript: jest.fn().mockResolvedValue({ success: true }) };
+    tools = new PremiereProTools(bridge as never);
+  });
+
+  it.each(['create_bin', 'import_folder'])('%s walks children by name', async (tool) => {
+    const args = tool === 'create_bin'
+      ? { name: 'B-Roll', parentBinName: 'Footage' }
+      : { folderPath: '/tmp/x', binName: 'Footage' };
+
+    await tools.executeTool(tool, args);
+    const script = bridge.executeScript.mock.calls[0][0] as string;
+
+    expect(script).toContain('__binByName(');
+    // Assert on the EMITTED script, not the template. `${JSON.stringify(` never
+    // survives emission, so a not.toContain on it can never fail -- the same
+    // source-versus-emitted confusion this change exists to fix.
+    expect(script).not.toContain('children["Footage"]');
+    expect(script).toContain('__binByName(app.project.rootItem, "Footage")');
+  });
+});
+
+describe('duplicate_sequence', () => {
+  let tools: PremiereProTools;
+  let bridge: { executeScript: jest.Mock };
+
+  beforeEach(() => {
+    bridge = { executeScript: jest.fn().mockResolvedValue({ success: true }) };
+    tools = new PremiereProTools(bridge as never);
+  });
+
+  const scriptFor = async (args: Record<string, unknown>): Promise<string> => {
+    await tools.executeTool('duplicate_sequence', args);
+    return bridge.executeScript.mock.calls[0][0] as string;
+  };
+
+  it('will not mistake the open timeline for the copy', async () => {
+    // clone() returns the clone's ProjectItem on current builds, so the code falls
+    // back to the active sequence when it cannot resolve a Sequence. Taken
+    // unconditionally that hands back the user's own timeline, which is then renamed
+    // and, with clearContents, emptied -- and reported as success.
+    const script = await scriptFor({ sequenceId: 'seq', newName: 'copy', clearContents: true });
+
+    expect(script).toContain('var priorActiveId = null;');
+    expect(script).toContain('activeCandidateId !== String(originalSeq.sequenceID)');
+    expect(script).toContain('activeCandidateId !== priorActiveId');
+  });
+
+  it('refuses to clear anything when the copy cannot be identified', async () => {
+    const script = await scriptFor({ sequenceId: 'seq', newName: 'copy', clearContents: true });
+
+    expect(script).toContain('Nothing was cleared.');
+    expect(script).toContain('cleared: false');
+  });
+
+  it('captures the prior active sequence before cloning, not after', async () => {
+    // Reading it after clone() would record the clone itself, and the guard would
+    // then accept the clone as proof that it is not the user's timeline.
+    const script = await scriptFor({ sequenceId: 'seq', newName: 'copy' });
+    const captured = script.indexOf('priorActiveId = app.project.activeSequence');
+    const cloned = script.indexOf('originalSeq.clone()');
+
+    expect(captured).toBeGreaterThan(-1);
+    expect(cloned).toBeGreaterThan(captured);
+  });
+});

--- a/src/__tests__/helpers/schema-args.ts
+++ b/src/__tests__/helpers/schema-args.ts
@@ -1,0 +1,139 @@
+/**
+ * Building arguments for every tool, from its schema.
+ *
+ * Shared by the injection and undefined-identifier guards. Both used to drive
+ * tools from a hand-maintained argument map, which decided what they could see:
+ * a key missing from the map meant the branch guarded by that key was never
+ * emitted, so a defect inside it was invisible while the suite stayed green.
+ *
+ * Nothing here dispatches on `_def.typeName`. It is `undefined` in this zod
+ * build, and a guard that relied on it silently degraded to a default for every
+ * field — reaching a third of the tools a working dispatch reaches.
+ */
+
+export type Schema = {
+  constructor?: { name?: string };
+  shape?: Record<string, Schema>;
+  element?: Schema;
+  _def?: {
+    innerType?: Schema; type?: Schema; element?: Schema;
+    values?: unknown[]; options?: Schema[];
+  };
+};
+
+export type ToolLike = { name: string; inputSchema?: { shape?: Record<string, Schema> } };
+
+const kindOf = (s: Schema): string => s?.constructor?.name ?? '';
+
+/** The element schema of an array, across the spellings this zod build uses. */
+const elementOf = (s: Schema): Schema | undefined => s._def?.type ?? s._def?.element ?? s.element;
+
+/** Values that must stay plausible or the tool rejects before emitting anything. */
+const NUMERIC: Record<string, number> = {
+  width: 1920, height: 1080, frameRate: 25, speed: 100, volume: 0, opacity: 100,
+  scale: 100, rotation: 0, level: 0, trackIndex: 0, time: 1, newTime: 2,
+  splitTime: 1, duration: 1,
+};
+
+/**
+ * Candidate strings, tried in order against the field's own schema.
+ *
+ * Several string parameters carry a regex or refinement — `color` is
+ * `/^[0-7]$/` — and a value that fails it is rejected before the tool emits
+ * anything, so the tool drops out of the sweep silently. Rather than keep a map
+ * of field name to legal value and let it rot, each candidate is offered to the
+ * schema and the first one it accepts is used.
+ */
+const CANDIDATES = [
+  'x', '0', '1', 'video', 'audio', 'green', 'start', 'end', 'png', 'both',
+  'Cross Dissolve', '/tmp/f.xml', '00:00:01:00', 'true', 'none', 'default',
+];
+
+/** Preferred value where several are legal and one exercises more of the tool. */
+const STRINGY: Record<string, string> = { position: 'end', format: 'png' };
+
+const accepts = (schema: Schema, value: unknown): boolean => {
+  const parser = schema as unknown as { safeParse?: (v: unknown) => { success: boolean } };
+  if (typeof parser.safeParse !== 'function') return true;
+  try {
+    return parser.safeParse(value).success;
+  } catch {
+    return false;
+  }
+};
+
+/** The first candidate this schema accepts, preferring a named override. */
+function stringFor(schema: Schema, key: string): string {
+  const preferred = STRINGY[key];
+  if (preferred !== undefined && accepts(schema, preferred)) return preferred;
+  for (const candidate of CANDIDATES) if (accepts(schema, candidate)) return candidate;
+  return preferred ?? 'x';
+}
+
+/** A valid-looking value for one schema node. */
+export function seed(schema: Schema, key = ''): unknown {
+  switch (kindOf(schema)) {
+    case 'ZodOptional':
+    case 'ZodNullable':
+    case 'ZodDefault':
+      return schema._def?.innerType ? seed(schema._def.innerType, key) : 'x';
+    case 'ZodArray': {
+      const element = elementOf(schema);
+      return [element ? seed(element, key) : 'x'];
+    }
+    case 'ZodObject': {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(schema.shape ?? {})) out[k] = seed(v, k);
+      return out;
+    }
+    case 'ZodUnion': {
+      const first = schema._def?.options?.[0];
+      return first ? seed(first, key) : 'x';
+    }
+    case 'ZodEnum':
+      return (schema._def?.values ?? ['start'])[0];
+    case 'ZodNumber':
+      return NUMERIC[key] ?? 1;
+    case 'ZodBoolean':
+      return true;
+    default:
+      return stringFor(schema, key);
+  }
+}
+
+/**
+ * Every declared parameter populated, optionals included.
+ *
+ * Optionals matter most: a tool that emits `${comment ? ... : ''}` only reveals
+ * that branch when `comment` is supplied.
+ */
+export function seedArgs(tool: ToolLike): Record<string, unknown> {
+  const shape = tool.inputSchema?.shape ?? {};
+  const args: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(shape)) args[k] = seed(v, k);
+  return args;
+}
+
+/** Every path in a seeded value that holds a string, as a list of keys/indices. */
+export function stringPaths(value: unknown, prefix: (string | number)[] = []): (string | number)[][] {
+  if (typeof value === 'string') return [prefix];
+  if (Array.isArray(value)) return value.flatMap((v, i) => stringPaths(v, [...prefix, i]));
+  if (value && typeof value === 'object') {
+    return Object.entries(value).flatMap(([k, v]) => stringPaths(v, [...prefix, k]));
+  }
+  return [];
+}
+
+/** A copy of `base` with `payload` substituted at `path`. */
+export function withPayloadAt(base: unknown, path: (string | number)[], payload: string): unknown {
+  if (path.length === 0) return payload;
+  const [head, ...rest] = path;
+  if (Array.isArray(base)) {
+    const copy = [...base];
+    copy[head as number] = withPayloadAt(copy[head as number], rest, payload);
+    return copy;
+  }
+  const copy = { ...(base as Record<string, unknown>) };
+  copy[head as string] = withPayloadAt(copy[head as string], rest, payload);
+  return copy;
+}

--- a/src/__tests__/helpers/schema-args.ts
+++ b/src/__tests__/helpers/schema-args.ts
@@ -11,22 +11,35 @@
  * field — reaching a third of the tools a working dispatch reaches.
  */
 
+/**
+ * Zod exposes these publicly. Reaching into `_def` is what produced the bugs this
+ * helper exists to avoid: `_def.typeName` is undefined here, `_def.values` is
+ * undefined for enums (members live on `.options`), and `_def.type` is the string
+ * "array" rather than the element schema. Each wrong guess degraded silently to a
+ * default that the schema then rejected, dropping the tool from every sweep.
+ */
 export type Schema = {
   constructor?: { name?: string };
   shape?: Record<string, Schema>;
   element?: Schema;
-  _def?: {
-    innerType?: Schema; type?: Schema; element?: Schema;
-    values?: unknown[]; options?: Schema[];
-  };
+  options?: Schema[] | string[];
+  unwrap?: () => Schema;
+  safeParse?: (value: unknown) => { success: boolean };
 };
 
 export type ToolLike = { name: string; inputSchema?: { shape?: Record<string, Schema> } };
 
 const kindOf = (s: Schema): string => s?.constructor?.name ?? '';
 
-/** The element schema of an array, across the spellings this zod build uses. */
-const elementOf = (s: Schema): Schema | undefined => s._def?.type ?? s._def?.element ?? s.element;
+/** Does this schema accept the value? The only question that actually matters. */
+export const accepts = (schema: Schema, value: unknown): boolean => {
+  if (typeof schema?.safeParse !== 'function') return true;
+  try {
+    return schema.safeParse(value).success;
+  } catch {
+    return false;
+  }
+};
 
 /** Values that must stay plausible or the tool rejects before emitting anything. */
 const NUMERIC: Record<string, number> = {
@@ -35,70 +48,64 @@ const NUMERIC: Record<string, number> = {
   splitTime: 1, duration: 1,
 };
 
-/**
- * Candidate strings, tried in order against the field's own schema.
- *
- * Several string parameters carry a regex or refinement — `color` is
- * `/^[0-7]$/` — and a value that fails it is rejected before the tool emits
- * anything, so the tool drops out of the sweep silently. Rather than keep a map
- * of field name to legal value and let it rot, each candidate is offered to the
- * schema and the first one it accepts is used.
- */
-const CANDIDATES = [
+/** Tried in order against the field's own schema; the first accepted one wins. */
+const CANDIDATES: unknown[] = [
   'x', '0', '1', 'video', 'audio', 'green', 'start', 'end', 'png', 'both',
   'Cross Dissolve', '/tmp/f.xml', '00:00:01:00', 'true', 'none', 'default',
+  1, 0, true, false, [], {}, null,
 ];
 
 /** Preferred value where several are legal and one exercises more of the tool. */
 const STRINGY: Record<string, string> = { position: 'end', format: 'png' };
 
-const accepts = (schema: Schema, value: unknown): boolean => {
-  const parser = schema as unknown as { safeParse?: (v: unknown) => { success: boolean } };
-  if (typeof parser.safeParse !== 'function') return true;
-  try {
-    return parser.safeParse(value).success;
-  } catch {
-    return false;
-  }
-};
-
-/** The first candidate this schema accepts, preferring a named override. */
-function stringFor(schema: Schema, key: string): string {
-  const preferred = STRINGY[key];
-  if (preferred !== undefined && accepts(schema, preferred)) return preferred;
-  for (const candidate of CANDIDATES) if (accepts(schema, candidate)) return candidate;
-  return preferred ?? 'x';
-}
-
-/** A valid-looking value for one schema node. */
-export function seed(schema: Schema, key = ''): unknown {
+/** A structural guess, from public accessors only. */
+function shapedGuess(schema: Schema, key: string): unknown {
   switch (kindOf(schema)) {
     case 'ZodOptional':
     case 'ZodNullable':
-    case 'ZodDefault':
-      return schema._def?.innerType ? seed(schema._def.innerType, key) : 'x';
-    case 'ZodArray': {
-      const element = elementOf(schema);
-      return [element ? seed(element, key) : 'x'];
+    case 'ZodDefault': {
+      const inner = typeof schema.unwrap === 'function' ? schema.unwrap() : undefined;
+      return inner ? seed(inner, key) : 'x';
     }
+    case 'ZodArray':
+      return [schema.element ? seed(schema.element, key) : 'x'];
     case 'ZodObject': {
       const out: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(schema.shape ?? {})) out[k] = seed(v, k);
       return out;
     }
     case 'ZodUnion': {
-      const first = schema._def?.options?.[0];
-      return first ? seed(first, key) : 'x';
+      const first = (schema.options ?? [])[0];
+      return first && typeof first === 'object' ? seed(first as Schema, key) : 'x';
     }
-    case 'ZodEnum':
-      return (schema._def?.values ?? ['start'])[0];
+    case 'ZodEnum': {
+      const members = (schema.options ?? []) as string[];
+      return members.length ? members[0] : 'x';
+    }
     case 'ZodNumber':
       return NUMERIC[key] ?? 1;
     case 'ZodBoolean':
       return true;
     default:
-      return stringFor(schema, key);
+      return STRINGY[key] ?? 'x';
   }
+}
+
+/**
+ * A value the schema accepts.
+ *
+ * The structural guess is checked rather than trusted: if an accessor is wrong for
+ * this zod build, the guess is rejected and candidates are tried instead, so a
+ * mis-read schema costs a slower path rather than a silently dropped tool.
+ */
+export function seed(schema: Schema, key = ''): unknown {
+  const guess = shapedGuess(schema, key);
+  if (accepts(schema, guess)) return guess;
+
+  const preferred = STRINGY[key];
+  if (preferred !== undefined && accepts(schema, preferred)) return preferred;
+  for (const candidate of CANDIDATES) if (accepts(schema, candidate)) return candidate;
+  return guess;
 }
 
 /**
@@ -111,6 +118,34 @@ export function seedArgs(tool: ToolLike): Record<string, unknown> {
   const shape = tool.inputSchema?.shape ?? {};
   const args: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(shape)) args[k] = seed(v, k);
+
+  const schema = tool.inputSchema as unknown as Schema | undefined;
+  if (!schema || accepts(schema, args)) return args;
+
+  // Some tools carry cross-field rules that supplying everything violates -- 
+  // trim_clip refuses outPoint and duration together. Drop one optional at a
+  // time until the whole object is accepted, so the tool still emits instead of
+  // dropping out of every sweep.
+  const optionalKeys = Object.entries(shape)
+    .filter(([, v]) => kindOf(v) === 'ZodOptional' || kindOf(v) === 'ZodDefault')
+    .map(([k]) => k);
+
+  for (const key of optionalKeys) {
+    const trimmed = { ...args };
+    delete trimmed[key];
+    if (accepts(schema, trimmed)) return trimmed;
+  }
+  return args;
+}
+
+/** Only the parameters a tool actually requires, so omitted-branch code is emitted too. */
+export function seedRequiredArgs(tool: ToolLike): Record<string, unknown> {
+  const shape = tool.inputSchema?.shape ?? {};
+  const args: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(shape)) {
+    if (kindOf(v) === 'ZodOptional' || kindOf(v) === 'ZodDefault') continue;
+    args[k] = seed(v, k);
+  }
   return args;
 }
 

--- a/src/__tests__/helpers/schema-args.ts
+++ b/src/__tests__/helpers/schema-args.ts
@@ -52,8 +52,12 @@ const NUMERIC: Record<string, number> = {
 const CANDIDATES: unknown[] = [
   'x', '0', '1', 'video', 'audio', 'green', 'start', 'end', 'png', 'both',
   'Cross Dissolve', '/tmp/f.xml', '00:00:01:00', 'true', 'none', 'default',
-  1, 0, true, false, [], {}, null,
+  1, 0, true, false,
 ];
+// Deliberately absent: [], {} and null. A schema accepts them, so they satisfy
+// the acceptance check while carrying no string to fuzz -- which turned a broken
+// array accessor into a silent loss of coverage rather than a visible rejection.
+
 
 /** Preferred value where several are legal and one exercises more of the tool. */
 const STRINGY: Record<string, string> = { position: 'end', format: 'png' };
@@ -99,11 +103,15 @@ function shapedGuess(schema: Schema, key: string): unknown {
  * mis-read schema costs a slower path rather than a silently dropped tool.
  */
 export function seed(schema: Schema, key = ''): unknown {
-  const guess = shapedGuess(schema, key);
-  if (accepts(schema, guess)) return guess;
-
+  // A named preference comes first. Falling through to the structural guess took
+  // the first enum member instead, which silently moved add_transition_to_clip
+  // from 'end' to 'start' and stopped exercising the branch that preference was
+  // chosen for.
   const preferred = STRINGY[key];
   if (preferred !== undefined && accepts(schema, preferred)) return preferred;
+
+  const guess = shapedGuess(schema, key);
+  if (accepts(schema, guess)) return guess;
   for (const candidate of CANDIDATES) if (accepts(schema, candidate)) return candidate;
   return guess;
 }
@@ -171,4 +179,66 @@ export function withPayloadAt(base: unknown, path: (string | number)[], payload:
   const copy = { ...(base as Record<string, unknown>) };
   copy[head as string] = withPayloadAt(copy[head as string], rest, payload);
   return copy;
+}
+
+/**
+ * The argument names a tool actually reads, taken from the script it emits.
+ *
+ * The 171 "expanded" tools declare `z.record(z.string(), z.any())` — a free-form
+ * bag with no `.shape` — so seeding from the schema yields `{}` and they carry no
+ * fuzzable position at all. That silently excluded 60% of the catalogue from the
+ * injection sweep while every floor and every acceptance check still passed,
+ * because an empty object is a perfectly valid record.
+ *
+ * Their generated script names what it reads (`args.sequenceId`, `args.name`), so
+ * the names come from there. Derived rather than hand-listed, so a tool that
+ * starts reading a new argument is covered without anyone remembering to add it.
+ */
+export function argNamesFromScript(script: string, tool: string, includeHelpers = true): string[] {
+  const start = script.indexOf(`case "${tool}":`);
+  if (start === -1) return [];
+
+  // Consume leading fall-through labels, then stop at the next label after code.
+  const lines = script.slice(start).split('\n');
+  const isLabel = (line: string): boolean => /^\s*case "/.test(line);
+  const body: string[] = [];
+  let seenStatement = false;
+  for (const line of lines) {
+    if (isLabel(line) && seenStatement) break;
+    if (!isLabel(line) && line.trim()) seenStatement = true;
+    body.push(line);
+  }
+
+  // The shared helpers above the switch read arguments too -- rename_track never
+  // names a sequence itself, it calls targetSequence(), which reads
+  // args.sequenceId. Scoping to the case block alone missed every argument
+  // consumed that way, which is most of the targeting surface.
+  const firstCase = script.indexOf('case "');
+  const helperRegion = firstCase === -1 ? '' : script.slice(0, firstCase);
+
+  const names = new Set<string>();
+  for (const region of includeHelpers ? [body.join('\n'), helperRegion] : [body.join('\n')]) {
+    for (const match of region.matchAll(/args\.([A-Za-z_][A-Za-z0-9_]*)/g)) {
+      if (match[1]) names.add(match[1]);
+    }
+  }
+  return [...names];
+}
+
+/**
+ * Arguments for a tool whose schema declares no fields.
+ *
+ * Values are chosen the same way as elsewhere: a name that looks numeric or
+ * boolean gets that, everything else a string, so the tool is not rejected before
+ * it emits.
+ */
+export function seedFreeFormArgs(names: string[]): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+  for (const name of names) {
+    if (name in NUMERIC) args[name] = NUMERIC[name];
+    else if (/^(is|has|should|enable|enabled|visible|locked|muted|selected|ripple|linked)/.test(name)) args[name] = true;
+    else if (/(index|count|duration|time|level|width|height|rate|speed|volume|opacity|scale|rotation)$/i.test(name)) args[name] = 1;
+    else args[name] = STRINGY[name] ?? 'x';
+  }
+  return args;
 }

--- a/src/__tests__/tools/generated-script-syntax.test.ts
+++ b/src/__tests__/tools/generated-script-syntax.test.ts
@@ -1,6 +1,7 @@
 import { parse } from "acorn";
 import { expandedToolNames, executeExpandedTool } from "../../tools/expanded";
 import { PremiereProTools } from "../../tools/index";
+import { seedArgs } from "../helpers/schema-args";
 
 /**
  * The expanded tools are emitted as ExtendScript from TypeScript template
@@ -40,7 +41,7 @@ describe("generated ExtendScript is syntactically valid", () => {
    * This used `new Function`, which compiles under whatever V8 the test runner
    * ships. That accepts a great deal ExtendScript will not, including a raw
    * U+2028 inside a string literal — the precise failure
-   * repairScriptLineTerminators exists to prevent, so the guard could not catch
+   * a U+2028 in a generated string literal produces, so the guard could not catch
    * the bug it was written for. Verified: V8 accepts raw U+2028, U+2029, `const`
    * and ES5 getters; acorn in ES3 mode rejects all four.
    *
@@ -176,21 +177,6 @@ describe("generated ExtendScript is syntactically valid", () => {
      * no-arg call is usually rejected before a script is generated. Filling
      * plausible arguments from the schema gets most of them to emit.
      */
-    const argsFor = (tool: { inputSchema?: { shape?: Record<string, unknown> } }): Record<string, unknown> => {
-      const shape = tool.inputSchema?.shape ?? {};
-      const args: Record<string, unknown> = {};
-      for (const key of Object.keys(shape)) {
-        const field = shape[key] as { _def?: { typeName?: string } };
-        const name = field?._def?.typeName;
-        if (name === "ZodNumber") args[key] = 1;
-        else if (name === "ZodBoolean") args[key] = true;
-        else if (name === "ZodArray") args[key] = [];
-        else if (name === "ZodObject") args[key] = {};
-        else args[key] = "x";
-      }
-      return args;
-    };
-
     const localScripts = async (): Promise<Array<[string, string]>> => {
       const captured: Array<[string, string]> = [];
       const expanded = new Set<string>([...expandedToolNames]);
@@ -205,7 +191,7 @@ describe("generated ExtendScript is syntactically valid", () => {
           executeScript: async (s: string) => { script = s; return { success: true }; },
         } as never);
         try {
-          await tools.executeTool(tool.name, argsFor(tool as never));
+          await tools.executeTool(tool.name, seedArgs(tool as never));
         } catch {
           // Schema rejections and handlers that never reach the bridge are fine;
           // an empty capture is skipped below.
@@ -233,13 +219,16 @@ describe("generated ExtendScript is syntactically valid", () => {
 
     it("actually captures a meaningful number of them", async () => {
       // Without this, a broken capture would make the parse check pass vacuously
-      // -- which is exactly how the expanded-only version hid the gap. Around 36
-      // of the 112 local tools emit a script under generic arguments; the rest are
-      // rejected by their schema first or are handled entirely in TypeScript. This
-      // is a floor to detect a broken harness, not a coverage target.
+      // -- which is exactly how the expanded-only version hid the gap.
+      //
+      // This used to build arguments by dispatching on `_def.typeName`, which is
+      // undefined in this zod build, so every field became the string "x" and any
+      // tool with a numeric parameter was rejected before emitting. It reached 36
+      // of the 112 local tools and the floor was calibrated to that broken number.
+      // Seeding from the schema reaches 77.
       const captured = await localScripts();
 
-      expect(captured.length).toBeGreaterThanOrEqual(30);
+      expect(captured.length).toBeGreaterThanOrEqual(70);
     }, 120_000);
   });
 
@@ -254,7 +243,7 @@ describe("generated ExtendScript is syntactically valid", () => {
     it("rejects a raw U+2028 inside a string literal", () => {
       // ExtendScript is ES3, where a line terminator inside a string literal is a
       // syntax error. V8 accepts it (ES2019 made it legal), so the old check could
-      // not catch the very bug repairScriptLineTerminators prevents.
+      // not catch a U+2028 smuggled into a generated string literal.
       expect(() => parses(`var a = "x${LS}y";`)).toThrow();
     });
 

--- a/src/__tests__/tools/generated-script-syntax.test.ts
+++ b/src/__tests__/tools/generated-script-syntax.test.ts
@@ -1,0 +1,271 @@
+import { parse } from "acorn";
+import { expandedToolNames, executeExpandedTool } from "../../tools/expanded";
+import { PremiereProTools } from "../../tools/index";
+
+/**
+ * The expanded tools are emitted as ExtendScript from TypeScript template
+ * literals. A backslash escape written for the *ExtendScript* string is
+ * consumed by the *template literal* first, so `\"` reaches the host as a bare
+ * `"` and silently terminates the message string it was meant to protect.
+ *
+ * That failure is invisible to `tsc` — the template literal is still a valid
+ * TypeScript string — and it does not break one tool, it breaks every tool in
+ * the file, because they all share one generated script. It reaches the host as
+ * a generic "ExtendScript execution failed via CEP evalScript()".
+ *
+ * So parse what is actually emitted, for every tool, rather than trusting that
+ * the TypeScript compiled.
+ */
+describe("generated ExtendScript is syntactically valid", () => {
+  const capture = async (name: string): Promise<string> => {
+    let script = "";
+    const bridge = {
+      executeScript: async (source: string) => {
+        script = source;
+        return { success: true, data: {} };
+      },
+    };
+    try {
+      await executeExpandedTool(bridge as any, name, {});
+    } catch {
+      // A tool may reject on missing arguments before it emits anything. That
+      // is not what this suite is about — an empty capture is handled below.
+    }
+    return script;
+  };
+
+  /**
+   * Parsed as ES3, which is what ExtendScript is — not as modern JavaScript.
+   *
+   * This used `new Function`, which compiles under whatever V8 the test runner
+   * ships. That accepts a great deal ExtendScript will not, including a raw
+   * U+2028 inside a string literal — the precise failure
+   * repairScriptLineTerminators exists to prevent, so the guard could not catch
+   * the bug it was written for. Verified: V8 accepts raw U+2028, U+2029, `const`
+   * and ES5 getters; acorn in ES3 mode rejects all four.
+   *
+   * Not exhaustive — acorn's ES3 mode still tolerates reserved words as property
+   * names and trailing commas, both of which ES3 forbids. It is a strict
+   * improvement, not a complete ES3 conformance check.
+   */
+  const parses = (source: string): void => {
+    // allowReturnOutsideFunction mirrors the bridge, which wraps these bodies in
+    // an IIFE before they reach the host.
+    parse(source, { ecmaVersion: 3, allowReturnOutsideFunction: true });
+  };
+
+  it.each([...expandedToolNames])("%s", async (name) => {
+    const script = await capture(name);
+
+    // A handful of tools are implemented in TypeScript rather than as generated
+    // ExtendScript. They emit nothing through the bridge and have nothing to
+    // parse; the shared-script tools are the ones this guard exists for.
+    if (script.length === 0) return;
+
+    expect(() => parses(script)).not.toThrow();
+  });
+
+  it("covers the shared generated script", async () => {
+    // If the capture shim silently stopped working, every case above would pass
+    // vacuously. Pin that the bulk of the catalog really is being parsed.
+    const captured = await Promise.all(
+      [...expandedToolNames].map((n) => capture(n)),
+    );
+    expect(captured.filter((s) => s.length > 0).length).toBeGreaterThan(100);
+  });
+
+  it("rejects an escape that collapses before it reaches the host", async () => {
+    // Pin the specific regression: a double-quoted ExtendScript string whose
+    // quotes were written as \" in the template literal. Guards the seven QE
+    // fail() messages that took down all 171 tools.
+    const script = await capture("add_tracks");
+    expect(script).toContain("Could not address sequence '");
+    expect(script).not.toContain('Could not address sequence "" +');
+  });
+
+  describe('lookup helpers signal "not found" with null', () => {
+    /**
+     * findClip() and markerCollectionForTool() used to return fail(seqErr) when
+     * the caller's sequenceId could not be resolved. fail() returns a JSON
+     * string, and a string is truthy, so every downstream
+     * `if (!x) return fail(...)` guard was dead code: callers went straight on
+     * to read .clip or .getFirstMarker off a string.
+     *
+     * Proven against a live 26.0.2 host before the fix:
+     *   get_sequence_markers_by_type({sequenceId: 'NOPE'})
+     *     -> {success: true, data: {count: 0, markers: []}}
+     *   rename_clip({sequenceId: 'NOPE', ...})
+     *     -> {success: false, error: 'undefined is not an object'}
+     * The first is the dangerous one: a bogus id answered "this sequence has no
+     * markers" with success: true.
+     */
+    const helperBody = (script, name) => {
+      const start = script.indexOf('function ' + name + '(');
+      expect(start).toBeGreaterThan(-1);
+      return script.slice(start, start + 400);
+    };
+
+    it.each(['findClip', 'markerCollectionForTool'])(
+      '%s returns null rather than a fail() string',
+      async (helper) => {
+        const script = await capture('get_clip_markers');
+        const body = helperBody(script, helper);
+
+        expect(body).toContain('pendingSequenceError = seqErr; return null;');
+        expect(body).not.toContain('if (seqErr) return fail(seqErr);');
+      },
+    );
+
+    it('reports the sequence error rather than the generic message', async () => {
+      const script = await capture('get_clip_markers');
+
+      expect(script).toContain('return fail(pendingSequenceError || "Marker collection unavailable")');
+      expect(script).not.toContain('return fail("Marker collection unavailable")');
+    });
+
+    it('prefers the sequence error at every clip lookup guard', async () => {
+      const script = await capture('rename_clip');
+
+      expect(script).toContain('return fail(pendingSequenceError || "Clip not found")');
+      expect(script).not.toContain('return fail("Clip not found")');
+    });
+  });
+
+  describe("qeSequenceFor falls back only to the right sequence", () => {
+    /**
+     * qe.project.getSequenceAt() does not expose every sequence: one made by
+     * duplicate_sequence and never opened in a timeline is invisible to it even
+     * while it is active. Verified against 26.0.2 — getActiveSequence() returns
+     * a working handle for exactly that sequence, guid and addTracks included —
+     * so refusing without trying it gave up work the host can do.
+     *
+     * The guid check is what keeps this from re-becoming the original bug,
+     * where a tool resolved one sequence and then mutated whichever was active.
+     */
+    it("verifies the guid before using the active sequence", async () => {
+      const script = await capture("add_tracks");
+
+      expect(script).toContain("qe.project.getActiveSequence()");
+      expect(script).toContain(
+        "String(activeCandidate.guid) === String(seq.sequenceID)",
+      );
+    });
+
+    it("tries the indexed scan before the active sequence", async () => {
+      const script = await capture("add_tracks");
+      // Scoped to the helper body: the same call appears in prose elsewhere in
+      // the generated script, and a whole-script indexOf finds the comment.
+      const start = script.indexOf("function qeSequenceFor(");
+      const body = script.slice(start, script.indexOf("\n    }", start));
+      const scan = body.indexOf("qe.project.getSequenceAt(qi)");
+      const fallback = body.indexOf("qe.project.getActiveSequence()");
+
+      expect(scan).toBeGreaterThan(-1);
+      expect(fallback).toBeGreaterThan(scan);
+    });
+  });
+
+  describe("the 112 tools declared in index.ts", () => {
+    /**
+     * This suite only ever parsed expanded.ts. A collapsing \\" escape injected
+     * into an index.ts generated script -- the exact failure this file
+     * exists to catch -- and all tests stayed green, because those scripts were
+     * never captured.
+     *
+     * They cannot be driven the same way: each tool has its own zod schema, so a
+     * no-arg call is usually rejected before a script is generated. Filling
+     * plausible arguments from the schema gets most of them to emit.
+     */
+    const argsFor = (tool: { inputSchema?: { shape?: Record<string, unknown> } }): Record<string, unknown> => {
+      const shape = tool.inputSchema?.shape ?? {};
+      const args: Record<string, unknown> = {};
+      for (const key of Object.keys(shape)) {
+        const field = shape[key] as { _def?: { typeName?: string } };
+        const name = field?._def?.typeName;
+        if (name === "ZodNumber") args[key] = 1;
+        else if (name === "ZodBoolean") args[key] = true;
+        else if (name === "ZodArray") args[key] = [];
+        else if (name === "ZodObject") args[key] = {};
+        else args[key] = "x";
+      }
+      return args;
+    };
+
+    const localScripts = async (): Promise<Array<[string, string]>> => {
+      const captured: Array<[string, string]> = [];
+      const expanded = new Set<string>([...expandedToolNames]);
+      const probe = new PremiereProTools({
+        executeScript: async () => ({ success: true }),
+      } as never);
+
+      for (const tool of probe.getAvailableTools()) {
+        if (expanded.has(tool.name)) continue;
+        let script = "";
+        const tools = new PremiereProTools({
+          executeScript: async (s: string) => { script = s; return { success: true }; },
+        } as never);
+        try {
+          await tools.executeTool(tool.name, argsFor(tool as never));
+        } catch {
+          // Schema rejections and handlers that never reach the bridge are fine;
+          // an empty capture is skipped below.
+        }
+        if (script) captured.push([tool.name, script]);
+      }
+      return captured;
+    };
+
+    it("emits a parseable script for every tool that generates one", async () => {
+      const captured = await localScripts();
+      const broken: string[] = [];
+
+      for (const [name, script] of captured) {
+        try {
+          parses(script);
+        } catch (error) {
+          broken.push(`${name}: ${(error as Error).message}`);
+        }
+      }
+
+      expect(broken).toEqual([]);
+      // Captures and parses every local tool; the default limit is not enough.
+    }, 120_000);
+
+    it("actually captures a meaningful number of them", async () => {
+      // Without this, a broken capture would make the parse check pass vacuously
+      // -- which is exactly how the expanded-only version hid the gap. Around 36
+      // of the 112 local tools emit a script under generic arguments; the rest are
+      // rejected by their schema first or are handled entirely in TypeScript. This
+      // is a floor to detect a broken harness, not a coverage target.
+      const captured = await localScripts();
+
+      expect(captured.length).toBeGreaterThanOrEqual(30);
+    }, 120_000);
+  });
+
+  describe("the parser itself", () => {
+    /**
+     * Pins the upgrade from `new Function` to acorn's ES3 mode. Without this the
+     * suite could quietly regress to a modern-JavaScript parser and keep passing
+     * while missing the failures it exists to catch.
+     */
+    const LS = "\u2028";
+
+    it("rejects a raw U+2028 inside a string literal", () => {
+      // ExtendScript is ES3, where a line terminator inside a string literal is a
+      // syntax error. V8 accepts it (ES2019 made it legal), so the old check could
+      // not catch the very bug repairScriptLineTerminators prevents.
+      expect(() => parses(`var a = "x${LS}y";`)).toThrow();
+    });
+
+    it("rejects syntax that only exists after ES3", () => {
+      expect(() => parses("const a = 1;")).toThrow();
+      expect(() => parses("var o = { get x() { return 1; } };")).toThrow();
+    });
+
+    it("still accepts the ES3 the generator actually emits", () => {
+      expect(() => parses('var a = 1; function f(){ return "ok"; } f();')).not.toThrow();
+      expect(() => parses('return JSON.stringify({ ok: true });')).not.toThrow();
+    });
+  });
+});

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { z } from 'zod';
 import { spawn } from 'child_process';
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -98,6 +99,460 @@ describe('PremiereProTools', () => {
   });
 
   describe('executeTool()', () => {
+    describe('marker colours', () => {
+      // Premiere's setColorByIndex() order, verified against 26.0.2 by writing
+      // each index and reading the rendered colour back off the timeline.
+      const EXPECTED_INDEX: Array<[string, number]> = [
+        ['green', 0], ['red', 1], ['purple', 2], ['orange', 3],
+        ['yellow', 4], ['white', 5], ['blue', 6], ['cyan', 7],
+      ];
+
+      it.each(EXPECTED_INDEX)('maps %s to index %i', async (name, index) => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await tools.executeTool('add_marker', {
+          sequenceId: 'seq', time: 1, name: 'm', color: name,
+        });
+
+        const script = mockBridge.executeScript.mock.calls[0][0] as string;
+        expect(script).toContain(`setColorByIndex(${index})`);
+      });
+
+      it('accepts a numeric index directly', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await tools.executeTool('add_marker', {
+          sequenceId: 'seq', time: 1, name: 'm', color: 5,
+        });
+
+        expect(mockBridge.executeScript.mock.calls[0][0]).toContain('setColorByIndex(5)');
+      });
+
+      it('ignores surrounding whitespace and case', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await tools.executeTool('add_marker', {
+          sequenceId: 'seq', time: 1, name: 'm', color: '  PuRPle ',
+        });
+
+        expect(mockBridge.executeScript.mock.calls[0][0]).toContain('setColorByIndex(2)');
+      });
+
+      it('leaves the marker at Premiere\'s default when no colour is given', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await tools.executeTool('add_marker', { sequenceId: 'seq', time: 1, name: 'm' });
+
+        expect(mockBridge.executeScript.mock.calls[0][0]).not.toContain('setColorByIndex');
+      });
+
+      // Premiere silently no-ops an index above 7 and silently truncates a
+      // non-integer, so accepting either would report success for a colour the
+      // caller never gets. Reject before the bridge is touched.
+      it.each([
+        ['an unknown colour name', 'chartreuse'],
+        ['an index above the palette', 8],
+        ['a negative index', -1],
+        ['a non-integer index', 3.5],
+      ])('rejects %s rather than silently defaulting', async (_label, color) => {
+        const result = await tools.executeTool('add_marker', {
+          sequenceId: 'seq', time: 1, name: 'm', color,
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('Invalid arguments');
+        expect(mockBridge.executeScript).not.toHaveBeenCalled();
+      });
+
+      it('applies the same mapping in update_marker', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await tools.executeTool('update_marker', {
+          sequenceId: 'seq', markerId: 'guid', color: 'cyan',
+        });
+
+        expect(mockBridge.executeScript.mock.calls[0][0]).toContain('setColorByIndex(7)');
+      });
+
+      it('does not touch colour when update_marker omits it', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await tools.executeTool('update_marker', {
+          sequenceId: 'seq', markerId: 'guid', name: 'renamed',
+        });
+
+        expect(mockBridge.executeScript.mock.calls[0][0]).not.toContain('setColorByIndex');
+      });
+
+      it('accepts a numeric index sent as a string', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        // Some MCP clients stringify every argument; without this the caller
+        // silently loses index input.
+        await tools.executeTool('add_marker', {
+          sequenceId: 'seq', time: 1, name: 'm', color: '3',
+        });
+
+        expect(mockBridge.executeScript.mock.calls[0][0]).toContain('setColorByIndex(3)');
+      });
+
+      it.each([
+        ['name', 'marker.name = ""'],
+        ['comment', 'marker.comments = ""'],
+      ])('update_marker applies an empty %s instead of silently ignoring it', async (field, expected) => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        // Same truthiness class the colour fix removed: `updates.name ? ...`
+        // treated "" as absent, so the call reported success and changed nothing.
+        await tools.executeTool('update_marker', {
+          sequenceId: 'seq', markerId: 'guid', [field]: '',
+        });
+
+        expect(mockBridge.executeScript.mock.calls[0][0]).toContain(expected);
+      });
+
+      it('add_marker_to_project_item applies colour rather than dropping it', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await executeExpandedTool(mockBridge, 'add_marker_to_project_item', {
+          projectItemId: 'item', time: 1, name: 'm', color: 'cyan',
+        });
+
+        const script = mockBridge.executeScript.mock.calls[0][0] as string;
+        expect(script).toContain('resolveMarkerColorIndex(args.color)');
+        expect(script).toContain('setColorByIndex(itemColorIndex)');
+        // Colour was readable through get_clip_markers but unwritable here.
+        expect(script).toContain('colorName: appliedColor.name');
+      });
+
+      it('add_marker_to_project_item refuses an unrecognised colour', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await executeExpandedTool(mockBridge, 'add_marker_to_project_item', {
+          projectItemId: 'item', time: 1, name: 'm', color: 'chartreuse',
+        });
+
+        const script = mockBridge.executeScript.mock.calls[0][0] as string;
+        // Expanded tools declare z.record(z.any()), so schema-layer rejection is
+        // not available; the guard has to live in the generated script.
+        expect(script).toContain('Unrecognised marker colour');
+      });
+
+      it.each(['get_clip_markers', 'get_sequence_markers_by_type'])(
+        '%s also reports marker colour',
+        async (tool) => {
+          mockBridge.executeScript.mockResolvedValue({ success: true });
+
+          await executeExpandedTool(mockBridge, tool, {});
+
+          const script = mockBridge.executeScript.mock.calls[0][0] as string;
+          // These share one implementation with list_markers' problem: colour was
+          // readable from the DOM but never surfaced, so a caller could not verify
+          // what it had written.
+          expect(script).toContain('markerColor(marker)');
+          expect(script).toContain('color: markerColorInfo.index');
+          expect(script).toContain('colorName: markerColorInfo.name');
+          // Same -1 guard as list_markers.
+          expect(script).toContain('index < MARKER_COLOR_NAMES.length');
+        },
+      );
+
+      it('reads colour back, guarding the unassigned -1 state', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true, markers: [] });
+
+        await tools.executeTool('list_markers', { sequenceId: 'seq' });
+
+        const script = mockBridge.executeScript.mock.calls[0][0] as string;
+        expect(script).toContain('getColorByIndex()');
+        // getColorByIndex() can return -1 ("no colour assigned"). An unguarded
+        // lookup yields undefined, which JSON.stringify drops entirely, making
+        // the response shape unstable.
+        expect(script).toContain('colorIndex >= 0');
+        expect(script).toContain(': null');
+      });
+    });
+
+    describe('ExtendScript interpolation safety', () => {
+      // Two severities, both proven on this codebase before the fix. Full code
+      // execution, where a payload closes the call and runs its own script; and
+      // response-shape injection, where a payload adds keys to the JSON the
+      // calling model reads back — quieter, and worse for an agent.
+      const CLOSE_CALL = 'zz"); return JSON.stringify({PWNED:"x"}); ("';
+      const ADD_KEY = 'zz", INJECTED_KEY: "yes';
+      const EXPRESSION = '" + app.project.name + "';
+
+      it.each([
+        ['get_clip_properties', 'clipId'],
+        ['apply_effect', 'clipId'],
+        ['add_transition_to_clip', 'transitionName'],
+        ['export_frame', 'outputPath'],
+      ])('%s escapes %s', async (tool, param) => {
+        for (const payload of [CLOSE_CALL, ADD_KEY, EXPRESSION]) {
+          jest.clearAllMocks();
+          mockBridge.executeScript.mockResolvedValue({ success: true });
+
+          const args: Record<string, unknown> = {
+            sequenceId: 'seq', clipId: 'clip', time: 0, outputPath: '/tmp/a.png',
+            transitionName: 'Cross Dissolve', effectName: 'Gain', lutPath: '/tmp/a.cube',
+            name: 'bin', [param]: payload,
+          };
+          await tools.executeTool(tool, args);
+          if (!mockBridge.executeScript.mock.calls.length) continue;
+
+          const script = mockBridge.executeScript.mock.calls[0][0] as string;
+          // The payload must appear only as an escaped literal, never bare
+          // between the quotes the generator wrote.
+          expect(script).not.toContain(`"${payload}"`);
+          expect(script).toContain(JSON.stringify(payload));
+        }
+      });
+
+    });
+
+    describe('schema validation output', () => {
+      /** Swap one tool's schema in the catalog executeTool actually reads. */
+      function withSchema(toolName: string, schema: unknown) {
+        const catalog = tools.getAvailableTools();
+        jest.spyOn(tools, 'getAvailableTools').mockReturnValue(
+          catalog.map((t) => (t.name === toolName ? { ...t, inputSchema: schema as never } : t)),
+        );
+      }
+
+      it('passes the validated value to the handler, not the raw args', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+        // parse() used to run and have its result discarded, so every
+        // .transform(), .default() and z.coerce() in this file was inert.
+        withSchema('add_marker', z.object({
+          sequenceId: z.string(),
+          time: z.number(),
+          name: z.string().transform((v) => `${v}-transformed`),
+        }));
+
+        await tools.executeTool('add_marker', { sequenceId: 'seq', time: 1, name: 'probe' });
+
+        expect(mockBridge.executeScript.mock.calls[0][0]).toContain('probe-transformed');
+      });
+
+      it('applies a schema default for an argument the caller omitted', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+        withSchema('add_marker', z.object({
+          sequenceId: z.string(),
+          time: z.number(),
+          name: z.string().default('defaulted-name'),
+        }));
+
+        await tools.executeTool('add_marker', { sequenceId: 'seq', time: 1 });
+
+        expect(mockBridge.executeScript.mock.calls[0][0]).toContain('defaulted-name');
+      });
+
+      it('keeps unknown keys the schema would strip', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+        // Zod strips unknown keys, and handlers read alternate spellings such as
+        // args.itemId || args.item_id — so the validated value is merged over
+        // the raw args rather than replacing them.
+        withSchema('add_marker', z.object({ sequenceId: z.string(), time: z.number() }));
+
+        await tools.executeTool('add_marker', { sequenceId: 'seq', time: 1, name: 'survives' });
+
+        expect(mockBridge.executeScript.mock.calls[0][0]).toContain('survives');
+      });
+    });
+
+    describe('expanded tools reject an unresolvable sequence id', () => {
+      // These declare inputSchema: z.record(z.any()), so schema-layer rejection
+      // is unavailable — the guard has to live in the generated script.
+      it.each([
+        'add_tracks', 'razor_all_tracks', 'get_timeline_gaps',
+        'get_next_edit_point', 'set_all_tracks_targeted', 'nest_clips',
+      ])('%s guards before acting', async (tool) => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await executeExpandedTool(mockBridge, tool, { sequenceId: 'no-such-sequence' });
+
+        const script = mockBridge.executeScript.mock.calls[0][0] as string;
+        // Previously every site did targetSequence() then fell back to the
+        // active sequence, so a stale id silently acted on whatever was on
+        // screen and reported success — razor_all_tracks cut the wrong timeline.
+        expect(script).toContain('var seqErr = sequenceRequestError();');
+        expect(script).toContain('if (seqErr) return fail(seqErr);');
+        expect(script).not.toContain('targetSequence() || activeSequence()');
+      });
+
+      it('emits a guard that can actually reach the empty-id branch', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await executeExpandedTool(mockBridge, 'get_timeline_gaps', { sequenceId: '' });
+        const script = mockBridge.executeScript.mock.calls[0][0] as string;
+
+        // Asserting only that the message string appears is vacuous — it is in
+        // the function body whether or not the logic ever reaches it. These two
+        // assertions pin the parts that were actually wrong.
+        //
+        // 1. The alias fallback must not treat "" as absent, or an empty id
+        //    takes the omitted-id path and lands on the active sequence.
+        expect(script).toContain('if (requested === undefined || requested === null) requested = args.sequence_id;');
+        expect(script).not.toContain('String(requested) === "") requested = args.sequence_id');
+        // 2. This lives in a template literal, where \s collapses to a bare "s".
+        //    The emitted regex must strip whitespace, not the letter s.
+        expect(script).toContain('replace(/^\\s+|\\s+$/g, "")');
+        expect(script).not.toContain('replace(/^s+|s+$/g, "")');
+        expect(script).toContain('sequenceId was supplied but empty');
+      });
+
+      it('leaves the omitted-id case alone', () => {
+        // An omitted id must still mean "the active sequence" — that is the
+        // documented contract, and only a supplied-but-unresolvable id is an error.
+        const src = require('fs').readFileSync(
+          require('path').join(__dirname, '../../tools/expanded.ts'), 'utf8',
+        ) as string;
+        expect(src).toContain('if (requested === undefined || requested === null) return null;');
+        expect(src).toMatch(/function targetSequence\(\)[\s\S]{0,200}activeSequence\(\)/);
+      });
+
+      it('no silent fallback remains anywhere in the expanded dispatcher', () => {
+        const src = require('fs').readFileSync(
+          require('path').join(__dirname, '../../tools/expanded.ts'), 'utf8',
+        ) as string;
+        expect(src).not.toContain('targetSequence() || activeSequence()');
+      });
+    });
+
+    describe('export_frame', () => {
+      const scriptFor = async (args: Record<string, unknown>): Promise<string> => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+        await tools.executeTool('export_frame', args);
+        return mockBridge.executeScript.mock.calls[0][0] as string;
+      };
+
+      it('exports the sequence that was asked for, not the active one', async () => {
+        // Proven live against 26.0.2: with an empty sequence active, asking for
+        // a populated one returned success, echoed the requested sequenceId,
+        // and wrote the empty sequence's black frame.
+        const script = await scriptFor({
+          sequenceId: 'seq-guid', time: 15, outputPath: '/tmp/f.png',
+        });
+
+        expect(script).toContain('var qeSequence = __qeSequenceFor(sequence);');
+        // Match the assignment, not the bare call: the surrounding comment
+        // names getActiveSequence() to explain what it replaced.
+        expect(script).not.toContain('var qeSequence = qe.project.getActiveSequence()');
+      });
+
+      it('hands Premiere the stem so the frame lands at the requested path', async () => {
+        // exportFramePNG appends "." + format to whatever path it is given, so
+        // passing "shot.png" through wrote "shot.png.png".
+        const script = await scriptFor({
+          sequenceId: 'seq-guid', time: 15, outputPath: '/tmp/shot.png',
+        });
+
+        expect(script).toContain('var exportStem = requestedPath;');
+        expect(script).toContain('tryExport(timeNumber, exportStem)');
+        expect(script).not.toContain('tryExport(timeNumber, "/tmp/shot.png")');
+      });
+
+      it('reports the path it actually wrote rather than the one requested', async () => {
+        const script = await scriptFor({
+          sequenceId: 'seq-guid', time: 15, outputPath: '/tmp/shot.png',
+        });
+
+        expect(script).toContain('outputPath: actualPath');
+        expect(script).toContain('requestedPath: requestedPath');
+      });
+
+      it('fails when the export call throws nothing but writes nothing', async () => {
+        const script = await scriptFor({
+          sequenceId: 'seq-guid', time: 15, outputPath: '/tmp/shot.png',
+        });
+
+        expect(script).toContain('if (!exported || !actualPath)');
+        expect(script).toContain('wrote no file');
+      });
+
+      it('picks the extension from the format, not the supplied path', async () => {
+        const jpg = await scriptFor({
+          sequenceId: 'seq-guid', time: 1, outputPath: '/tmp/shot.png', format: 'jpg',
+        });
+
+        expect(jpg).toContain('=== "jpg"');
+        expect(jpg).toContain('".jpg"');
+      });
+
+      it('escapes the output path instead of interpolating it', async () => {
+        const path = 'INJ"+(1000*1000+7)+"END';
+        const script = await scriptFor({ sequenceId: 'seq-guid', time: 1, outputPath: path });
+
+        expect(script).toContain(JSON.stringify(path));
+        expect(script).not.toContain('= "' + path + '"');
+      });
+    });
+
+    describe('sequence targeting hardening', () => {
+      const INJECTION = 'INJ"+(1000*1000+7)+"END';
+
+      it.each(['add_marker', 'list_markers', 'razor_timeline_at_time'])(
+        '%s escapes the sequence id instead of interpolating it into the script',
+        async (tool) => {
+          mockBridge.executeScript.mockResolvedValue({ success: true });
+
+          const args: Record<string, unknown> = { sequenceId: INJECTION };
+          if (tool === 'add_marker') Object.assign(args, { time: 1, name: 'm' });
+          if (tool === 'razor_timeline_at_time') Object.assign(args, { time: 1 });
+
+          await tools.executeTool(tool, args);
+
+          const script = mockBridge.executeScript.mock.calls[0][0] as string;
+          // Raw interpolation would close the string and let the arithmetic run,
+          // which is how this was proven live: the id came back as INJ1000007END.
+          expect(script).not.toContain('"' + INJECTION + '"');
+          expect(script).toContain(JSON.stringify(INJECTION));
+        },
+      );
+
+      it.each(['add_track', 'apply_audio_effect_to_all_clips', 'razor_timeline_at_time'])(
+        '%s restores the previously active sequence',
+        async (tool) => {
+          mockBridge.executeScript.mockResolvedValue({ success: true });
+
+          const args: Record<string, unknown> = { sequenceId: 'seq-guid' };
+          if (tool === 'add_track') Object.assign(args, { trackType: 'video' });
+          if (tool === 'apply_audio_effect_to_all_clips') Object.assign(args, { effectName: 'Gain' });
+          if (tool === 'razor_timeline_at_time') Object.assign(args, { time: 1 });
+
+          await tools.executeTool(tool, args);
+
+          const script = mockBridge.executeScript.mock.calls[0][0] as string;
+          // Honouring the id by switching the active sequence and leaving it
+          // switched moves the user's timeline and retargets later calls.
+          expect(script).toContain('var __priorActive = app.project.activeSequence');
+          expect(script).toContain('app.project.activeSequence = __priorActive');
+          expect(script).toContain('finally');
+        },
+      );
+
+      it('read_sequence_captions fails on an unresolved id rather than reading the active sequence', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await tools.executeTool('read_sequence_captions', { sequenceId: 'no-such-sequence' });
+
+        const script = mockBridge.executeScript.mock.calls[0][0] as string;
+        expect(script).toContain('Sequence not found by id');
+        // The old shape silently reassigned to the active sequence on a miss.
+        expect(script).not.toContain('if (!sequence) sequence = app.project.activeSequence;');
+      });
+
+      it('escapes the effect name too', async () => {
+        mockBridge.executeScript.mockResolvedValue({ success: true });
+
+        await tools.executeTool('apply_audio_effect_to_all_clips', {
+          sequenceId: 'seq-guid', effectName: 'Gain" + (2*2) + "',
+        });
+
+        const script = mockBridge.executeScript.mock.calls[0][0] as string;
+        expect(script).toContain(JSON.stringify('Gain" + (2*2) + "'));
+      });
+    });
+
     it('reports local capabilities without probing the Premiere bridge by default', async () => {
       const result = await tools.executeTool('get_capabilities', {});
 
@@ -1177,6 +1632,171 @@ describe('PremiereProTools', () => {
     });
   });
 
+  describe('marker sequence targeting', () => {
+    // Premiere's ExtendScript DOM can mutate any sequence in the project, not only the one
+    // on screen, so these tools must act on the sequenceId they advertise instead of
+    // silently retargeting app.project.activeSequence.
+    const markerCalls: Array<{ tool: string; args: Record<string, any> }> = [
+      { tool: 'add_marker', args: { sequenceId: 'seq-target', time: 3, name: 'Cue' } },
+      { tool: 'delete_marker', args: { sequenceId: 'seq-target', markerId: 'marker-1' } },
+      { tool: 'update_marker', args: { sequenceId: 'seq-target', markerId: 'marker-1', name: 'Renamed' } },
+      { tool: 'list_markers', args: { sequenceId: 'seq-target' } }
+    ];
+
+    it.each(markerCalls)('resolves the requested sequence for $tool', async ({ tool, args }) => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+
+      await tools.executeTool(tool, args);
+
+      const script = mockBridge.executeScript.mock.calls[0][0] as string;
+      expect(script).toContain('__findSequence("seq-target")');
+      expect(script).not.toContain('app.project.activeSequence');
+    });
+
+    it.each(markerCalls)('returns a truthful error instead of retargeting for $tool', async ({ tool, args }) => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+
+      await tools.executeTool(tool, args);
+
+      const script = mockBridge.executeScript.mock.calls[0][0] as string;
+      expect(script).toContain('"Sequence not found by id: "');
+      expect(script).toContain('Use list_sequences or get_active_sequence to obtain a valid sequence ID.');
+    });
+
+    it.each(markerCalls)('rejects an empty sequenceId for $tool before touching the bridge', async ({ tool, args }) => {
+      const result = await tools.executeTool(tool, { ...args, sequenceId: '' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+      expect(mockBridge.executeScript).not.toHaveBeenCalled();
+    });
+
+    it('escapes quoted sequence ids so they cannot break out of the generated script', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+
+      await tools.executeTool('list_markers', { sequenceId: 'seq-"quoted"' });
+
+      const script = mockBridge.executeScript.mock.calls[0][0] as string;
+      expect(script).toContain('__findSequence("seq-\\"quoted\\"")');
+      expect(script).not.toContain('__findSequence("seq-"quoted"")');
+    });
+
+    it('reports which sequence a marker was written to', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+
+      await tools.executeTool('add_marker', { sequenceId: 'seq-target', time: 3, name: 'Cue' });
+
+      const script = mockBridge.executeScript.mock.calls[0][0] as string;
+      expect(script).toContain('sequenceId: sequence.sequenceID');
+      expect(script).toContain('sequenceName: sequence.name');
+    });
+  });
+
+  describe('track tool sequence targeting', () => {
+    // Same class of bug as the marker tools: these declared a sequenceId and then operated on
+    // app.project.activeSequence, or resolved the id and silently fell back to the active
+    // sequence when it did not match.
+    const trackCalls: Array<{ tool: string; args: Record<string, any> }> = [
+      { tool: 'lock_track', args: { sequenceId: 'seq-target', trackType: 'video', trackIndex: 0, locked: true } },
+      { tool: 'toggle_track_visibility', args: { sequenceId: 'seq-target', trackIndex: 0, visible: false } },
+      { tool: 'delete_track', args: { sequenceId: 'seq-target', trackType: 'video', trackIndex: 1 } }
+    ];
+
+    it('fails truthfully instead of falling back for list_sequence_tracks', async () => {
+      // This one keeps its existing lookup and replaces only the silent fallback,
+      // which previously echoed the requested id beside a different sequence's
+      // tracks -- a substitution the caller had no way to detect.
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+
+      await tools.executeTool('list_sequence_tracks', { sequenceId: 'seq-target' });
+
+      const script = mockBridge.executeScript.mock.calls[0][0] as string;
+      expect(script).toContain('Sequence not found by id:');
+      expect(script).not.toContain('sequence = app.project.activeSequence;');
+    });
+
+    it.each(trackCalls)('resolves the requested sequence for $tool', async ({ tool, args }) => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+
+      await tools.executeTool(tool, args);
+
+      const script = mockBridge.executeScript.mock.calls[0][0] as string;
+      expect(script).toContain('__findSequence("seq-target")');
+      expect(script).toContain('"Sequence not found by id: "');
+    });
+
+    it.each(trackCalls)('rejects an empty sequenceId for $tool before touching the bridge', async ({ tool, args }) => {
+      const result = await tools.executeTool(tool, { ...args, sequenceId: '' });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid arguments');
+      expect(mockBridge.executeScript).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { tool: 'list_sequence_tracks', args: { sequenceId: 'seq-target' } },
+      { tool: 'lock_track', args: { sequenceId: 'seq-target', trackType: 'video', trackIndex: 0, locked: true } },
+      { tool: 'toggle_track_visibility', args: { sequenceId: 'seq-target', trackIndex: 0, visible: false } }
+    ])('never falls back to the active sequence for $tool', async ({ tool, args }) => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+
+      await tools.executeTool(tool, args);
+
+      const script = mockBridge.executeScript.mock.calls[0][0] as string;
+      expect(script).not.toContain('app.project.activeSequence');
+    });
+
+    it('echoes the resolved sequence id from list_sequence_tracks rather than the requested one', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+
+      await tools.executeTool('list_sequence_tracks', { sequenceId: 'seq-target' });
+
+      const script = mockBridge.executeScript.mock.calls[0][0] as string;
+      expect(script).toContain('sequenceId: sequence.sequenceID');
+      expect(script).not.toContain('sequenceId: "seq-target"');
+    });
+
+    it('deletes from the requested sequence rather than requiring it to be active', async () => {
+      // Premiere 26 has no DOM trackCollection.deleteTrack, so deletion falls
+      // through to QE. QE reaches sequences by index through getSequenceAt(),
+      // not just the active one — verified against 26.0.2 — so requiring the
+      // target to be active refused work QE can actually do.
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+
+      await tools.executeTool('delete_track', { sequenceId: 'seq-target', trackType: 'video', trackIndex: 1 });
+
+      const script = mockBridge.executeScript.mock.calls[0][0] as string;
+      expect(script).toContain('var qeSeq = __qeSequenceFor(sequence);');
+      expect(script).not.toContain('activeSeq.sequenceID !== sequence.sequenceID');
+      expect(script).not.toContain('var qeSeq = qe.project.getActiveSequence()');
+    });
+
+    it('reports a sequence QE cannot address instead of deleting from the wrong one', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+
+      await tools.executeTool('delete_track', { sequenceId: 'seq-target', trackType: 'video', trackIndex: 1 });
+
+      const script = mockBridge.executeScript.mock.calls[0][0] as string;
+      expect(script).toContain('requiresOpenSequence: true');
+      // The refusal has to name the sequence, so a caller can tell which one
+      // needs opening rather than guessing.
+      expect(script).toContain("cannot address sequence '\" + sequence.name + \"'");
+    });
+
+    it('still reports caption track deletion as unsupported without touching the bridge', async () => {
+      const result = await tools.executeTool('delete_track', {
+        sequenceId: 'seq-target',
+        trackType: 'caption',
+        trackIndex: 0
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.unsupportedByPremiereApi).toBe(true);
+      expect(result.sequenceId).toBe('seq-target');
+      expect(mockBridge.executeScript).not.toHaveBeenCalled();
+    });
+  });
+
   describe('high-level workflow tools', () => {
     it('builds a motion graphics demo sequence', async () => {
       mockBridge.importMedia = jest
@@ -1256,8 +1876,8 @@ describe('PremiereProTools', () => {
       expect(result.message).toContain('directed clip plan');
       expect(result.transitions).toHaveLength(0);
       expect(result.animations).toHaveLength(0);
-      expect(mockBridge.addToTimeline).toHaveBeenNthCalledWith(1, 'seq-2b', 'item-a', 1, 1.5, true, undefined, undefined);
-      expect(mockBridge.addToTimeline).toHaveBeenNthCalledWith(2, 'seq-2b', 'item-b', 2, 3.6, true, undefined, undefined);
+      expect(mockBridge.addToTimeline).toHaveBeenNthCalledWith(1, 'seq-2b', 'item-a', 1, 1.5, true, undefined, undefined, 'overwrite');
+      expect(mockBridge.addToTimeline).toHaveBeenNthCalledWith(2, 'seq-2b', 'item-b', 2, 3.6, true, undefined, undefined, 'overwrite');
     });
 
     it('builds a brand spot from assets without requiring a mogrt', async () => {

--- a/src/__tests__/tools/injection-guard.test.ts
+++ b/src/__tests__/tools/injection-guard.test.ts
@@ -4,59 +4,48 @@
  * This used to scan the TypeScript source for raw interpolation. That reads the
  * wrong artifact and it read it badly: the span scanner tracked `${` and `}`
  * depth, so an object literal inside an interpolation decremented the depth
- * early and the next backtick ended the span before the method did. Three spans
- * were truncated that way, two of them methods that handle caller-supplied bin
- * names, so a raw site there was invisible.
+ * early and the next backtick ended the span before the method did.
  *
- * So this drives every tool with a hostile value in every string parameter and
+ * So this drives every tool with a hostile value at every string position and
  * checks what the host would actually receive: that it still parses as ES3, and
  * that executing it cannot run the payload.
+ *
+ * Two blind spots the earlier version of this file had, both of which let a real
+ * breakout through with the whole suite green:
+ *
+ *   - It selected parameters by `constructor.name` against a fixed list, so
+ *     `z.array(z.string())` and nested `z.object({...})` were never fuzzed at
+ *     all. A raw `${ids.join('","')}` was invisible. Arguments are now seeded
+ *     from the schema and the payload is placed at *every* string leaf, inside
+ *     arrays and nested objects included.
+ *   - Every payload contained only double quotes, so a raw interpolation into a
+ *     single-quoted ExtendScript literal could not be seen — it never terminated
+ *     the string, so even the ES3 parse check passed. The PR moves message text
+ *     to single quotes, which makes that shape idiomatic here, so single-quote
+ *     payloads are now part of the set.
+ *
+ * It also captures every script a tool emits rather than the last one; a tool
+ * that runs two scripts was previously only half-checked.
  */
 
 import vm from 'vm';
 import { parse } from 'acorn';
 import { PremiereProTools } from '../../tools/index.js';
+import { seedArgs, stringPaths, withPayloadAt } from '../helpers/schema-args.js';
 
-/** Closes the string, sets a flag, and reopens it so the rest still parses. */
-const BREAKOUT = 'zz"); __OWNED = true; ("';
+/** Closes a double-quoted literal, sets a flag, and reopens it so the rest parses. */
+const BREAKOUT_DOUBLE = 'zz"); __OWNED = true; ("';
+/** The same against a single-quoted literal. */
+const BREAKOUT_SINGLE = "zz'; __OWNED = true; var __x = '";
 /** Adds a key to the returned JSON without breaking the call. */
 const ADD_KEY = 'zz", INJECTED: "yes';
-/** An ordinary name that happens to contain a quote. */
-const BENIGN = '12" Cuts';
+/** Ordinary names that merely contain a quote. */
+const BENIGN_DOUBLE = '12" Cuts';
+const BENIGN_SINGLE = "Bob's Takes";
 
-const PAYLOADS = [BREAKOUT, ADD_KEY, BENIGN];
+const PAYLOADS = [BREAKOUT_DOUBLE, BREAKOUT_SINGLE, ADD_KEY, BENIGN_DOUBLE, BENIGN_SINGLE];
 
-/** Plausible non-string values, so a tool is not rejected before it emits. */
-const FILLER: Record<string, unknown> = {
-  trackIndex: 0, time: 1, newTime: 2, splitTime: 1, duration: 1, speed: 100,
-  volume: 0, opacity: 100, scale: 100, rotation: 0, width: 1920, height: 1080,
-  frameRate: 25, level: 0, position: 'end', locked: true, visible: true,
-  enabled: true, muted: true, settings: {}, adjustments: {}, clips: [],
-  parameters: {}, textItems: [], steps: [],
-};
-
-function stringParams(tool: { inputSchema?: { shape?: Record<string, unknown> } }): string[] {
-  // This zod build does not expose _def.typeName; the runtime class name is what
-  // identifies the type. Optionals are included because the value inside is
-  // usually a string, and a wrong guess only costs a skipped case.
-  const shape = tool.inputSchema?.shape ?? {};
-  return Object.keys(shape).filter((key) => {
-    const name = (shape[key] as { constructor?: { name?: string } })?.constructor?.name;
-    return name === 'ZodString' || name === 'ZodOptional' || name === 'ZodUnion';
-  });
-}
-
-function argsFor(tool: { inputSchema?: { shape?: Record<string, unknown> } },
-                 param: string, payload: string): Record<string, unknown> {
-  const shape = tool.inputSchema?.shape ?? {};
-  const args: Record<string, unknown> = {};
-  for (const key of Object.keys(shape)) {
-    args[key] = key === param ? payload : (FILLER[key] ?? 'x');
-  }
-  return args;
-}
-
-/** Runs the emitted script against a host that records whether the payload fired. */
+/** Runs an emitted script against a host that records whether the payload fired. */
 function payloadRuns(script: string): boolean {
   const sandbox: Record<string, unknown> = {
     __OWNED: false,
@@ -68,6 +57,7 @@ function payloadRuns(script: string): boolean {
         rootItem: { name: 'root', nodeId: 'r', children: { numItems: 0 }, createBin: () => ({ name: 'b', nodeId: 'n' }) },
         activeSequence: null,
         importFiles: () => true,
+        importSequences: () => true,
       },
     },
     qe: { project: {} },
@@ -85,42 +75,55 @@ function payloadRuns(script: string): boolean {
 }
 
 describe('generated scripts cannot be broken out of', () => {
-  it('survives a hostile value in every string parameter of every tool', async () => {
+  it('survives a hostile value at every string position of every tool', async () => {
     const probe = new PremiereProTools({ executeScript: async () => ({ success: true }) } as never);
     const escaped: string[] = [];
     const unparseable: string[] = [];
     let checked = 0;
+    let toolsReached = 0;
 
     for (const tool of probe.getAvailableTools()) {
-      for (const param of stringParams(tool as never)) {
+      const base = seedArgs(tool as never);
+      const paths = stringPaths(base);
+      if (paths.length) toolsReached++;
+
+      for (const path of paths) {
         for (const payload of PAYLOADS) {
-          let script = '';
+          const scripts: string[] = [];
           const tools = new PremiereProTools({
-            executeScript: async (s: string) => { script = s; return { success: true }; },
+            executeScript: async (s: string) => { scripts.push(s); return { success: true }; },
           } as never);
           try {
-            await tools.executeTool(tool.name, argsFor(tool as never, param, payload));
+            await tools.executeTool(tool.name, withPayloadAt(base, path, payload) as Record<string, unknown>);
           } catch {
             // schema rejection: nothing was emitted
           }
-          if (!script) continue;
-          checked++;
 
-          try {
-            parse(script, { ecmaVersion: 3, allowReturnOutsideFunction: true });
-          } catch {
-            unparseable.push(`${tool.name}.${param}`);
-            continue;
+          const where = `${tool.name}.${path.join('.') || '(root)'}`;
+          for (const script of scripts) {
+            checked++;
+            try {
+              parse(script, { ecmaVersion: 3, allowReturnOutsideFunction: true });
+            } catch {
+              unparseable.push(where);
+              continue;
+            }
+            if (payloadRuns(script)) escaped.push(where);
           }
-          if (payloadRuns(script)) escaped.push(`${tool.name}.${param}`);
         }
       }
     }
 
-    // A broken harness would make the two assertions below pass vacuously.
-    // 183 cases at present; the floor only catches a harness that stopped capturing.
-    expect(checked).toBeGreaterThan(150);
+    // Floors, so a harness that quietly stopped emitting cannot pass vacuously.
+    // Currently 97 tools carry a string position, 199 positions in all, driven
+    // with 5 payloads each; 545 of those emit a script, the rest being rejected
+    // by a field's own validation before anything is generated. The old selector
+    // reached 61 tools and skipped array and nested-object parameters entirely,
+    // so a raw interpolation there was invisible. These floors sit just under the
+    // present numbers to catch a harness that silently stops reaching most of them.
+    expect(toolsReached).toBeGreaterThan(90);
+    expect(checked).toBeGreaterThan(500);
     expect([...new Set(escaped)]).toEqual([]);
     expect([...new Set(unparseable)]).toEqual([]);
-  }, 300_000);
+  }, 600_000);
 });

--- a/src/__tests__/tools/injection-guard.test.ts
+++ b/src/__tests__/tools/injection-guard.test.ts
@@ -1,0 +1,126 @@
+/**
+ * No caller-supplied string may break out of the generated ExtendScript.
+ *
+ * This used to scan the TypeScript source for raw interpolation. That reads the
+ * wrong artifact and it read it badly: the span scanner tracked `${` and `}`
+ * depth, so an object literal inside an interpolation decremented the depth
+ * early and the next backtick ended the span before the method did. Three spans
+ * were truncated that way, two of them methods that handle caller-supplied bin
+ * names, so a raw site there was invisible.
+ *
+ * So this drives every tool with a hostile value in every string parameter and
+ * checks what the host would actually receive: that it still parses as ES3, and
+ * that executing it cannot run the payload.
+ */
+
+import vm from 'vm';
+import { parse } from 'acorn';
+import { PremiereProTools } from '../../tools/index.js';
+
+/** Closes the string, sets a flag, and reopens it so the rest still parses. */
+const BREAKOUT = 'zz"); __OWNED = true; ("';
+/** Adds a key to the returned JSON without breaking the call. */
+const ADD_KEY = 'zz", INJECTED: "yes';
+/** An ordinary name that happens to contain a quote. */
+const BENIGN = '12" Cuts';
+
+const PAYLOADS = [BREAKOUT, ADD_KEY, BENIGN];
+
+/** Plausible non-string values, so a tool is not rejected before it emits. */
+const FILLER: Record<string, unknown> = {
+  trackIndex: 0, time: 1, newTime: 2, splitTime: 1, duration: 1, speed: 100,
+  volume: 0, opacity: 100, scale: 100, rotation: 0, width: 1920, height: 1080,
+  frameRate: 25, level: 0, position: 'end', locked: true, visible: true,
+  enabled: true, muted: true, settings: {}, adjustments: {}, clips: [],
+  parameters: {}, textItems: [], steps: [],
+};
+
+function stringParams(tool: { inputSchema?: { shape?: Record<string, unknown> } }): string[] {
+  // This zod build does not expose _def.typeName; the runtime class name is what
+  // identifies the type. Optionals are included because the value inside is
+  // usually a string, and a wrong guess only costs a skipped case.
+  const shape = tool.inputSchema?.shape ?? {};
+  return Object.keys(shape).filter((key) => {
+    const name = (shape[key] as { constructor?: { name?: string } })?.constructor?.name;
+    return name === 'ZodString' || name === 'ZodOptional' || name === 'ZodUnion';
+  });
+}
+
+function argsFor(tool: { inputSchema?: { shape?: Record<string, unknown> } },
+                 param: string, payload: string): Record<string, unknown> {
+  const shape = tool.inputSchema?.shape ?? {};
+  const args: Record<string, unknown> = {};
+  for (const key of Object.keys(shape)) {
+    args[key] = key === param ? payload : (FILLER[key] ?? 'x');
+  }
+  return args;
+}
+
+/** Runs the emitted script against a host that records whether the payload fired. */
+function payloadRuns(script: string): boolean {
+  const sandbox: Record<string, unknown> = {
+    __OWNED: false,
+    app: {
+      enableQE() {},
+      project: {
+        name: 'p',
+        sequences: { numSequences: 0 },
+        rootItem: { name: 'root', nodeId: 'r', children: { numItems: 0 }, createBin: () => ({ name: 'b', nodeId: 'n' }) },
+        activeSequence: null,
+        importFiles: () => true,
+      },
+    },
+    qe: { project: {} },
+    JSON,
+    File: function () { return { exists: false }; },
+    Folder: function () { return { exists: false, create: () => false }; },
+  };
+  vm.createContext(sandbox);
+  try {
+    vm.runInContext(`(function(){${script}})()`, sandbox, { timeout: 2000 });
+  } catch {
+    // A missing DOM member is expected; only the flag matters.
+  }
+  return sandbox.__OWNED === true;
+}
+
+describe('generated scripts cannot be broken out of', () => {
+  it('survives a hostile value in every string parameter of every tool', async () => {
+    const probe = new PremiereProTools({ executeScript: async () => ({ success: true }) } as never);
+    const escaped: string[] = [];
+    const unparseable: string[] = [];
+    let checked = 0;
+
+    for (const tool of probe.getAvailableTools()) {
+      for (const param of stringParams(tool as never)) {
+        for (const payload of PAYLOADS) {
+          let script = '';
+          const tools = new PremiereProTools({
+            executeScript: async (s: string) => { script = s; return { success: true }; },
+          } as never);
+          try {
+            await tools.executeTool(tool.name, argsFor(tool as never, param, payload));
+          } catch {
+            // schema rejection: nothing was emitted
+          }
+          if (!script) continue;
+          checked++;
+
+          try {
+            parse(script, { ecmaVersion: 3, allowReturnOutsideFunction: true });
+          } catch {
+            unparseable.push(`${tool.name}.${param}`);
+            continue;
+          }
+          if (payloadRuns(script)) escaped.push(`${tool.name}.${param}`);
+        }
+      }
+    }
+
+    // A broken harness would make the two assertions below pass vacuously.
+    // 183 cases at present; the floor only catches a harness that stopped capturing.
+    expect(checked).toBeGreaterThan(150);
+    expect([...new Set(escaped)]).toEqual([]);
+    expect([...new Set(unparseable)]).toEqual([]);
+  }, 300_000);
+});

--- a/src/__tests__/tools/injection-guard.test.ts
+++ b/src/__tests__/tools/injection-guard.test.ts
@@ -31,7 +31,9 @@
 import vm from 'vm';
 import { parse } from 'acorn';
 import { PremiereProTools } from '../../tools/index.js';
-import { seedArgs, stringPaths, withPayloadAt } from '../helpers/schema-args.js';
+import {
+  seedArgs, stringPaths, withPayloadAt, argNamesFromScript, seedFreeFormArgs,
+} from '../helpers/schema-args.js';
 
 /** Closes a double-quoted literal, sets a flag, and reopens it so the rest parses. */
 const BREAKOUT_DOUBLE = 'zz"); __OWNED = true; ("';
@@ -68,13 +70,31 @@ const PAYLOADS = [
  *
  * Serialising a value containing one produces a script the host cannot parse:
  * legal inside a JSON string, but a line terminator to a JavaScript parser. That
- * is a broken call rather than a breakout — measured here as 135 unparseable and
- * 0 executed — and it is not introduced by this change: interpolating the value
- * raw, as before, emits the same character. Repairing it belongs to the bridge,
- * which re-escapes line terminators as it assembles the script, and doing it at
- * each of the interpolation sites instead would be the wrong layer.
+ * is a broken call rather than a breakout — 0 of these execute — and it is not
+ * introduced by this change: interpolating the value raw, as before, emits the
+ * same character.
+ *
+ * Stated plainly: **nothing in this branch repairs it.** The repair belongs at the
+ * bridge, which re-escapes line terminators as it assembles the script, and that
+ * is a separate change not present here. Doing it at each of the interpolation
+ * sites would be the wrong layer. Until the two are together, a value carrying
+ * U+2028 still fails — legibly, as a script that will not parse.
  */
 const PARSE_EXEMPT = new Set([BREAKOUT_LINE_SEPARATOR]);
+
+/** How many free-form tools also get the shared helpers' arguments fuzzed. */
+const HELPER_SAMPLE = 6;
+
+/**
+ * The 171 free-form tools emit one shared ~123 KB body, so every payload against
+ * every one of them re-parses that body. They are driven with the breakout
+ * payloads only: those are what detect an escape, and they exercise the parse
+ * check as thoroughly as the benign values do. Tools with a declared schema still
+ * get the full set.
+ */
+const BREAKOUT_PAYLOADS = [
+  BREAKOUT_DOUBLE, BREAKOUT_SINGLE, BREAKOUT_BACKSLASH, BREAKOUT_LINE_SEPARATOR,
+];
 
 /** Runs an emitted script against a host that records whether the payload fired. */
 function payloadRuns(script: string): boolean {
@@ -111,14 +131,43 @@ describe('generated scripts cannot be broken out of', () => {
     const escaped: string[] = [];
     const unparseable: string[] = [];
     let checked = 0;
+    let freeFormSeen = 0;
     const emittingTools = new Set<string>();
 
     for (const tool of probe.getAvailableTools()) {
-      const base = seedArgs(tool as never);
+      let base = seedArgs(tool as never);
+      let freeForm = false;
+
+      // A tool declaring a free-form record has no fields to seed, so nothing was
+      // ever fuzzed through it. Ask the tool what it reads: emit once, then take
+      // the argument names out of its own generated script.
+      if (stringPaths(base).length === 0) {
+        let probeScript = '';
+        const prober = new PremiereProTools({
+          executeScript: async (s: string) => { probeScript = s; return { success: true }; },
+        } as never);
+        try {
+          await prober.executeTool(tool.name, base);
+        } catch { /* nothing emitted; leaves base as it was */ }
+        if (probeScript) {
+          // The arguments the shared helpers read apply to every one of these
+          // tools, and they all emit the same body, so fuzzing those names once
+          // per tool is 171 times the work for the same answer. They are covered
+          // on a few representatives; each tool still gets its own case block
+          // fuzzed in full.
+          freeForm = true;
+          const helperNamesCovered = freeFormSeen < HELPER_SAMPLE;
+          freeFormSeen++;
+          const names = argNamesFromScript(probeScript, tool.name, helperNamesCovered);
+          if (names.length) base = seedFreeFormArgs(names);
+        }
+      }
+
       const paths = stringPaths(base);
+      const payloads = freeForm ? BREAKOUT_PAYLOADS : PAYLOADS;
 
       for (const path of paths) {
-        for (const payload of PAYLOADS) {
+        for (const payload of payloads) {
           const scripts: string[] = [];
           const tools = new PremiereProTools({
             executeScript: async (s: string) => { scripts.push(s); return { success: true }; },
@@ -150,11 +199,13 @@ describe('generated scripts cannot be broken out of', () => {
     }
 
     // Floors, so a harness that quietly stopped emitting cannot pass vacuously.
-    // Floored on tools that actually EMITTED a script, not on how many carry a
-    // string position. The previous floor was schema arithmetic: it never touched
-    // executeTool, so it was satisfied while a third of the tools it counted
-    // emitted nothing at all and were silently absent from the sweep.
-    expect(emittingTools.size).toBeGreaterThan(60);
+    // Floored on tools that actually EMITTED a script. Two earlier floors were
+    // wrong in the same direction: one counted schema arithmetic without touching
+    // executeTool, the next was set at 60 while 71% of the catalogue emitted
+    // nothing, because the 171 free-form tools carried no fuzzable position at
+    // all. With those driven from the arguments their own script reads, this sits
+    // just under the real number.
+    expect(emittingTools.size).toBeGreaterThan(180);
     expect(checked).toBeGreaterThan(900);
     expect([...new Set(escaped)]).toEqual([]);
     expect([...new Set(unparseable)]).toEqual([]);

--- a/src/__tests__/tools/injection-guard.test.ts
+++ b/src/__tests__/tools/injection-guard.test.ts
@@ -42,8 +42,39 @@ const ADD_KEY = 'zz", INJECTED: "yes';
 /** Ordinary names that merely contain a quote. */
 const BENIGN_DOUBLE = '12" Cuts';
 const BENIGN_SINGLE = "Bob's Takes";
+/**
+ * Defeats an escaper that handles quotes but not backslashes. Escaping only the
+ * quote turns this into `"zz\\"` -- a complete literal ending in a backslash --
+ * and everything after it becomes code.
+ */
+const BREAKOUT_BACKSLASH = 'zz\\"); __OWNED = true; ("';
+/** A raw line terminator, which no single-line ExtendScript literal survives. */
+const BREAKOUT_NEWLINE = 'zz\n__OWNED = true;\n';
+/**
+ * Legal unescaped inside a JSON string but a line terminator to a JavaScript
+ * parser, so a value carrying one can split a literal that looked safely quoted.
+ */
+const BREAKOUT_LINE_SEPARATOR = 'zz\u2028__OWNED = true;\u2028';
+/** An ordinary Windows path, which is where the backslash case shows up in real use. */
+const BENIGN_BACKSLASH = 'C:\\Footage\\take "1"';
 
-const PAYLOADS = [BREAKOUT_DOUBLE, BREAKOUT_SINGLE, ADD_KEY, BENIGN_DOUBLE, BENIGN_SINGLE];
+const PAYLOADS = [
+  BREAKOUT_DOUBLE, BREAKOUT_SINGLE, ADD_KEY, BENIGN_DOUBLE, BENIGN_SINGLE,
+  BREAKOUT_BACKSLASH, BREAKOUT_NEWLINE, BREAKOUT_LINE_SEPARATOR, BENIGN_BACKSLASH,
+];
+
+/**
+ * U+2028 is held to the execution check only, not to the parse check.
+ *
+ * Serialising a value containing one produces a script the host cannot parse:
+ * legal inside a JSON string, but a line terminator to a JavaScript parser. That
+ * is a broken call rather than a breakout — measured here as 135 unparseable and
+ * 0 executed — and it is not introduced by this change: interpolating the value
+ * raw, as before, emits the same character. Repairing it belongs to the bridge,
+ * which re-escapes line terminators as it assembles the script, and doing it at
+ * each of the interpolation sites instead would be the wrong layer.
+ */
+const PARSE_EXEMPT = new Set([BREAKOUT_LINE_SEPARATOR]);
 
 /** Runs an emitted script against a host that records whether the payload fired. */
 function payloadRuns(script: string): boolean {
@@ -80,12 +111,11 @@ describe('generated scripts cannot be broken out of', () => {
     const escaped: string[] = [];
     const unparseable: string[] = [];
     let checked = 0;
-    let toolsReached = 0;
+    const emittingTools = new Set<string>();
 
     for (const tool of probe.getAvailableTools()) {
       const base = seedArgs(tool as never);
       const paths = stringPaths(base);
-      if (paths.length) toolsReached++;
 
       for (const path of paths) {
         for (const payload of PAYLOADS) {
@@ -102,11 +132,16 @@ describe('generated scripts cannot be broken out of', () => {
           const where = `${tool.name}.${path.join('.') || '(root)'}`;
           for (const script of scripts) {
             checked++;
+            emittingTools.add(tool.name);
             try {
               parse(script, { ecmaVersion: 3, allowReturnOutsideFunction: true });
             } catch {
-              unparseable.push(where);
-              continue;
+              // Still executed below when exempt: a payload that cannot be parsed
+              // by acorn may still run something once the bridge has repaired it.
+              if (!PARSE_EXEMPT.has(payload)) {
+                unparseable.push(where);
+                continue;
+              }
             }
             if (payloadRuns(script)) escaped.push(where);
           }
@@ -115,14 +150,12 @@ describe('generated scripts cannot be broken out of', () => {
     }
 
     // Floors, so a harness that quietly stopped emitting cannot pass vacuously.
-    // Currently 97 tools carry a string position, 199 positions in all, driven
-    // with 5 payloads each; 545 of those emit a script, the rest being rejected
-    // by a field's own validation before anything is generated. The old selector
-    // reached 61 tools and skipped array and nested-object parameters entirely,
-    // so a raw interpolation there was invisible. These floors sit just under the
-    // present numbers to catch a harness that silently stops reaching most of them.
-    expect(toolsReached).toBeGreaterThan(90);
-    expect(checked).toBeGreaterThan(500);
+    // Floored on tools that actually EMITTED a script, not on how many carry a
+    // string position. The previous floor was schema arithmetic: it never touched
+    // executeTool, so it was satisfied while a third of the tools it counted
+    // emitted nothing at all and were silently absent from the sweep.
+    expect(emittingTools.size).toBeGreaterThan(60);
+    expect(checked).toBeGreaterThan(900);
     expect([...new Set(escaped)]).toEqual([]);
     expect([...new Set(unparseable)]).toEqual([]);
   }, 600_000);

--- a/src/__tests__/tools/qe-targeting.test.ts
+++ b/src/__tests__/tools/qe-targeting.test.ts
@@ -1,0 +1,157 @@
+/**
+ * The half-finished sweeps.
+ *
+ * Two rewrites in this branch — "address the sequence the caller asked for" and
+ * "match QE items by start time, not DOM index" — were applied at the tool call
+ * sites and missed the shared helpers and a few stragglers. An independent audit
+ * executed the generated scripts against a mock host and showed the leftovers
+ * still mutating the wrong clip in the wrong sequence while reporting success.
+ *
+ * Every test here was confirmed to fail when its fix is reverted.
+ */
+
+import { PremiereProTools } from '../../tools/index.js';
+import { executeExpandedTool } from '../../tools/expanded.js';
+
+describe('QE targeting, second pass', () => {
+  const expandedScript = async (name: string): Promise<string> => {
+    let script = '';
+    const bridge = { executeScript: async (s: string) => { script = s; return { success: true }; } };
+    try { await executeExpandedTool(bridge as any, name, {}); } catch { /* arg guards are fine */ }
+    return script;
+  };
+
+  describe('shared helpers', () => {
+    it('qeClipForClip resolves the clip own sequence, not the active one', async () => {
+      // This helper feeds set_frame_blend, set_time_interpolation, set_clip_volume,
+      // set_clip_pan and set_clip_opacity. While it used getActiveSequence() every
+      // one of them mutated whatever sat at that index on screen.
+      const script = await expandedScript('set_frame_blend');
+      const body = script.slice(script.indexOf('function qeClipForClip'), script.indexOf('function markerCollectionForTool'));
+
+      expect(body).toContain('qeSequenceFor(found.sequence)');
+      expect(body).not.toContain('qe.project.getActiveSequence()');
+    });
+
+    it('qeClipForClip matches the QE item by start time, not by index', async () => {
+      const script = await expandedScript('set_frame_blend');
+      const body = script.slice(script.indexOf('function qeClipForClip'), script.indexOf('function markerCollectionForTool'));
+
+      expect(body).toContain('__findQeClipByDomClip(qeTrack, found.clip)');
+      expect(body).not.toContain('getItemAt(found.clipIndex)');
+    });
+  });
+
+  describe('stragglers', () => {
+    it('set_clip_speed_qe addresses the requested sequence', async () => {
+      const script = await expandedScript('set_clip_speed_qe');
+
+      expect(script).toContain('qeSequenceFor(speedClip.sequence)');
+      expect(script).not.toContain('var speedQeSeq = qe.project.getActiveSequence()');
+      expect(script).not.toContain('getItemAt(speedClip.clipIndex)');
+    });
+
+    it('batch_apply_effect matches items by start time', async () => {
+      const script = await expandedScript('batch_apply_effect');
+
+      expect(script).toContain('__findQeClipByDomClip(qeBatchTrack,');
+      expect(script).not.toContain('getItemAt(batchClips[bai].clipIndex)');
+    });
+
+    it('expanded.ts has no getActiveSequence left outside the guid-checked fallback', async () => {
+      const script = await expandedScript('set_frame_blend');
+      const helper = script.slice(script.indexOf('function qeSequenceFor'));
+      const inFallback = helper.slice(0, helper.indexOf('function ', 10));
+
+      // Count code only. Comments in the generated script mention the call by
+      // name to explain what replaced it, and a naive count picks those up.
+      const code = script.split('\n').filter((l) => !l.trim().startsWith('//')).join('\n');
+      const total = (code.match(/qe\.project\.getActiveSequence\(\)/g) || []).length;
+      expect(total).toBe(1);
+      expect(inFallback).toContain('String(activeCandidate.guid) === String(seq.sequenceID)');
+    });
+  });
+
+  describe('tools that took a sequenceId and ignored it', () => {
+    it.each([
+      'rename_track', 'set_target_track', 'get_track_info', 'get_target_tracks',
+      'insert_from_source', 'unnest_sequence', 'get_clip_at_playhead',
+    ])('%s resolves the requested sequence', async (tool) => {
+      const script = await expandedScript(tool);
+
+      expect(script).toContain('var seqErr = sequenceRequestError();');
+      expect(script).toContain('targetSequence()');
+    });
+
+    it.each([
+      'get_timeline_summary', 'get_total_clip_count', 'get_sequence_structure',
+    ])('%s rejects an id that does not resolve', async (tool) => {
+      // These answered a stale id with success:true and a null sequence, which a
+      // caller cannot tell apart from a genuinely empty one.
+      const script = await expandedScript(tool);
+
+      expect(script).toContain('var seqErr = sequenceRequestError();');
+    });
+  });
+
+  describe('split_clip timecode', () => {
+    it('takes the frame rate from the clip own sequence', async () => {
+      const bridge = { executeScript: jest.fn().mockResolvedValue({ success: true }) };
+      const tools = new PremiereProTools(bridge as any);
+      await tools.executeTool('split_clip', { clipId: 'c', splitTime: 12.5 });
+      const script = bridge.executeScript.mock.calls[0][0] as string;
+
+      expect(script).toContain('var seq = info.sequence;');
+      expect(script).not.toContain('var seq = app.project.activeSequence;');
+    });
+  });
+
+  describe('move_clip', () => {
+    it('rejects a leftover newTrackIndex instead of dropping it', async () => {
+      const bridge = { executeScript: jest.fn().mockResolvedValue({ success: true }) };
+      const tools = new PremiereProTools(bridge as any);
+
+      const result = await tools.executeTool('move_clip', {
+        clipId: 'c', newTime: 1, newTrackIndex: 3,
+      });
+
+      expect(result.success).toBe(false);
+      expect(bridge.executeScript).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remaining uncovered fixes', () => {
+    /** All three could be reverted with the suite staying green. */
+    it('toggle_track_visibility sets track output, not targeting', async () => {
+      const bridge = { executeScript: jest.fn().mockResolvedValue({ success: true }) };
+      const tools = new PremiereProTools(bridge as any);
+      await tools.executeTool('toggle_track_visibility', {
+        sequenceId: 'seq', trackIndex: 0, visible: false,
+      });
+      const script = bridge.executeScript.mock.calls[0][0] as string;
+
+      // setTargeted is the V1/A1 patch button; the eye is setMute on a video track.
+      expect(script).toContain('visibilityTrack.setMute(');
+      expect(script).not.toContain('.setTargeted(');
+      // Assignment is not evidence of effect anywhere else in this API.
+      expect(script).toContain('isMuted()');
+    });
+
+    it('set_sequence_pixel_aspect_ratio sends a ratio string, not a number', async () => {
+      // videoPixelAspectRatio throws "Illegal Parameter type" for a number, which
+      // is why this tool never worked at all.
+      const script = await expandedScript('set_sequence_pixel_aspect_ratio');
+
+      expect(script).toContain('parRatioString(');
+      expect(script).not.toContain('videoPixelAspectRatio = Number(');
+    });
+
+    it('parRatioString reduces a decimal to an exact fraction', async () => {
+      const script = await expandedScript('set_sequence_pixel_aspect_ratio');
+      const body = script.slice(script.indexOf('function parRatioString'));
+
+      expect(body).toContain('function gcd');
+      expect(body).toContain('indexOf(":")');
+    });
+  });
+});

--- a/src/__tests__/tools/qe-targeting.test.ts
+++ b/src/__tests__/tools/qe-targeting.test.ts
@@ -37,8 +37,9 @@ describe('QE targeting, second pass', () => {
    * of cases had never been given the check at all, so even a listed spelling
    * survived there. These blocks resolve through `targetSequence()`, which already
    * handles an absent id, so none of them has any business naming the active
-   * sequence directly: all ten contain it zero times. Asserting its absence is
-   * independent of how a fallback might be written.
+   * sequence directly: all ten contain it zero times. The substring is matched
+   * without the call parentheses, because `app.project.activeSequence || seq`
+   * reaches the same result without ever writing them.
    */
   const caseBlock = (script: string, tool: string): string => {
     const start = script.indexOf(`case "${tool}":`);
@@ -126,7 +127,7 @@ describe('QE targeting, second pass', () => {
 
       expect(block).toContain('var seqErr = sequenceRequestError();');
       expect(block).toContain('targetSequence()');
-      expect(block).not.toContain('activeSequence()');
+      expect(block).not.toContain('activeSequence');
     });
 
     it.each([
@@ -137,7 +138,7 @@ describe('QE targeting, second pass', () => {
       const block = caseBlock(await expandedScript(tool), tool);
 
       expect(block).toContain('var seqErr = sequenceRequestError();');
-      expect(block).not.toContain('activeSequence()');
+      expect(block).not.toContain('activeSequence');
     });
   });
 

--- a/src/__tests__/tools/qe-targeting.test.ts
+++ b/src/__tests__/tools/qe-targeting.test.ts
@@ -21,6 +21,41 @@ describe('QE targeting, second pass', () => {
     return script;
   };
 
+  /**
+   * The block for one tool inside the shared script.
+   *
+   * All 171 expanded tools emit the same ~123 KB body, differing only in the tool
+   * name near the top, so asserting `toContain` against the whole script says
+   * nothing about the tool under test: `sequenceRequestError()` appears in it 39
+   * times no matter which tool asked. Every case below therefore passed while the
+   * silent active-sequence fallback was restored in one of them.
+   */
+  const caseBlock = (script: string, tool: string): string => {
+    const start = script.indexOf(`case "${tool}":`);
+    expect(start).toBeGreaterThan(-1);
+
+    // Several tools share one body through consecutive case labels
+    // (`case "insert_from_source":` sits directly above `case
+    // "overwrite_from_source":`). Cutting at the next label would return an empty
+    // block and assert nothing, so leading labels are consumed first and the
+    // block ends at the next label that follows actual statements.
+    const lines = script.slice(start).split('\n');
+    const isLabel = (line: string): boolean => /^\s*case "/.test(line);
+    const body: string[] = [];
+    let seenStatement = false;
+    for (const line of lines) {
+      if (isLabel(line) && seenStatement) break;
+      if (!isLabel(line) && line.trim()) seenStatement = true;
+      body.push(line);
+    }
+
+    const block = body.join('\n');
+    // A block that collapsed to nothing would make every assertion below vacuous.
+    expect(seenStatement).toBe(true);
+    expect(block.length).toBeGreaterThan(40);
+    return block;
+  };
+
   describe('shared helpers', () => {
     it('qeClipForClip resolves the clip own sequence, not the active one', async () => {
       // This helper feeds set_frame_blend, set_time_interpolation, set_clip_volume,
@@ -77,10 +112,15 @@ describe('QE targeting, second pass', () => {
       'rename_track', 'set_target_track', 'get_track_info', 'get_target_tracks',
       'insert_from_source', 'unnest_sequence', 'get_clip_at_playhead',
     ])('%s resolves the requested sequence', async (tool) => {
-      const script = await expandedScript(tool);
+      const block = caseBlock(await expandedScript(tool), tool);
 
-      expect(script).toContain('var seqErr = sequenceRequestError();');
-      expect(script).toContain('targetSequence()');
+      expect(block).toContain('var seqErr = sequenceRequestError();');
+      expect(block).toContain('targetSequence()');
+      // The defect this pins is a fallback to whatever is on screen. It was
+      // reintroduced here spelled with an `if` rather than `||` and nothing
+      // noticed, so both spellings are named.
+      expect(block).not.toContain('|| activeSequence()');
+      expect(block).not.toMatch(/if \(![A-Za-z]+\)\s*[A-Za-z]+ = activeSequence\(\)/);
     });
 
     it.each([
@@ -88,9 +128,10 @@ describe('QE targeting, second pass', () => {
     ])('%s rejects an id that does not resolve', async (tool) => {
       // These answered a stale id with success:true and a null sequence, which a
       // caller cannot tell apart from a genuinely empty one.
-      const script = await expandedScript(tool);
+      const block = caseBlock(await expandedScript(tool), tool);
 
-      expect(script).toContain('var seqErr = sequenceRequestError();');
+      expect(block).toContain('var seqErr = sequenceRequestError();');
+      expect(block).not.toContain('|| activeSequence()');
     });
   });
 

--- a/src/__tests__/tools/qe-targeting.test.ts
+++ b/src/__tests__/tools/qe-targeting.test.ts
@@ -30,6 +30,16 @@ describe('QE targeting, second pass', () => {
    * times no matter which tool asked. Every case below therefore passed while the
    * silent active-sequence fallback was restored in one of them.
    */
+  /**
+   * Naming the shapes of the fallback did not work. Two spellings were listed,
+   * `x || activeSequence()` and `if (!x) x = activeSequence()`, and a third —
+   * `x = x ? x : activeSequence()` — walked straight past both; the second group
+   * of cases had never been given the check at all, so even a listed spelling
+   * survived there. These blocks resolve through `targetSequence()`, which already
+   * handles an absent id, so none of them has any business naming the active
+   * sequence directly: all ten contain it zero times. Asserting its absence is
+   * independent of how a fallback might be written.
+   */
   const caseBlock = (script: string, tool: string): string => {
     const start = script.indexOf(`case "${tool}":`);
     expect(start).toBeGreaterThan(-1);
@@ -116,11 +126,7 @@ describe('QE targeting, second pass', () => {
 
       expect(block).toContain('var seqErr = sequenceRequestError();');
       expect(block).toContain('targetSequence()');
-      // The defect this pins is a fallback to whatever is on screen. It was
-      // reintroduced here spelled with an `if` rather than `||` and nothing
-      // noticed, so both spellings are named.
-      expect(block).not.toContain('|| activeSequence()');
-      expect(block).not.toMatch(/if \(![A-Za-z]+\)\s*[A-Za-z]+ = activeSequence\(\)/);
+      expect(block).not.toContain('activeSequence()');
     });
 
     it.each([
@@ -131,7 +137,7 @@ describe('QE targeting, second pass', () => {
       const block = caseBlock(await expandedScript(tool), tool);
 
       expect(block).toContain('var seqErr = sequenceRequestError();');
-      expect(block).not.toContain('|| activeSequence()');
+      expect(block).not.toContain('activeSequence()');
     });
   });
 

--- a/src/__tests__/tools/schema-args.test.ts
+++ b/src/__tests__/tools/schema-args.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The argument seeder must produce arguments the tools accept.
+ *
+ * Every guard in this suite drives tools through this helper, so when it produces
+ * a value a schema rejects, that tool emits nothing and drops out of *all* of them
+ * silently. Nothing goes red; coverage just quietly shrinks. That has now happened
+ * three times, each from reading a zod internal that is wrong in this build:
+ *
+ *   _def.typeName  undefined, so every field became the string "x"
+ *   _def.values    undefined for enums, so all 20 enum fields got "start"
+ *   _def.type      the string "array", not the element schema
+ *
+ * Guarding the accessors individually would only catch the ones I thought to
+ * check. This asserts the property that actually matters and is independent of how
+ * the seeder is written: whatever it produces, the schema takes it.
+ */
+
+import { PremiereProTools } from '../../tools/index.js';
+import { seedArgs, seedRequiredArgs, accepts } from '../helpers/schema-args.js';
+
+describe('seeded arguments', () => {
+  const tools = new PremiereProTools({ executeScript: async () => ({ success: true }) } as never)
+    .getAvailableTools();
+
+  it('are accepted by the schema of every tool', () => {
+    const rejected: string[] = [];
+
+    for (const tool of tools) {
+      const schema = (tool as { inputSchema?: { safeParse?: (v: unknown) => { success: boolean } } })
+        .inputSchema;
+      if (typeof schema?.safeParse !== 'function') continue;
+      if (!accepts(schema as never, seedArgs(tool as never))) rejected.push(tool.name);
+    }
+
+    expect(rejected).toEqual([]);
+  });
+
+  it('are accepted when only the required parameters are supplied', () => {
+    // detect_silence is excluded by construction, not by convenience: it requires
+    // one of mediaPath or projectItemId and both are optional, so an object
+    // holding only required fields cannot satisfy it.
+    const CANNOT_BE_SATISFIED_BY_REQUIRED_ONLY = new Set(['detect_silence']);
+    const rejected: string[] = [];
+
+    for (const tool of tools) {
+      const schema = (tool as { inputSchema?: { safeParse?: (v: unknown) => { success: boolean } } })
+        .inputSchema;
+      if (typeof schema?.safeParse !== 'function') continue;
+      if (CANNOT_BE_SATISFIED_BY_REQUIRED_ONLY.has(tool.name)) continue;
+      if (!accepts(schema as never, seedRequiredArgs(tool as never))) rejected.push(tool.name);
+    }
+
+    expect(rejected).toEqual([]);
+  });
+
+  it('give every enum a member of that enum', () => {
+    // The failure that motivated this: enums fell back to the literal "start",
+    // which 19 of 20 enum fields reject, taking those tools out of every sweep.
+    const wrong: string[] = [];
+
+    for (const tool of tools) {
+      const shape = (tool as { inputSchema?: { shape?: Record<string, unknown> } }).inputSchema?.shape ?? {};
+      const args = seedArgs(tool as never);
+      for (const [key, field] of Object.entries(shape)) {
+        const inner = field as { constructor?: { name?: string }; unwrap?: () => unknown };
+        const kind = inner?.constructor?.name;
+        const target = kind === 'ZodOptional' && typeof inner.unwrap === 'function'
+          ? (inner.unwrap() as { constructor?: { name?: string } })
+          : inner;
+        if (target?.constructor?.name !== 'ZodEnum') continue;
+        if (!accepts(target as never, args[key])) wrong.push(`${tool.name}.${key}`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
+  it('reach a meaningful share of the tools with a script', async () => {
+    // A floor on tools that actually EMIT, not on schema arithmetic: the previous
+    // floor counted tools with a string position and would have been satisfied
+    // while a third of them silently emitted nothing.
+    let emitted = 0;
+
+    for (const tool of tools) {
+      let script = '';
+      const driver = new PremiereProTools({
+        executeScript: async (s: string) => { script = s; return { success: true }; },
+      } as never);
+      try {
+        await driver.executeTool(tool.name, seedArgs(tool as never));
+      } catch {
+        // Handlers that never reach the bridge are fine.
+      }
+      if (script) emitted++;
+    }
+
+    expect(emitted).toBeGreaterThan(230);
+  }, 300_000);
+});

--- a/src/__tests__/tools/sequence-settings.test.ts
+++ b/src/__tests__/tools/sequence-settings.test.ts
@@ -1,0 +1,92 @@
+/**
+ * set_sequence_settings used to compare width and height, write nothing at all,
+ * and answer "Requested sequence settings already match the active Premiere
+ * sequence" — which was false twice over: frameRate and pixelAspectRatio were
+ * never examined, and the sequence being operated on is the resolved one, not
+ * whatever happens to be active. Any frame-size change was refused outright on
+ * the grounds that Premiere cannot resize a sequence after creation, which is
+ * also untrue.
+ *
+ * Types verified against 26.0.2, because two of these fields reject or silently
+ * corrupt the obvious value:
+ *   videoFrameRate         a Time; must be assigned a STRING of ticks per frame.
+ *                          Assigning the number is accepted and then reads back
+ *                          as 2^63 ticks, i.e. a frame rate of 2.75e-08.
+ *   videoPixelAspectRatio  an "N:M" string. A number throws "Illegal Parameter
+ *                          type". Every ratio string tried was accepted verbatim.
+ *   videoFrameWidth/Height plain numbers, and they really do resize the sequence.
+ */
+
+import { PremiereProTools } from '../../tools/index.js';
+
+describe('set_sequence_settings', () => {
+  let tools: PremiereProTools;
+  let bridge: { executeScript: jest.Mock };
+
+  beforeEach(() => {
+    bridge = { executeScript: jest.fn().mockResolvedValue({ success: true }) };
+    tools = new PremiereProTools(bridge as any);
+  });
+
+  const scriptFor = async (settings: Record<string, unknown>): Promise<string> => {
+    await tools.executeTool('set_sequence_settings', { sequenceId: 'seq', settings });
+    return bridge.executeScript.mock.calls[0][0] as string;
+  };
+
+  it('assigns the frame rate as a string of ticks, not a number', async () => {
+    const script = await scriptFor({ frameRate: 25 });
+
+    expect(script).toContain('settingsObject.videoFrameRate = String(');
+    expect(script).not.toContain('settingsObject.videoFrameRate = Math.round(');
+  });
+
+  it('converts a numeric pixel aspect ratio to an N:M string', async () => {
+    const script = await scriptFor({ pixelAspectRatio: 1.5 });
+
+    expect(script).toContain('settingsObject.videoPixelAspectRatio = parText;');
+    expect(script).toContain('parText.indexOf(":") === -1');
+  });
+
+  it('accepts a ratio string without mangling it', async () => {
+    // z.number() alone rejected "16:9" at the schema before reaching the host.
+    const result = await tools.executeTool('set_sequence_settings', {
+      sequenceId: 'seq', settings: { pixelAspectRatio: '16:9' },
+    });
+
+    expect(result.success).not.toBe(false);
+    expect(bridge.executeScript).toHaveBeenCalled();
+  });
+
+  it('writes the settings rather than only comparing them', async () => {
+    const script = await scriptFor({ width: 1280, height: 720 });
+
+    expect(script).toContain('sequence.setSettings(settingsObject)');
+    expect(script).toContain('settingsObject.videoFrameWidth = Number(');
+    expect(script).toContain('settingsObject.videoFrameHeight = Number(');
+  });
+
+  it('no longer claims frame size cannot be changed after creation', async () => {
+    const script = await scriptFor({ width: 1280, height: 720 });
+
+    // Match the emitted values, not the prose: the comment explaining what this
+    // replaced quotes both of the old strings.
+    expect(script).not.toContain('error: "set_sequence_settings: Sequence frame size cannot');
+    expect(script).not.toContain('message: "Requested sequence settings already match');
+  });
+
+  it('reads the values back and reports any field that did not take', async () => {
+    // Several of these accept an assignment and keep their old value, so the
+    // write is not evidence that anything changed.
+    const script = await scriptFor({ frameRate: 25 });
+
+    expect(script).toContain('var after = readSettings(sequence);');
+    expect(script).toContain('accepted the assignment but did not apply');
+  });
+
+  it('says so plainly when nothing recognisable was supplied', async () => {
+    const script = await scriptFor({ nonsense: 1 });
+
+    expect(script).toContain('No recognised settings were supplied');
+    expect(script).toContain('supported: ["width", "height", "frameRate", "pixelAspectRatio"]');
+  });
+});

--- a/src/__tests__/tools/undefined-identifiers.test.ts
+++ b/src/__tests__/tools/undefined-identifiers.test.ts
@@ -1,0 +1,131 @@
+/**
+ * No generated script may reference an identifier it never declares.
+ *
+ * Generated ExtendScript is assembled from template literals, so a rename or a
+ * search-and-replace across similar methods can leave one site referring to a
+ * variable that exists only in its neighbour. Nothing catches that: the
+ * TypeScript compiles, the script parses, and the failure appears only when the
+ * host runs it — as a ReferenceError on every call to that tool.
+ *
+ * This walks the emitted script's AST and reports any identifier that is read
+ * without being declared, parameterised, or provided by the host.
+ */
+
+import { parse } from 'acorn';
+import { PremiereProTools } from '../../tools/index.js';
+
+// Provided by the ExtendScript host or by the prelude the bridge prepends.
+const HOST_GLOBALS = new Set([
+  'app', 'qe', 'JSON', 'Sequence', 'File', 'Folder', 'Time', 'String', 'Number', 'Boolean',
+  'Math', 'Date', 'Array', 'Object', 'RegExp', 'Error', 'parseInt', 'parseFloat',
+  'isFinite', 'isNaN', 'undefined', 'NaN', 'Infinity', '$', 'XMPMeta', 'ExternalObject',
+  '__findSequence', '__findClip', '__findClipInSequence', '__findProjectItem',
+  '__samePath', '__ticksToSeconds', '__secondsToTicks', '__mcpStringify',
+  '__mcpEscapeString', '__qeSequenceFor', '__findQeClipByDomClip',
+]);
+
+/** Every name bound anywhere in the script: vars, functions, params, catch clauses. */
+function declaredNames(node: any, into: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const child of node) declaredNames(child, into);
+    return;
+  }
+  if (node.type === 'VariableDeclarator' && node.id?.type === 'Identifier') {
+    into.add(node.id.name);
+  }
+  if (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression') {
+    if (node.id?.type === 'Identifier') into.add(node.id.name);
+    for (const param of node.params ?? []) {
+      if (param.type === 'Identifier') into.add(param.name);
+    }
+  }
+  if (node.type === 'CatchClause' && node.param?.type === 'Identifier') {
+    into.add(node.param.name);
+  }
+  for (const key of Object.keys(node)) {
+    if (key === 'type' || key === 'start' || key === 'end') continue;
+    declaredNames(node[key], into);
+  }
+}
+
+/** Identifiers actually read, ignoring property names and assignment targets. */
+function readNames(node: any, into: Set<string>, parent?: any, key?: string): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const child of node) readNames(child, into, parent, key);
+    return;
+  }
+  if (node.type === 'Identifier') {
+    const isProperty = parent?.type === 'MemberExpression' && key === 'property' && !parent.computed;
+    const isKey = parent?.type === 'Property' && key === 'key';
+    if (!isProperty && !isKey) into.add(node.name);
+    return;
+  }
+  for (const k of Object.keys(node)) {
+    if (k === 'type' || k === 'start' || k === 'end') continue;
+    readNames(node[k], into, node, k);
+  }
+}
+
+describe('generated scripts declare everything they reference', () => {
+  const ARGS: Record<string, unknown> = {
+    sequenceId: 'S', clipId: 'C', clipId1: 'A', clipId2: 'B', projectItemId: 'P',
+    name: 'N', newName: 'N2', binName: 'B', parentBinName: 'PB', folderPath: '/tmp/f',
+    filePath: '/tmp/f.xml', outputPath: '/tmp/o.png', lutPath: '/tmp/l.cube',
+    presetPath: '/tmp/p.epr', transitionName: 'Cross Dissolve', effectName: 'Gain',
+    trackType: 'video', trackIndex: 0, time: 1, newTime: 2, splitTime: 1, duration: 1,
+    speed: 100, volume: 0, locked: true, visible: true, enabled: true, markerId: 'M',
+    settings: {}, adjustments: {}, location: '/tmp', text: 'T', format: 'png',
+    // add_transition_to_clip needs this or it is rejected before emitting anything,
+    // which silently excluded it from this sweep.
+    position: 'end',
+  };
+
+  const capture = async (tool: string): Promise<string> => {
+    let script = '';
+    const tools = new PremiereProTools({
+      executeScript: async (s: string) => { script = s; return { success: true }; },
+    } as never);
+    try {
+      await tools.executeTool(tool, ARGS);
+    } catch {
+      // A schema rejection means no script; skipped below.
+    }
+    return script;
+  };
+
+  it('references no identifier that is never declared', async () => {
+    const probe = new PremiereProTools({ executeScript: async () => ({ success: true }) } as never);
+    const offenders: string[] = [];
+    let checked = 0;
+
+    for (const tool of probe.getAvailableTools()) {
+      const script = await capture(tool.name);
+      if (!script) continue;
+      checked++;
+
+      let ast: unknown;
+      try {
+        ast = parse(script, { ecmaVersion: 3, allowReturnOutsideFunction: true });
+      } catch {
+        continue; // parse failures are the syntax suite's business, not this one
+      }
+
+      const declared = new Set<string>();
+      const read = new Set<string>();
+      declaredNames(ast, declared);
+      readNames(ast, read);
+
+      for (const name of read) {
+        if (declared.has(name) || HOST_GLOBALS.has(name)) continue;
+        offenders.push(`${tool.name}: ${name}`);
+      }
+    }
+
+    // Guard against a silently broken capture making this pass vacuously.
+    expect(checked).toBeGreaterThan(40);
+    expect(offenders).toEqual([]);
+    // Walks every generated script; the default 5s limit is not enough.
+  }, 120_000);
+});

--- a/src/__tests__/tools/undefined-identifiers.test.ts
+++ b/src/__tests__/tools/undefined-identifiers.test.ts
@@ -23,7 +23,8 @@
 
 import { parse } from 'acorn';
 import { PremiereProTools } from '../../tools/index.js';
-import { seedArgs } from '../helpers/schema-args.js';
+import { expandedToolNames } from '../../tools/expanded.js';
+import { seedArgs, seedRequiredArgs } from '../helpers/schema-args.js';
 
 // Provided by the ExtendScript host or by the prelude the bridge prepends.
 const HOST_GLOBALS = new Set([
@@ -136,12 +137,22 @@ describe('generated scripts declare everything they reference', () => {
 
   it('references no identifier that is never declared', async () => {
     const probe = new PremiereProTools({ executeScript: async () => ({ success: true }) } as never);
+    const expanded = new Set<string>([...expandedToolNames]);
     const offenders: string[] = [];
+    const localToolsSeen = new Set<string>();
     let checked = 0;
 
     for (const tool of probe.getAvailableTools()) {
-      for (const script of await capture(tool, seedArgs(tool as never))) {
+      // Both argument sets. Supplying every optional was itself a blind spot: it
+      // fixed "a key the map lacked hid its branch" and created the mirror of it,
+      // where the branch taken when the caller omits that key is never emitted.
+      const argumentSets = [seedArgs(tool as never), seedRequiredArgs(tool as never)];
+      const scripts: string[] = [];
+      for (const args of argumentSets) scripts.push(...await capture(tool, args));
+
+      for (const script of scripts) {
         checked++;
+        if (!expanded.has(tool.name)) localToolsSeen.add(tool.name);
 
         let ast: Node;
         try {
@@ -158,9 +169,10 @@ describe('generated scripts declare everything they reference', () => {
       }
     }
 
-    // Guard against a silently broken capture making this pass vacuously. Driving
-    // from the schema reaches every tool that emits, not the subset one fixed
-    // argument map happened to satisfy.
+    // Floored on distinct LOCAL tools, not on total scripts. The old floor of 100
+    // scripts was met by the expanded tools alone -- they all emit one shared body,
+    // so sabotaging every local tool left it green.
+    expect(localToolsSeen.size).toBeGreaterThan(60);
     expect(checked).toBeGreaterThan(100);
     expect([...new Set(offenders)]).toEqual([]);
     // Walks every generated script; the default 5s limit is not enough.

--- a/src/__tests__/tools/undefined-identifiers.test.ts
+++ b/src/__tests__/tools/undefined-identifiers.test.ts
@@ -7,12 +7,23 @@
  * TypeScript compiles, the script parses, and the failure appears only when the
  * host runs it — as a ReferenceError on every call to that tool.
  *
- * This walks the emitted script's AST and reports any identifier that is read
- * without being declared, parameterised, or provided by the host.
+ * Two ways the earlier version of this file missed exactly that:
+ *
+ *   - It collected every binding anywhere in the script into one flat set, so a
+ *     name that exists only as a parameter of a nested function counted as
+ *     declared at top level. Referencing `wanted` — a parameter of the nested
+ *     `__binByName(parent, wanted)` — from `create_bin`'s body threw
+ *     `ReferenceError` at runtime and passed here. Scopes are now tracked, with
+ *     `var` hoisting to the enclosing function as ES3 requires.
+ *   - It drove every tool from one hand-written `ARGS` object, so a branch
+ *     guarded by a key that object lacked was never emitted. `add_marker`'s
+ *     `${comment ? ... : ''}` was never in the AST being walked. Arguments now
+ *     come from each tool's own schema, optionals included.
  */
 
 import { parse } from 'acorn';
 import { PremiereProTools } from '../../tools/index.js';
+import { seedArgs } from '../helpers/schema-args.js';
 
 // Provided by the ExtendScript host or by the prelude the bridge prepends.
 const HOST_GLOBALS = new Set([
@@ -24,75 +35,103 @@ const HOST_GLOBALS = new Set([
   '__mcpEscapeString', '__qeSequenceFor', '__findQeClipByDomClip',
 ]);
 
-/** Every name bound anywhere in the script: vars, functions, params, catch clauses. */
-function declaredNames(node: any, into: Set<string>): void {
-  if (!node || typeof node !== 'object') return;
-  if (Array.isArray(node)) {
-    for (const child of node) declaredNames(child, into);
-    return;
-  }
-  if (node.type === 'VariableDeclarator' && node.id?.type === 'Identifier') {
-    into.add(node.id.name);
-  }
-  if (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression') {
-    if (node.id?.type === 'Identifier') into.add(node.id.name);
-    for (const param of node.params ?? []) {
-      if (param.type === 'Identifier') into.add(param.name);
-    }
-  }
-  if (node.type === 'CatchClause' && node.param?.type === 'Identifier') {
-    into.add(node.param.name);
-  }
+type Node = Record<string, any>;
+
+interface Scope { parent: Scope | null; names: Set<string> }
+
+const newScope = (parent: Scope | null): Scope => ({ parent, names: new Set() });
+
+const isFunction = (n: Node): boolean =>
+  n.type === 'FunctionDeclaration' || n.type === 'FunctionExpression';
+
+const resolves = (scope: Scope, name: string): boolean => {
+  for (let s: Scope | null = scope; s; s = s.parent) if (s.names.has(name)) return true;
+  return HOST_GLOBALS.has(name);
+};
+
+const children = (node: Node): Node[] => {
+  const out: Node[] = [];
   for (const key of Object.keys(node)) {
     if (key === 'type' || key === 'start' || key === 'end') continue;
-    declaredNames(node[key], into);
+    const value = node[key];
+    if (Array.isArray(value)) {
+      for (const v of value) if (v && typeof v === 'object') out.push(v);
+    } else if (value && typeof value === 'object') {
+      out.push(value);
+    }
   }
+  return out;
+};
+
+/**
+ * `var` and function declarations reachable without entering a nested function.
+ * ES3 hoists both to the top of the enclosing function, so a use above the
+ * declaration is legal and must not be reported.
+ */
+function hoist(node: Node, scope: Scope): void {
+  if (node.type === 'VariableDeclarator' && node.id?.type === 'Identifier') {
+    scope.names.add(node.id.name);
+  }
+  if (node.type === 'FunctionDeclaration' && node.id?.type === 'Identifier') {
+    scope.names.add(node.id.name);
+    return; // its body belongs to its own scope
+  }
+  if (node.type === 'FunctionExpression') return;
+  for (const child of children(node)) hoist(child, scope);
 }
 
-/** Identifiers actually read, ignoring property names and assignment targets. */
-function readNames(node: any, into: Set<string>, parent?: any, key?: string): void {
-  if (!node || typeof node !== 'object') return;
-  if (Array.isArray(node)) {
-    for (const child of node) readNames(child, into, parent, key);
+function walk(node: Node, scope: Scope, offenders: Set<string>, parent?: Node, key?: string): void {
+  if (isFunction(node)) {
+    const inner = newScope(scope);
+    if (node.type === 'FunctionExpression' && node.id?.type === 'Identifier') {
+      inner.names.add(node.id.name);
+    }
+    for (const param of node.params ?? []) {
+      if (param.type === 'Identifier') inner.names.add(param.name);
+    }
+    hoist(node.body, inner);
+    walk(node.body, inner, offenders);
     return;
   }
+
+  if (node.type === 'CatchClause') {
+    const inner = newScope(scope);
+    if (node.param?.type === 'Identifier') inner.names.add(node.param.name);
+    hoist(node.body, inner);
+    walk(node.body, inner, offenders);
+    return;
+  }
+
   if (node.type === 'Identifier') {
     const isProperty = parent?.type === 'MemberExpression' && key === 'property' && !parent.computed;
     const isKey = parent?.type === 'Property' && key === 'key';
-    if (!isProperty && !isKey) into.add(node.name);
+    if (!isProperty && !isKey && !resolves(scope, node.name)) offenders.add(node.name);
     return;
   }
+
   for (const k of Object.keys(node)) {
     if (k === 'type' || k === 'start' || k === 'end') continue;
-    readNames(node[k], into, node, k);
+    const value = node[k];
+    if (Array.isArray(value)) {
+      for (const v of value) if (v && typeof v === 'object') walk(v, scope, offenders, node, k);
+    } else if (value && typeof value === 'object') {
+      walk(value, scope, offenders, node, k);
+    }
   }
 }
 
 describe('generated scripts declare everything they reference', () => {
-  const ARGS: Record<string, unknown> = {
-    sequenceId: 'S', clipId: 'C', clipId1: 'A', clipId2: 'B', projectItemId: 'P',
-    name: 'N', newName: 'N2', binName: 'B', parentBinName: 'PB', folderPath: '/tmp/f',
-    filePath: '/tmp/f.xml', outputPath: '/tmp/o.png', lutPath: '/tmp/l.cube',
-    presetPath: '/tmp/p.epr', transitionName: 'Cross Dissolve', effectName: 'Gain',
-    trackType: 'video', trackIndex: 0, time: 1, newTime: 2, splitTime: 1, duration: 1,
-    speed: 100, volume: 0, locked: true, visible: true, enabled: true, markerId: 'M',
-    settings: {}, adjustments: {}, location: '/tmp', text: 'T', format: 'png',
-    // add_transition_to_clip needs this or it is rejected before emitting anything,
-    // which silently excluded it from this sweep.
-    position: 'end',
-  };
-
-  const capture = async (tool: string): Promise<string> => {
-    let script = '';
+  const capture = async (tool: { name: string }, args: Record<string, unknown>): Promise<string[]> => {
+    const scripts: string[] = [];
     const tools = new PremiereProTools({
-      executeScript: async (s: string) => { script = s; return { success: true }; },
+      executeScript: async (s: string) => { scripts.push(s); return { success: true }; },
     } as never);
     try {
-      await tools.executeTool(tool, ARGS);
+      await tools.executeTool(tool.name, args);
     } catch {
-      // A schema rejection means no script; skipped below.
+      // A schema rejection means nothing was emitted; skipped below.
     }
-    return script;
+    return scripts;
   };
 
   it('references no identifier that is never declared', async () => {
@@ -101,31 +140,29 @@ describe('generated scripts declare everything they reference', () => {
     let checked = 0;
 
     for (const tool of probe.getAvailableTools()) {
-      const script = await capture(tool.name);
-      if (!script) continue;
-      checked++;
+      for (const script of await capture(tool, seedArgs(tool as never))) {
+        checked++;
 
-      let ast: unknown;
-      try {
-        ast = parse(script, { ecmaVersion: 3, allowReturnOutsideFunction: true });
-      } catch {
-        continue; // parse failures are the syntax suite's business, not this one
-      }
+        let ast: Node;
+        try {
+          ast = parse(script, { ecmaVersion: 3, allowReturnOutsideFunction: true }) as never;
+        } catch {
+          continue; // parse failures are the syntax suite's business, not this one
+        }
 
-      const declared = new Set<string>();
-      const read = new Set<string>();
-      declaredNames(ast, declared);
-      readNames(ast, read);
-
-      for (const name of read) {
-        if (declared.has(name) || HOST_GLOBALS.has(name)) continue;
-        offenders.push(`${tool.name}: ${name}`);
+        const top = newScope(null);
+        hoist(ast, top);
+        const found = new Set<string>();
+        walk(ast, top, found);
+        for (const name of found) offenders.push(`${tool.name}: ${name}`);
       }
     }
 
-    // Guard against a silently broken capture making this pass vacuously.
-    expect(checked).toBeGreaterThan(40);
-    expect(offenders).toEqual([]);
+    // Guard against a silently broken capture making this pass vacuously. Driving
+    // from the schema reaches every tool that emits, not the subset one fixed
+    // argument map happened to satisfy.
+    expect(checked).toBeGreaterThan(100);
+    expect([...new Set(offenders)]).toEqual([]);
     // Walks every generated script; the default 5s limit is not enough.
-  }, 120_000);
+  }, 300_000);
 });

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -60,6 +60,61 @@ function __findSequence(id) {
   }
   return null;
 }
+function __qeSequenceFor(seq) {
+  if (!seq) return null;
+  try { app.enableQE(); } catch (eEnable) { return null; }
+  var count = 0;
+  try { count = qe.project.numSequences; } catch (eCount) { return null; }
+  for (var qi = 0; qi < count; qi++) {
+    // Each index is guarded separately: qe.project.numSequences can report more
+    // sequences than getSequenceAt() will actually return, and a throw at one
+    // index must not abort the scan before the target index is reached.
+    try {
+      var candidate = qe.project.getSequenceAt(qi);
+      if (candidate && String(candidate.guid) === String(seq.sequenceID)) return candidate;
+    } catch (eAt) {}
+  }
+  // getSequenceAt() does not expose every sequence: one created by
+  // duplicate_sequence and never opened in a timeline is invisible to it, even
+  // while it is the active sequence. getActiveSequence() still returns a
+  // working handle in that case — verified against 26.0.2, guid and all — so
+  // fall back to it, but only once the guid confirms it is the sequence that
+  // was asked for. Addressing the wrong one is the bug this helper exists to
+  // prevent.
+  try {
+    var activeCandidate = qe.project.getActiveSequence();
+    if (activeCandidate && String(activeCandidate.guid) === String(seq.sequenceID)) return activeCandidate;
+  } catch (eActive) {}
+  return null;
+}
+function __findQeClipByDomClip(qeTrack, domClip) {
+  // QE track items are not the DOM clip list: they include gaps and
+  // transitions, so the DOM clip index addresses a different item as soon as
+  // anything precedes the target. Verified against 26.0.2 — a track holding
+  // three clips with one gap reported five QE items, and color_correct on DOM
+  // clip 2 landed on the gap at QE index 2 and reported success having done
+  // nothing. Match on start time instead, and skip anything that is not a clip.
+  if (!qeTrack || !domClip) return null;
+  var targetTicks = null;
+  try { targetTicks = String(domClip.start.ticks); } catch (eTarget) {}
+  var best = null, bestDelta = null;
+  for (var qi = 0; qi < qeTrack.numItems; qi++) {
+    var item = qeTrack.getItemAt(qi);
+    if (!item) continue;
+    var itemType = null;
+    try { itemType = String(item.type); } catch (eType) {}
+    if (itemType !== "Clip") continue;
+    if (targetTicks === null) return item;
+    var itemTicks = null;
+    try { itemTicks = String(item.start.ticks); } catch (eItem) {}
+    if (itemTicks === targetTicks) return item;
+    if (itemTicks !== null) {
+      var delta = Math.abs(parseInt(itemTicks, 10) - parseInt(targetTicks, 10));
+      if (best === null || delta < bestDelta) { best = item; bestDelta = delta; }
+    }
+  }
+  return best;
+}
 function __findClipInSequence(seq, nodeId) {
   if (!seq) return null;
   for (var t = 0; t < seq.videoTracks.numTracks; t++) {
@@ -625,15 +680,21 @@ export class PremiereProBridge implements PremiereProTransport {
     return await this.executeScript(script);
   }
 
-  async addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio: boolean = true, sourceInPoint?: number, sourceOutPoint?: number): Promise<PremiereProClip> {
+  async addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio: boolean = true, sourceInPoint?: number, sourceOutPoint?: number, insertMode: string = 'overwrite'): Promise<PremiereProClip> {
+    const useInsert = insertMode === 'insert';
     const script = `
       try {
-        var sequence = __findSequence("${sequenceId}");
+        // Both ids are caller-supplied and are embedded in generated ExtendScript.
+        // Naive quoting here was a full code-execution hole, not just a bad error
+        // message: an id of zz"); return JSON.stringify({PWNED:"..."}); (" closed
+        // the call, ran arbitrary script, and returned a forged tool result while
+        // the real work never happened.
+        var sequence = __findSequence(${JSON.stringify(sequenceId)});
         if (!sequence) {
-          return JSON.stringify({ success: false, error: "Sequence not found" });
+          return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         }
 
-        var projectItem = __findProjectItem("${projectItemId}");
+        var projectItem = __findProjectItem(${JSON.stringify(projectItemId)});
         if (!projectItem) {
           return JSON.stringify({ success: false, error: "Project item not found" });
         }
@@ -694,7 +755,24 @@ export class PremiereProBridge implements PremiereProTransport {
           }
         }
 
-        track.overwriteClip(projectItem, ${time});
+        // insertMode was accepted by the tool, echoed back in its response, and then
+        // dropped: placement was always an overwrite. A caller asking to insert-and-shift
+        // therefore had existing footage destroyed and was told the opposite. Both methods
+        // exist on video and audio tracks in 26.0.2, so honour the request — and refuse
+        // rather than silently overwriting if this build lacks insertClip, since falling
+        // back would be the destructive direction.
+        var requestedInsert = ${useInsert ? 'true' : 'false'};
+        if (requestedInsert) {
+          if (typeof track.insertClip !== "function") {
+            return JSON.stringify({
+              success: false,
+              error: "insertMode 'insert' was requested but this Premiere build exposes no track.insertClip. Refusing rather than overwriting, which would delete existing footage."
+            });
+          }
+          track.insertClip(projectItem, ${time});
+        } else {
+          track.overwriteClip(projectItem, ${time});
+        }
 
         var placedClip = null;
         for (var i = 0; i < track.clips.numItems; i++) {
@@ -705,12 +783,19 @@ export class PremiereProBridge implements PremiereProTransport {
           }
         }
 
-        if (!placedClip && track.clips.numItems > 0) {
-          placedClip = track.clips[track.clips.numItems - 1];
-        }
-
+        // No fallback to track.clips[numItems - 1]. That guessed at the last clip on the
+        // track — which is simply whatever was already there when the placement did not
+        // happen — and then reported its name, times and id back as though they were the
+        // new clip. Worse, its start time drove the linkAudio=false sweep below, so a
+        // placement that did nothing could delete a completely unrelated audio clip.
+        // If the clip cannot be identified, nothing downstream may act on a guess.
         if (!placedClip) {
-          return JSON.stringify({ success: false, error: "Clip placement did not produce a track item" });
+          return JSON.stringify({
+            success: false,
+            error: "Placement could not be confirmed: no clip from this project item appears at " + ${time} + "s on the target track. Nothing was reported back and no linked audio was removed.",
+            trackKind: trackKind,
+            requestedTime: ${time}
+          });
         }
 
         // linkAudio=false post-processing: when placing a video-track clip whose source
@@ -752,6 +837,7 @@ export class PremiereProBridge implements PremiereProTransport {
           outPoint: placedClip.end.seconds,
           duration: placedClip.duration.seconds,
           mediaPath: placedClip.projectItem && placedClip.projectItem.getMediaPath ? placedClip.projectItem.getMediaPath() : "",
+          insertMode: ${JSON.stringify(useInsert ? 'insert' : 'overwrite')},
           linkAudio: ${linkAudio},
           unlinkedAudioRemoved: unlinkedAudioRemoved,
           appliedSourceInOut: appliedSourceInOut,
@@ -833,10 +919,15 @@ export class PremiereProBridge implements PremiereProTransport {
                 break;
               }
             }
-            if (!placedClip && track.clips.numItems > 0) {
-              placedClip = track.clips[track.clips.numItems - 1];
+            // Same reasoning as the single-call path: never fall back to the last clip on
+            // the track. An unconfirmed placement here fed both this result row and the
+            // linkAudio=false sweep below, so one no-op could report a pre-existing clip
+            // as placed and delete an unrelated audio clip alongside it.
+            if (!placedClip) {
+              r.error = "Placement could not be confirmed: no clip from this project item appears at " + spec.time + "s on the target track. No linked audio was removed.";
+              results.push(r);
+              continue;
             }
-            if (!placedClip) { r.error = "Clip placement did not produce a track item"; results.push(r); continue; }
 
             r.success = true;
             r.id = placedClip.nodeId;

--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -12,7 +12,7 @@ export interface PremiereProTransport {
   saveProject(): Promise<void>;
   importMedia(filePath: string): Promise<PremiereProProjectItem>;
   createSequence(name: string, presetPath: string): Promise<PremiereProSequence>;
-  addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio?: boolean, sourceInPoint?: number, sourceOutPoint?: number): Promise<PremiereProClip>;
+  addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, linkAudio?: boolean, sourceInPoint?: number, sourceOutPoint?: number, insertMode?: string): Promise<PremiereProClip>;
   addToTimelineBatch(sequenceId: string, clips: Array<{ projectItemId: string; trackIndex: number; time: number; linkAudio?: boolean; sourceInPoint?: number; sourceOutPoint?: number }>): Promise<any>;
   renderSequence(sequenceId: string, outputPath: string, presetPath: string, options?: {
     sourceRange?: 'entire' | 'in_out' | 'work_area';

--- a/src/tools/expanded.ts
+++ b/src/tools/expanded.ts
@@ -565,6 +565,38 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
     function fail(message, details) { return JSON.stringify({ success: false, tool: toolName, error: String(message), details: details || null }); }
     function secondsToTicks(seconds) { return String(Math.round(Number(seconds || 0) * 254016000000)); }
     function ticksToSeconds(ticks) { return parseInt(String(ticks || "0"), 10) / 254016000000; }
+    // Premiere's marker palette, in setColorByIndex() order. getColorByIndex()
+    // is a getter despite the name — it ignores any argument and returns the
+    // marker's own index. It is not bounded by the 0-7 write domain: a marker
+    // can hold -1, a "no colour assigned" state that renders black, so the name
+    // lookup is guarded and reports null rather than an absent key.
+    var MARKER_COLOR_NAMES = ["green","red","purple","orange","yellow","white","blue","cyan"];
+    function markerColor(marker) {
+      var index = -1;
+      try { index = Number(marker.getColorByIndex()); } catch (e) { return { index: null, name: null }; }
+      if (isNaN(index)) return { index: null, name: null };
+      var withinPalette = index >= 0 && index < MARKER_COLOR_NAMES.length;
+      return { index: index, name: withinPalette ? MARKER_COLOR_NAMES[index] : null };
+    }
+    // Mirrors the sequence-marker resolver: a name (case-insensitive) or an
+    // index 0-7. Returns null for "not supplied" and the string "invalid" for
+    // input that cannot be honoured, so the caller can be told rather than
+    // silently given the default colour.
+    function resolveMarkerColorIndex(value) {
+      if (value === undefined || value === null || value === "") return null;
+      if (typeof value === "number") {
+        if (value !== Math.floor(value) || value < 0 || value > 7) return "invalid";
+        return value;
+      }
+      // \\s, not \s: inside a template literal \s collapses to a bare "s",
+      // so the emitted code would strip the letter s instead of whitespace.
+      var text = String(value).replace(/^\\s+|\\s+$/g, "").toLowerCase();
+      if (/^[0-7]$/.test(text)) return Number(text);
+      for (var ci = 0; ci < MARKER_COLOR_NAMES.length; ci++) {
+        if (MARKER_COLOR_NAMES[ci] === text) return ci;
+      }
+      return "invalid";
+    }
     function valueOfTime(timeValue) {
       if (!timeValue) return 0;
       if (typeof timeValue.seconds !== "undefined") return Number(timeValue.seconds);
@@ -581,6 +613,84 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         if (seq.sequenceID === idOrName || seq.name === idOrName) return seq;
       }
       return null;
+    }
+    // Returns an error message when the caller named a sequence that does not
+    // resolve, and null otherwise. targetSequence() already distinguishes "no id
+    // given" (use the active sequence) from "id given but unresolvable" (null),
+    // but every call site fell back to the active sequence anyway, which
+    // collapsed the two — so a stale id silently operated on whatever sequence
+    // happened to be on screen and reported success.
+    // Maps a DOM sequence to its QE counterpart. QE exposes .guid, which is the
+    // same value as sequence.sequenceID, so this is exact — no name matching and
+    // no assumption that QE and DOM index orders agree.
+    //
+    // This exists because qe.project.getActiveSequence() is what most QE work
+    // used, which silently retargets to whatever is on screen. QE can address any
+    // sequence, so honouring a sequenceId needs no activation and no restore.
+    function parRatioString(value) {
+      // videoPixelAspectRatio is a string in "N:M" form, not a number. Assigning a
+      // number throws "Illegal Parameter type" — verified against 26.0.2, where every
+      // ratio string tried (1:1, 10:11, 40:33, 4:3, 3:2, 2:1, 64:45, 16:9, 1:2) was
+      // accepted verbatim and read back unchanged.
+      var text = String(value);
+      if (text.indexOf(":") !== -1) return text;
+      var num = Number(value);
+      if (!isFinite(num) || num <= 0) return null;
+      // Reduce the decimal to a fraction so 1.5 becomes "3:2" rather than a value
+      // Premiere will not accept.
+      var denominator = 1000;
+      var numerator = Math.round(num * denominator);
+      function gcd(a, b) { while (b) { var t = a % b; a = b; b = t; } return a; }
+      var g = gcd(numerator, denominator);
+      return (numerator / g) + ":" + (denominator / g);
+    }
+    function qeSequenceFor(seq) {
+      if (!seq) return null;
+      try { app.enableQE(); } catch (eEnable) { return null; }
+      var count = 0;
+      try { count = qe.project.numSequences; } catch (eCount) { return null; }
+      for (var qi = 0; qi < count; qi++) {
+        // Each index is guarded separately: qe.project.numSequences can report
+        // more sequences than getSequenceAt() will actually return, and a throw
+        // at one index must not abort the scan before the target is reached.
+        try {
+          var cand = qe.project.getSequenceAt(qi);
+          if (cand && String(cand.guid) === String(seq.sequenceID)) return cand;
+        } catch (eAt) {}
+      }
+      // getSequenceAt() does not expose every sequence: one created by
+      // duplicate_sequence and never opened in a timeline is invisible to it, even
+      // while it is the active sequence. getActiveSequence() still returns a
+      // working handle in that case — verified against 26.0.2, guid and all — so
+      // fall back to it, but only once the guid confirms it is the sequence that
+      // was asked for. Addressing the wrong one is the bug this helper exists to
+      // prevent.
+      try {
+        var activeCandidate = qe.project.getActiveSequence();
+        if (activeCandidate && String(activeCandidate.guid) === String(seq.sequenceID)) return activeCandidate;
+      } catch (eActive) {}
+      return null;
+    }
+    function sequenceRequestError() {
+      // An empty or whitespace-only id is a supplied id, not an omitted one.
+      // Treating "" as absent let it fall through to the active sequence, which
+      // is the exact substitution this guard exists to prevent.
+      // Only fall back to the snake_case alias when sequenceId is genuinely
+      // absent. Treating "" as absent would send an empty id down the
+      // omitted-id path, which is the substitution this guard exists to stop.
+      var requested = args.sequenceId;
+      if (requested === undefined || requested === null) requested = args.sequence_id;
+      if (requested === undefined || requested === null) return null;
+      // \\s, not \s: this lives in a template literal, where \s collapses to a
+      // bare "s" and would strip the letter s instead of whitespace.
+      requested = String(requested).replace(/^\\s+|\\s+$/g, "");
+      if (requested === "") {
+        return "sequenceId was supplied but empty. Omit it to use the active sequence, " +
+          "or pass an id from list_sequences or get_active_sequence.";
+      }
+      if (findSequence(requested)) return null;
+      return "Sequence not found by id: " + requested +
+        ". Use list_sequences or get_active_sequence to obtain a valid sequence ID.";
     }
     function targetSequence() {
       return args.sequenceId || args.sequence_id ? findSequence(args.sequenceId || args.sequence_id) : activeSequence();
@@ -630,8 +740,16 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
       });
       return found;
     }
+    // Set when a lookup helper bailed because the caller's sequenceId could not
+    // be resolved. The helpers can only return null to mean "not found", so the
+    // specific reason is parked here and preferred over the generic message at
+    // the call site. One tool call per generated script, so this cannot leak
+    // between requests.
+    var pendingSequenceError = null;
     function findClip(nodeId) {
-      var seq = targetSequence() || activeSequence();
+      var seqErr = sequenceRequestError();
+      if (seqErr) { pendingSequenceError = seqErr; return null; }
+      var seq = targetSequence();
       if (!seq) return null;
       function scan(collection, type) {
         for (var t = 0; t < collection.numTracks; t++) {
@@ -693,7 +811,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
       return data;
     }
     function setSelection(matchFn, selected, additive) {
-      var seq = targetSequence() || activeSequence();
+      var seqErr = sequenceRequestError();
+      if (seqErr) return fail(seqErr);
+      var seq = targetSequence();
       if (!seq) return fail("No active sequence");
       var changed = [];
       function apply(collection, type) {
@@ -868,16 +988,23 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
       return null;
     }
     function qeClipForClip(found) {
+      // findClip() searches every sequence, so the clip may not live in the active
+      // one; and QE track items include gaps and transitions, so the DOM clip index
+      // addresses a different item. Both were fixed at the tool call sites but missed
+      // here, which meant every tool routing through this helper -- set_frame_blend,
+      // set_time_interpolation, set_clip_volume, set_clip_pan, set_clip_opacity --
+      // kept mutating whatever sat at that index in whatever sequence was on screen.
       if (!found) return null;
-      app.enableQE();
-      var qeSeq = qe.project.getActiveSequence();
+      var qeSeq = qeSequenceFor(found.sequence);
       if (!qeSeq) return null;
       var qeTrack = found.trackType === "video" ? qeSeq.getVideoTrackAt(found.trackIndex) : qeSeq.getAudioTrackAt(found.trackIndex);
       if (!qeTrack) return null;
-      return qeTrack.getItemAt(found.clipIndex);
+      return __findQeClipByDomClip(qeTrack, found.clip);
     }
     function markerCollectionForTool() {
-      var seq = targetSequence() || activeSequence();
+      var seqErr = sequenceRequestError();
+      if (seqErr) { pendingSequenceError = seqErr; return null; }
+      var seq = targetSequence();
       if (args.projectItemId || args.itemId || args.item_id) {
         var markerItem = findItem(args.projectItemId || args.itemId || args.item_id);
         if (markerItem && markerItem.getMarkers) return markerItem.getMarkers();
@@ -940,9 +1067,13 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
 
         case "get_sequence_structure":
         case "get_full_sequence_info":
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
           return ok(sequenceStructure(targetSequence()));
 
         case "get_timeline_summary":
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
           var sumSeq = targetSequence();
           var structure = sequenceStructure(sumSeq);
           var videoClips = 0;
@@ -957,6 +1088,8 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ count: app.project && app.project.sequences ? app.project.sequences.numSequences : 0 });
 
         case "get_total_clip_count":
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
           var countStruct = sequenceStructure(targetSequence());
           var vCount = 0, aCount = 0;
           if (countStruct) {
@@ -1048,7 +1181,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ value: app.project.getGraphicsWhiteLuminance() });
 
         case "is_work_area_enabled":
-          var workSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var workSeq = targetSequence();
           if (!workSeq) return fail("No active sequence");
           var workAreaEnabled = null;
           try { if (workSeq.isWorkAreaEnabled) workAreaEnabled = Boolean(workSeq.isWorkAreaEnabled()); } catch (workEnabledError) {}
@@ -1057,7 +1192,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ enabled: workAreaEnabled });
 
         case "get_timeline_gaps":
-          var gapSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var gapSeq = targetSequence();
           if (!gapSeq) return fail("No active sequence");
           var gaps = [];
           for (var gt = 0; gt < gapSeq.videoTracks.numTracks; gt++) {
@@ -1168,7 +1305,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
 
         case "insert_from_source":
         case "overwrite_from_source":
-          var editSeq = activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var editSeq = targetSequence();
           var editItem = app.sourceMonitor.getProjectItem();
           if (!editSeq || !editItem) return fail("Need active sequence and source monitor item");
           var editPos = editSeq.getPlayerPosition().ticks;
@@ -1193,7 +1332,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return setSelection(function(clip) { return clip.nodeId === (args.clipId || args.node_id || args.nodeId); }, Boolean(args.selected !== false), true);
 
         case "get_target_tracks":
-          var targetSeq = activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var targetSeq = targetSequence();
           if (!targetSeq) return fail("No active sequence");
           var videoTargets = [], audioTargets = [];
           for (var tv = 0; tv < targetSeq.videoTracks.numTracks; tv++) { try { if (targetSeq.videoTracks[tv].isTargeted()) videoTargets.push({ index: tv, name: targetSeq.videoTracks[tv].name }); } catch (e) {} }
@@ -1201,7 +1342,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ video: videoTargets, audio: audioTargets });
 
         case "set_target_track":
-          var targetTrackSeq = activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var targetTrackSeq = targetSequence();
           if (!targetTrackSeq) return fail("No active sequence");
           var targetCollection = String(args.track_type || args.trackType || "video") === "audio" ? targetTrackSeq.audioTracks : targetTrackSeq.videoTracks;
           var targetTrack = targetCollection[Number(args.track_index || args.trackIndex || 0)];
@@ -1210,14 +1353,18 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ targeted: Boolean(args.targeted !== false) });
 
         case "rename_track":
-          var renameSeq = activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var renameSeq = targetSequence();
           if (!renameSeq) return fail("No active sequence");
           var renameTracks = String(args.track_type || args.trackType || "video") === "audio" ? renameSeq.audioTracks : renameSeq.videoTracks;
           renameTracks[Number(args.track_index || args.trackIndex || 0)].name = String(args.name || args.newName);
           return ok({ renamed: true, name: String(args.name || args.newName) });
 
         case "get_track_info":
-          var infoSeq = activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var infoSeq = targetSequence();
           if (!infoSeq) return fail("No active sequence");
           var trackType = String(args.track_type || args.trackType || "video");
           var trackIndex = Number(args.track_index || args.trackIndex || 0);
@@ -1417,7 +1564,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "remove_effect":
         case "remove_effect_by_name":
           var removeEffectClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!removeEffectClip) return fail("Clip not found");
+          if (!removeEffectClip) return fail(pendingSequenceError || "Clip not found");
           var effectToRemove = findComponent(removeEffectClip.clip, args.effectName || args.name);
           if (!effectToRemove) return ok({ removed: true, changed: false, effect: args.effectName || args.name, note: "Effect was already absent from clip" });
           var removeEffectResult = tryCall(effectToRemove.component, ["remove", "delete"], []);
@@ -1427,7 +1574,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "ripple_delete":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail("ripple_delete requires clipId.");
           var rippleClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!rippleClip) return fail("Clip not found");
+          if (!rippleClip) return fail(pendingSequenceError || "Clip not found");
           rippleClip.clip.remove(true, true);
           return ok({ removed: true, ripple: true, clipId: args.clipId || args.node_id || args.nodeId });
 
@@ -1436,7 +1583,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "slip_edit":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail(toolName + " requires clipId.");
           var trimClipInfo = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!trimClipInfo) return fail("Clip not found");
+          if (!trimClipInfo) return fail(pendingSequenceError || "Clip not found");
           var editDelta = Number(args.delta || args.deltaSeconds || args.amount || 0);
           if (toolName === "slip_edit") {
             trimClipInfo.clip.inPoint = secondsToTime(valueOfTime(trimClipInfo.clip.inPoint) + editDelta);
@@ -1466,7 +1613,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "move_clip_to_track":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail("move_clip_to_track requires clipId.");
           var moveTrackClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!moveTrackClip) return fail("Clip not found");
+          if (!moveTrackClip) return fail(pendingSequenceError || "Clip not found");
           var moveTrackResult = tryCall(moveTrackClip.clip, ["moveToTrack", "setTrack"], [Number(args.trackIndex || args.newTrackIndex || 0)]);
           if (moveTrackResult.called) return ok({ moved: true, trackIndex: Number(args.trackIndex || args.newTrackIndex || 0), method: moveTrackResult.method });
           var moveTargetIndex = Number(args.trackIndex || args.newTrackIndex || 0);
@@ -1486,7 +1633,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "remove_all_effects":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail("remove_all_effects requires clipId.");
           var removeAllClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!removeAllClip) return fail("Clip not found");
+          if (!removeAllClip) return fail(pendingSequenceError || "Clip not found");
           var removedEffects = [];
           var failedEffects = [];
           for (var rai = removeAllClip.clip.components.numItems - 1; rai >= 0; rai--) {
@@ -1503,11 +1650,12 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "set_clip_speed_qe":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail("set_clip_speed_qe requires clipId.");
           var speedClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!speedClip) return fail("Clip not found");
-          app.enableQE();
-          var speedQeSeq = qe.project.getActiveSequence();
+          if (!speedClip) return fail(pendingSequenceError || "Clip not found");
+          var speedQeSeq = qeSequenceFor(speedClip.sequence);
+          if (!speedQeSeq) return fail("Could not address sequence '" + speedClip.sequence.name + "' through the QE API.");
           var speedQeTrack = speedClip.trackType === "video" ? speedQeSeq.getVideoTrackAt(speedClip.trackIndex) : speedQeSeq.getAudioTrackAt(speedClip.trackIndex);
-          var speedQeClip = speedQeTrack.getItemAt(speedClip.clipIndex);
+          if (!speedQeTrack) return fail("QE track not found at index " + speedClip.trackIndex);
+          var speedQeClip = __findQeClipByDomClip(speedQeTrack, speedClip.clip);
           if (!speedQeClip || !speedQeClip.setSpeed) return fail("QE clip setSpeed API unavailable");
           var requestedSpeed = Number(args.speed || args.percent || 100);
           try {
@@ -1524,7 +1672,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "set_time_interpolation":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail(toolName + " requires clipId.");
           var interpClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!interpClip) return fail("Clip not found");
+          if (!interpClip) return fail(pendingSequenceError || "Clip not found");
           var interpQeClip = qeClipForClip(interpClip);
           if (!interpQeClip) return fail("QE clip not found");
           var interpMethod = "setFrameBlend";
@@ -1536,7 +1684,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ method: interpResult.method, value: interpValue, before: interpBefore, after: interpAfter });
 
         case "overwrite_clip":
-          var overwriteSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var overwriteSeq = targetSequence();
           var overwriteItem = findItem(args.projectItemId || args.itemId || args.item_id);
           if (!overwriteSeq || !overwriteItem) return fail("Need sequence and project item");
           overwriteSeq.overwriteClip(overwriteItem, secondsToTicks(args.time || args.start || 0), Number(args.videoTrackIndex || args.video_track_index || args.trackIndex || 0), Number(args.audioTrackIndex || args.audio_track_index || 0));
@@ -1556,21 +1706,27 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ created: true, name: sequenceFromClips.name, sequenceId: sequenceFromClips.sequenceID, itemCount: clipItems.length });
 
         case "close_sequence":
-          var closeSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var closeSeq = targetSequence();
           if (!closeSeq) return fail("No sequence found");
           var closeSeqResult = tryCall(closeSeq, ["close"], []);
           if (!closeSeqResult.called) return fail(closeSeqResult.error, { available: false });
           return ok({ closed: true, sequenceId: closeSeq.sequenceID, sequenceName: closeSeq.name, method: closeSeqResult.method });
 
         case "export_as_project":
-          var exportProjectSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var exportProjectSeq = targetSequence();
           if (!exportProjectSeq) return fail("No sequence found");
           var exportProjectResult = tryCall(exportProjectSeq, ["exportAsProject"], [String(args.outputPath || args.path || "")]);
           if (!exportProjectResult.called) return fail(exportProjectResult.error, { available: false });
           return ok({ exported: true, outputPath: String(args.outputPath || args.path || ""), method: exportProjectResult.method });
 
         case "export_omf":
-          var omfSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var omfSeq = targetSequence();
           if (!omfSeq) return fail("No sequence found");
           var omfPath = String(args.outputPath || args.path || "");
           var omfResult = tryCall(omfSeq, ["exportAsOMF", "exportOMF"], [omfPath]);
@@ -1579,7 +1735,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ exported: true, outputPath: omfPath, method: omfResult.method });
 
         case "set_zero_point":
-          var zeroSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var zeroSeq = targetSequence();
           if (!zeroSeq) return fail("No sequence found");
           var zeroTicks = secondsToTicks(args.time || args.seconds || 0);
           var zeroResult = tryCall(zeroSeq, ["setZeroPoint"], [zeroTicks]);
@@ -1590,7 +1748,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ zeroPointSeconds: Number(args.time || args.seconds || 0), method: zeroResult.method });
 
         case "scene_edit_detection":
-          var sceneSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var sceneSeq = targetSequence();
           if (!sceneSeq) return fail("No sequence found");
           if (!sceneSeq.performSceneEditDetectionOnSelection) return fail("performSceneEditDetectionOnSelection API unavailable");
           if (args.allowUnsafeSynchronous !== true) {
@@ -1607,14 +1767,18 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ performed: true, action: String(args.action || "CreateMarkers"), sensitivity: String(args.sensitivity || "Medium") });
 
         case "delete_preview_files":
-          var previewSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var previewSeq = targetSequence();
           if (!previewSeq) return fail("No sequence found");
           var previewResult = tryCall(previewSeq, ["deletePreviewFiles"], []);
           if (!previewResult.called) {
             try {
               app.enableQE();
-              var qePreviewSeq = qe.project.getActiveSequence();
-              previewResult = tryCall(qePreviewSeq, ["deletePreviewFiles"], []);
+              var qePreviewSeq = qeSequenceFor(previewSeq);
+              previewResult = qePreviewSeq
+                ? tryCall(qePreviewSeq, ["deletePreviewFiles"], [])
+                : { called: false, error: "Could not address sequence '" + previewSeq.name + "' through the QE API." };
             } catch (qePreviewError) {
               previewResult = { called: false, error: qePreviewError.toString() };
             }
@@ -1626,7 +1790,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "set_effect_property":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail(toolName + " requires clipId.");
           var propertyClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!propertyClip) return fail("Clip not found");
+          if (!propertyClip) return fail(pendingSequenceError || "Clip not found");
           var propertyComponent = findComponent(propertyClip.clip, args.effectName || args.componentName || args.component || "Motion");
           if (!propertyComponent) return fail("Component/effect not found on clip");
           var propertyResult = setComponentProperty(propertyComponent.component, args.propertyName || args.property || args.name, args.value);
@@ -1636,7 +1800,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "get_value_at_time":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail("get_value_at_time requires clipId.");
           var valueClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!valueClip) return fail("Clip not found");
+          if (!valueClip) return fail(pendingSequenceError || "Clip not found");
           var valueComponent = findComponent(valueClip.clip, args.effectName || args.componentName || args.component || "Motion");
           if (!valueComponent) return fail("Component/effect not found on clip");
           var valuePropName = args.propertyName || args.property || args.name;
@@ -1648,7 +1812,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "set_keyframe_interpolation":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail(toolName + " requires clipId.");
           var keyClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!keyClip) return fail("Clip not found");
+          if (!keyClip) return fail(pendingSequenceError || "Clip not found");
           var keyComponent = findComponent(keyClip.clip, args.effectName || args.componentName || args.component || "Motion");
           if (!keyComponent) return fail("Component/effect not found on clip");
           var keyProperty = findProperty(keyComponent.component, args.propertyName || args.property || args.name);
@@ -1671,7 +1835,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return setSelection(function(clip) { try { return Number(clip.projectItem.getColorLabel()) === labelValue; } catch (e) { return false; } }, true, Boolean(args.add_to_selection || args.addToSelection));
 
         case "invert_selection":
-          var invertSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var invertSeq = targetSequence();
           if (!invertSeq) return fail("No active sequence");
           var inverted = [];
           var invertClips = allClips(invertSeq);
@@ -1717,16 +1883,27 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ replaced: true, item: replaceItem.name, newFilePath: String(args.newFilePath || args.filePath || args.path || "") });
 
         case "batch_apply_effect":
-          var batchSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var batchSeq = targetSequence();
           if (!batchSeq) return fail("No active sequence");
           app.enableQE();
+          // Resolved once, outside the loop: qeSequenceFor() scans every QE
+          // sequence, so doing it per clip made the tool O(clips x sequences),
+          // and its failure is a property of the sequence rather than of any
+          // one clip — returning from inside the per-clip catch abandoned the
+          // whole batch instead of recording one clip's error and continuing.
+          var qeBatchSeq = qeSequenceFor(batchSeq);
+          if (!qeBatchSeq) return fail("Could not address sequence '" + batchSeq.name + "' through the QE API.");
           var batchClips = allClips(batchSeq);
           var batchResults = [];
           for (var bai = 0; bai < batchClips.length; bai++) {
             try {
-              var qeBatchSeq = qe.project.getActiveSequence();
               var qeBatchTrack = batchClips[bai].trackType === "video" ? qeBatchSeq.getVideoTrackAt(batchClips[bai].trackIndex) : qeBatchSeq.getAudioTrackAt(batchClips[bai].trackIndex);
-              var qeBatchClip = qeBatchTrack.getItemAt(batchClips[bai].clipIndex);
+              // Matched on start time, not DOM index: QE track items include gaps and
+              // transitions, so an index addresses a different item whenever anything
+              // precedes the target.
+              var qeBatchClip = __findQeClipByDomClip(qeBatchTrack, batchClips[bai].clip);
               var batchEffect = batchClips[bai].trackType === "video" ? qe.project.getVideoEffectByName(String(args.effectName || args.name)) : qe.project.getAudioEffectByName(String(args.effectName || args.name));
               if (!batchEffect || !qeBatchClip) batchResults.push({ clipId: batchClips[bai].clip.nodeId, ok: false, error: "QE clip/effect unavailable" });
               else { qeBatchClip.addVideoEffect ? (batchClips[bai].trackType === "video" ? qeBatchClip.addVideoEffect(batchEffect) : qeBatchClip.addAudioEffect(batchEffect)) : qeBatchClip.addAudioEffect(batchEffect); batchResults.push({ clipId: batchClips[bai].clip.nodeId, ok: true }); }
@@ -1739,7 +1916,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "set_blend_mode":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail("set_blend_mode requires clipId.");
           var blendClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!blendClip) return fail("Clip not found");
+          if (!blendClip) return fail(pendingSequenceError || "Clip not found");
           var opacityComponent = findComponent(blendClip.clip, "Opacity");
           if (!opacityComponent) return fail("Opacity component not found");
           var blendResult = setComponentProperty(opacityComponent.component, "Blend Mode", args.mode || args.blendMode || args.value);
@@ -1747,7 +1924,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ blendMode: args.mode || args.blendMode || args.value, result: blendResult });
 
         case "set_all_tracks_targeted":
-          var allTargetSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var allTargetSeq = targetSequence();
           if (!allTargetSeq) return fail("No active sequence");
           for (var atv = 0; atv < allTargetSeq.videoTracks.numTracks; atv++) try { allTargetSeq.videoTracks[atv].setTargeted(Boolean(args.targeted !== false), true); } catch (e) {}
           for (var ata = 0; ata < allTargetSeq.audioTracks.numTracks; ata++) try { allTargetSeq.audioTracks[ata].setTargeted(Boolean(args.targeted !== false), true); } catch (e) {}
@@ -1755,13 +1934,16 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
 
         case "razor_all_tracks":
           app.enableQE();
-          var razorSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var razorSeq = targetSequence();
           if (!razorSeq) return fail("No active sequence");
           var razorFps = razorSeq.timebase ? (254016000000 / parseInt(razorSeq.timebase, 10)) : 30;
           var razorFrames = Math.round(Number(args.time || args.seconds || 0) * razorFps);
           function pad(n) { return n < 10 ? "0" + n : "" + n; }
           var razorTc = pad(Math.floor(razorFrames / (razorFps * 3600))) + ":" + pad(Math.floor((razorFrames % (razorFps * 3600)) / (razorFps * 60))) + ":" + pad(Math.floor((razorFrames % (razorFps * 60)) / razorFps)) + ":" + pad(Math.round(razorFrames % razorFps));
-          var qeRazorSeq = qe.project.getActiveSequence();
+          var qeRazorSeq = qeSequenceFor(razorSeq);
+          if (!qeRazorSeq) return fail("Could not address sequence '" + razorSeq.name + "' through the QE API.");
           for (var rv = 0; rv < razorSeq.videoTracks.numTracks; rv++) qeRazorSeq.getVideoTrackAt(rv).razor(razorTc);
           for (var ra = 0; ra < razorSeq.audioTracks.numTracks; ra++) qeRazorSeq.getAudioTrackAt(ra).razor(razorTc);
           return ok({ razorTimecode: razorTc, seconds: Number(args.time || args.seconds || 0) });
@@ -1769,7 +1951,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "set_clip_start_time":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail("set_clip_start_time requires clipId.");
           var startClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!startClip) return fail("Clip not found");
+          if (!startClip) return fail(pendingSequenceError || "Clip not found");
           startClip.clip.start = secondsToTime(args.time || args.start || 0);
           return ok({ clipId: startClip.clip.nodeId, start: valueOfTime(startClip.clip.start) });
 
@@ -1790,7 +1972,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "set_scale_width_height":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail(toolName + " requires clipId.");
           var transformClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!transformClip) return fail("Clip not found");
+          if (!transformClip) return fail(pendingSequenceError || "Clip not found");
           var componentName = (toolName === "set_clip_volume" || toolName === "set_clip_pan") ? "Volume" : "Motion";
           if (toolName === "set_clip_opacity") componentName = "Opacity";
           var transformComponent = findComponent(transformClip.clip, componentName);
@@ -1825,7 +2007,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ component: componentName, property: transformMap[toolName], result: transformSet });
 
         case "batch_rename_clips":
-          var renameSeqBatch = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var renameSeqBatch = targetSequence();
           if (!renameSeqBatch) return fail("No active sequence");
           var renameClips = allClips(renameSeqBatch);
           var renamePrefix = String(args.prefix || args.namePrefix || "Clip");
@@ -1833,7 +2017,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ renamed: renameClips.length, prefix: renamePrefix });
 
         case "batch_enable_disable":
-          var enableSeqBatch = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var enableSeqBatch = targetSequence();
           if (!enableSeqBatch) return fail("No active sequence");
           var enableClips = allClips(enableSeqBatch);
           var enableValue = Boolean(args.enabled !== false);
@@ -1841,7 +2027,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ changed: enableClips.length, enabled: enableValue });
 
         case "clear_sequence_in_out":
-          var clearSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var clearSeq = targetSequence();
           if (!clearSeq) return fail("No sequence found");
           var clearSeqResult = tryCall(clearSeq, ["clearInPoint"], []);
           var clearOutResult = tryCall(clearSeq, ["clearOutPoint"], []);
@@ -1882,7 +2070,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ destination: destBin.name, results: moveResults });
 
         case "add_adjustment_layer":
-          var adjustmentSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var adjustmentSeq = targetSequence();
           if (!adjustmentSeq) return fail("No active sequence");
           var adjustmentResult = tryCall(app.project, ["createAdjustmentLayer"], [Number(args.width || adjustmentSeq.frameSizeHorizontal || 1920), Number(args.height || adjustmentSeq.frameSizeVertical || 1080), Number(args.duration || 5)]);
           if (!adjustmentResult.called) return fail(adjustmentResult.error, { available: false });
@@ -1891,7 +2081,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "freeze_frame":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail("freeze_frame requires clipId.");
           var freezeClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!freezeClip) return fail("Clip not found");
+          if (!freezeClip) return fail(pendingSequenceError || "Clip not found");
           var freezeResult = tryCall(freezeClip.clip, ["setFrameHold", "freezeFrame"], [secondsToTicks(args.time || args.seconds || 0)]);
           if (!freezeResult.called) {
             var freezePath = "";
@@ -1907,21 +2097,23 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "set_sequence_pixel_aspect_ratio":
         case "set_sequence_field_type":
         case "set_sequence_display_format":
-          var settingsSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var settingsSeq = targetSequence();
           if (!settingsSeq || !settingsSeq.getSettings || !settingsSeq.setSettings) return fail("Sequence settings API unavailable");
           var seqSettings = settingsSeq.getSettings();
           if (toolName === "set_sequence_pixel_aspect_ratio") {
             var requestedPar = Number(args.pixelAspectRatio || args.value || 1);
             try {
               app.enableQE();
-              var qeParSeq = qe.project.getActiveSequence();
+              var qeParSeq = qeSequenceFor(settingsSeq);
               if (qeParSeq && Number(qeParSeq.par) === requestedPar) return ok({ sequenceId: settingsSeq.sequenceID, changed: false, par: Number(qeParSeq.par), method: "qe.par readback" });
             } catch (parReadError) {}
           }
           if (toolName === "set_sequence_field_type") {
             try {
               app.enableQE();
-              var qeFieldSeq = qe.project.getActiveSequence();
+              var qeFieldSeq = qeSequenceFor(settingsSeq);
               var requestedField = args.fieldType || args.value;
               if (qeFieldSeq && (String(requestedField).toLowerCase() === "no fields" || String(requestedField) === String(qeFieldSeq.fieldType))) return ok({ sequenceId: settingsSeq.sequenceID, changed: false, fieldType: Number(qeFieldSeq.fieldType), method: "qe.fieldType readback" });
             } catch (fieldReadError) {}
@@ -1929,7 +2121,11 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           if (toolName === "set_sequence_frame_rate") seqSettings.videoFrameRate = secondsToTicks(1 / Number(args.frameRate || args.value || 30));
           if (toolName === "set_sequence_resolution") { seqSettings.videoFrameWidth = Number(args.width || 1920); seqSettings.videoFrameHeight = Number(args.height || 1080); }
           if (toolName === "set_sequence_audio_settings") { seqSettings.audioSampleRate = Number(args.sampleRate || 48000); seqSettings.audioChannelType = args.channelType || seqSettings.audioChannelType; }
-          if (toolName === "set_sequence_pixel_aspect_ratio") seqSettings.videoPixelAspectRatio = Number(args.pixelAspectRatio || args.value || 1);
+          if (toolName === "set_sequence_pixel_aspect_ratio") {
+            var parText = parRatioString(args.pixelAspectRatio !== undefined ? args.pixelAspectRatio : (args.value !== undefined ? args.value : 1));
+            if (!parText) return fail("pixelAspectRatio must be a positive number or an 'N:M' ratio string.");
+            seqSettings.videoPixelAspectRatio = parText;
+          }
           if (toolName === "set_sequence_field_type") seqSettings.videoFieldType = String(args.fieldType || args.value || "No Fields");
           if (toolName === "set_sequence_display_format") seqSettings.videoDisplayFormat = args.displayFormat || args.value || seqSettings.videoDisplayFormat;
           settingsSeq.setSettings(seqSettings);
@@ -1942,26 +2138,40 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           var itemMarker = itemMarkers.createMarker(Number(args.time || args.seconds || 0));
           itemMarker.name = String(args.name || "");
           itemMarker.comments = String(args.comment || args.comments || "");
-          return ok({ markerId: itemMarker.guid, item: markerItemTarget.name, time: Number(args.time || args.seconds || 0) });
+          // Clip-marker colour was readable through get_clip_markers but not
+          // writable here, so a caller could see a colour it had no way to set.
+          // Resolve the same way the sequence-marker tools do, and refuse an
+          // unrecognised value rather than silently leaving the default.
+          var itemColorIndex = resolveMarkerColorIndex(args.color);
+          if (itemColorIndex === "invalid") {
+            return fail("Unrecognised marker colour: " + String(args.color) +
+              ". Use a name (" + MARKER_COLOR_NAMES.join(", ") + ") or an index 0-7.");
+          }
+          if (itemColorIndex !== null) { itemMarker.setColorByIndex(itemColorIndex); }
+          var appliedColor = markerColor(itemMarker);
+          return ok({ markerId: itemMarker.guid, item: markerItemTarget.name, time: Number(args.time || args.seconds || 0), color: appliedColor.index, colorName: appliedColor.name });
 
         case "get_clip_markers":
         case "get_sequence_markers_by_type":
           var markers = markerCollectionForTool();
-          if (!markers) return fail("Marker collection unavailable");
+          if (!markers) return fail(pendingSequenceError || "Marker collection unavailable");
           var markerOutput = [];
           var marker = markers.getFirstMarker ? markers.getFirstMarker() : null;
           while (marker) {
             var markerType = "";
             try { markerType = String(marker.type); } catch (e) {}
             if (toolName === "get_clip_markers" || !args.type || markerType === String(args.type)) {
-              markerOutput.push({ id: marker.guid, name: marker.name, comments: marker.comments, type: markerType, start: valueOfTime(marker.start), end: valueOfTime(marker.end) });
+              var markerColorInfo = markerColor(marker);
+              markerOutput.push({ id: marker.guid, name: marker.name, comments: marker.comments, type: markerType, start: valueOfTime(marker.start), end: valueOfTime(marker.end), color: markerColorInfo.index, colorName: markerColorInfo.name });
             }
             marker = markers.getNextMarker ? markers.getNextMarker(marker) : null;
           }
           return ok({ count: markerOutput.length, markers: markerOutput });
 
         case "get_next_edit_point":
-          var editPointSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var editPointSeq = targetSequence();
           if (!editPointSeq) return fail("No active sequence");
           var fromTime = Number(args.time || args.seconds || 0);
           var nextPoint = null;
@@ -1973,7 +2183,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           return ok({ from: fromTime, nextEditPoint: nextPoint });
 
         case "move_playhead_to_edit":
-          var moveEditSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var moveEditSeq = targetSequence();
           if (!moveEditSeq) return fail("No active sequence");
           var moveFrom = Number(args.time || args.seconds || 0);
           var moveNext = null;
@@ -1988,27 +2200,29 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
 
         case "get_clip_adjustment_layer":
           var adjustmentClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!adjustmentClip) return fail("Clip not found");
+          if (!adjustmentClip) return fail(pendingSequenceError || "Clip not found");
           var isAdjustment = false;
           try { isAdjustment = Boolean(adjustmentClip.clip.projectItem && adjustmentClip.clip.projectItem.isAdjustmentLayer && adjustmentClip.clip.projectItem.isAdjustmentLayer()); } catch (e) {}
           return ok({ clipId: adjustmentClip.clip.nodeId, isAdjustmentLayer: isAdjustment });
 
         case "get_linked_items":
           var linkedClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!linkedClip) return fail("Clip not found");
+          if (!linkedClip) return fail(pendingSequenceError || "Clip not found");
           var linkedItemsResult = tryCall(linkedClip.clip, ["getLinkedItems"], []);
           if (!linkedItemsResult.called) return fail(linkedItemsResult.error, { available: false });
           return ok({ linkedItems: linkedItemsResult.result });
 
         case "get_mogrt_component":
           var mogrtClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!mogrtClip) return fail("Clip not found");
+          if (!mogrtClip) return fail(pendingSequenceError || "Clip not found");
           var mogrtComponents = [];
           for (var mg = 0; mg < mogrtClip.clip.components.numItems; mg++) mogrtComponents.push({ name: String(mogrtClip.clip.components[mg].displayName), properties: componentProperties(mogrtClip.clip.components[mg]) });
           return ok({ components: mogrtComponents });
 
         case "capture_frame":
-          var frameSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var frameSeq = targetSequence();
           if (!frameSeq) return fail("No active sequence");
           var framePath = String(args.outputPath || args.path || "");
           if (!framePath) return fail("capture_frame requires outputPath");
@@ -2016,8 +2230,8 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
             try { frameSeq.openInTimeline(); } catch (frameOpenError) {}
           }
           app.enableQE();
-          var qeFrameSeq = qe.project.getActiveSequence();
-          if (!qeFrameSeq) return fail("QE active sequence not available for frame export");
+          var qeFrameSeq = qeSequenceFor(frameSeq);
+          if (!qeFrameSeq) return fail("Could not address sequence '" + frameSeq.name + "' through the QE API.");
           var frameFormat = String(args.format || "png").toLowerCase();
           var frameMethod = frameFormat === "jpg" || frameFormat === "jpeg" ? "exportFrameJPEG" : (frameFormat === "tiff" || frameFormat === "tif" ? "exportFrameTiff" : "exportFramePNG");
           if (typeof qeFrameSeq[frameMethod] !== "function") return fail("Frame export method unavailable: " + frameMethod, { available: false });
@@ -2051,7 +2265,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
 
         case "nest_clips":
           if (!app.project || !app.project.createNewSequenceFromClips) return commandByName("Nest...");
-          var nestSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var nestSeq = targetSequence();
           if (!nestSeq) return fail("No active sequence");
           var nestClipIds = args.clipIds || args.clip_ids || [];
           var nestItems = [];
@@ -2076,7 +2292,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "unnest_sequence":
           var unnestInfo = findClip(args.nestedSequenceClipId || args.clipId || args.nodeId || args.node_id);
           if (!unnestInfo) return fail("Nested sequence clip not found");
-          var unnestParentSeq = activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var unnestParentSeq = targetSequence();
           if (!unnestParentSeq) return fail("No active parent sequence");
           var unnestClip = unnestInfo.clip;
           var unnestItem = unnestClip.projectItem;
@@ -2156,12 +2374,15 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
 
         case "add_tracks":
           app.enableQE();
-          var addTracksSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var addTracksSeq = targetSequence();
           if (!addTracksSeq) return fail("No active sequence");
           var beforeVideoTracks = addTracksSeq.videoTracks.numTracks;
           var beforeAudioTracks = addTracksSeq.audioTracks.numTracks;
-          var addQeSeq = qe.project.getActiveSequence();
-          if (!addQeSeq || !addQeSeq.addTracks) return fail("QE addTracks API unavailable");
+          var addQeSeq = qeSequenceFor(addTracksSeq);
+          if (!addQeSeq) return fail("Could not address sequence '" + addTracksSeq.name + "' through the QE API.");
+          if (!addQeSeq.addTracks) return fail("QE addTracks API unavailable");
           var requestedVideoTracks = Number(args.videoTracks || args.videoTrackCount || 0);
           var requestedAudioTracks = Number(args.audioTracks || args.audioTrackCount || 0);
           if (requestedVideoTracks > 0) addQeSeq.addTracks(requestedVideoTracks, beforeVideoTracks, 0, 1, beforeAudioTracks, 0, 0);
@@ -2189,7 +2410,9 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           });
 
         case "get_clip_at_playhead":
-          var playSeq = activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var playSeq = targetSequence();
           if (!playSeq) return fail("No active sequence");
           args.time = ticksToSeconds(playSeq.getPlayerPosition().ticks);
           var clipAt = findClip(null);
@@ -2202,7 +2425,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
         case "get_effect_properties":
         case "get_qe_clip_info":
           var foundClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!foundClip) return fail("Clip not found");
+          if (!foundClip) return fail(pendingSequenceError || "Clip not found");
           var fullClip = clipInfo(foundClip.clip, foundClip.trackType, foundClip.trackIndex, foundClip.clipIndex);
           fullClip.components = [];
           try {
@@ -2222,14 +2445,16 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
 
         case "rename_clip":
           var renameClip = findClip(args.clipId || args.node_id || args.nodeId);
-          if (!renameClip) return fail("Clip not found");
+          if (!renameClip) return fail(pendingSequenceError || "Clip not found");
           renameClip.clip.name = String(args.new_name || args.newName || args.name);
           return ok({ renamed: true, name: renameClip.clip.name });
 
         case "remove_selected_clips":
         case "lift_selection":
         case "extract_selection":
-          var selectionSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var selectionSeq = targetSequence();
           if (!selectionSeq) return fail("No active sequence");
           if (typeof selectionSeq.getSelection !== "function") return fail("sequence.getSelection is unavailable");
           var selectedItems = selectionSeq.getSelection();
@@ -2257,14 +2482,18 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
 
         case "link_selection":
         case "unlink_selection":
-          var linkSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var linkSeq = targetSequence();
           if (!linkSeq) return fail("No active sequence");
           var linkResult = tryCall(linkSeq, [toolName === "link_selection" ? "linkSelection" : "unlinkSelection"], []);
           if (!linkResult.called) return commandByName(toolName === "link_selection" ? "Link" : "Unlink");
           return ok({ linked: toolName === "link_selection", method: linkResult.method });
 
         case "match_frame":
-          var matchSeq = targetSequence() || activeSequence();
+          var seqErr = sequenceRequestError();
+          if (seqErr) return fail(seqErr);
+          var matchSeq = targetSequence();
           if (!matchSeq) return fail("No active sequence");
           var matchTime = matchSeq.getPlayerPosition ? ticksToSeconds(matchSeq.getPlayerPosition().ticks) : Number(args.time || args.seconds || 0);
           args.time = matchTime;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -227,6 +227,40 @@ const clipPlanSchema = z.object({
   }).optional()
 });
 
+/**
+ * Premiere's marker colours, in `setColorByIndex()` order. The write domain is
+ * exactly 0-7: verified against Premiere 26.0.2, where an index of 8 or above
+ * is a silent no-op (there is no ninth colour) and a non-integer is silently
+ * truncated toward zero. Index 0 (Green) is the default for a marker created
+ * without an explicit colour.
+ */
+const MARKER_COLOR_NAMES = [
+  'green', 'red', 'purple', 'orange', 'yellow', 'white', 'blue', 'cyan',
+] as const;
+
+/**
+ * Accepts a colour name (case-insensitive, surrounding whitespace ignored) or
+ * an index 0-7. Anything else is rejected here, at the schema layer, so the
+ * caller gets a truthful error rather than a marker that silently keeps the
+ * default colour.
+ */
+const MarkerColorSchema = z.union([
+  z.preprocess(
+    (value) => (typeof value === 'string' ? value.trim().toLowerCase() : value),
+    z.enum(MARKER_COLOR_NAMES),
+  ),
+  z.number().int().min(0).max(7),
+  // Some MCP clients stringify every argument, which would otherwise drop index
+  // input entirely. Accept the string form of a valid index, but nothing looser.
+  // Deliberately no .transform(): executeTool() discards the parse() result and
+  // passes the raw args on, so a transform here would silently never apply.
+  // The string-to-number conversion lives in resolveMarkerColor instead.
+  z.string().trim().regex(/^[0-7]$/),
+]);
+
+const MARKER_COLOR_DESCRIPTION =
+  `Marker colour — a name (${MARKER_COLOR_NAMES.join(', ')}) or an index 0-7. Defaults to green.`;
+
 export class PremiereProTools {
   private bridge: PremiereProTransport;
   private logger: Logger;
@@ -256,7 +290,7 @@ export class PremiereProTools {
         name: 'list_sequence_tracks',
         description: 'Lists all video and audio tracks in a specific sequence with their properties and clips.',
         inputSchema: z.object({
-          sequenceId: z.string().describe('The ID of the sequence to list tracks for')
+          sequenceId: z.string().min(1).describe('The sequence ID (GUID) to list tracks for, as returned in the "id" field by list_sequences or get_active_sequence')
         })
       },
       {
@@ -472,12 +506,15 @@ export class PremiereProTools {
       },
       {
         name: 'move_clip',
-        description: 'Moves a clip to a different position on the timeline.',
+        description: 'Moves a clip along the timeline, keeping it on its current track. To move a clip to a different track, use move_clip_to_track: on this Premiere build that is a remove-and-reinsert, which can overwrite whatever occupies the destination and gives the clip a new id, so it is deliberately a separate call rather than an option here.',
         inputSchema: z.object({
           clipId: z.string().describe('The ID of the clip to move'),
-          newTime: z.number().describe('The new time position in seconds'),
-          newTrackIndex: z.number().optional().describe('The new track index (if moving to different track)')
-        })
+          newTime: z.number().describe('The new time position in seconds')
+        // .strict() so a leftover newTrackIndex is an error rather than being
+        // silently dropped. Zod strips unknown keys by default, which would have
+        // let a caller migrating from the old signature keep passing it and keep
+        // believing the clip changed track.
+        }).strict()
       },
       {
         name: 'trim_clip',
@@ -706,40 +743,40 @@ export class PremiereProTools {
       // Markers
       {
         name: 'add_marker',
-        description: 'Adds a marker to the timeline for navigation or notes.',
+        description: 'Adds a marker to the specified sequence for navigation or notes. The sequence does not have to be the active one.',
         inputSchema: z.object({
-          sequenceId: z.string().describe('The ID of the sequence to add the marker to'),
+          sequenceId: z.string().min(1).describe('The sequence ID (GUID) to add the marker to, as returned in the "id" field by list_sequences or get_active_sequence'),
           time: z.number().describe('The time in seconds where the marker should be placed'),
           name: z.string().describe('The name/label for the marker'),
           comment: z.string().optional().describe('Optional comment or description for the marker'),
-          color: z.string().optional().describe('Marker color (e.g., "red", "green", "blue")'),
+          color: MarkerColorSchema.optional().describe(MARKER_COLOR_DESCRIPTION),
           duration: z.number().optional().describe('Duration in seconds for a span marker (0 for point marker)')
         })
       },
       {
         name: 'delete_marker',
-        description: 'Deletes a marker from the timeline.',
+        description: 'Deletes a marker from the specified sequence. The sequence does not have to be the active one.',
         inputSchema: z.object({
-          sequenceId: z.string().describe('The ID of the sequence'),
-          markerId: z.string().describe('The ID of the marker to delete')
+          sequenceId: z.string().min(1).describe('The sequence ID (GUID) as returned in the "id" field by list_sequences or get_active_sequence'),
+          markerId: z.string().min(1).describe('The ID of the marker to delete')
         })
       },
       {
         name: 'update_marker',
-        description: 'Updates an existing marker\'s properties.',
+        description: 'Updates an existing marker\'s properties in the specified sequence. The sequence does not have to be the active one.',
         inputSchema: z.object({
-          sequenceId: z.string().describe('The ID of the sequence'),
-          markerId: z.string().describe('The ID of the marker to update'),
+          sequenceId: z.string().min(1).describe('The sequence ID (GUID) as returned in the "id" field by list_sequences or get_active_sequence'),
+          markerId: z.string().min(1).describe('The ID of the marker to update'),
           name: z.string().optional().describe('New name for the marker'),
           comment: z.string().optional().describe('New comment'),
-          color: z.string().optional().describe('New color')
+          color: MarkerColorSchema.optional().describe(`New colour. ${MARKER_COLOR_DESCRIPTION}`)
         })
       },
       {
         name: 'list_markers',
-        description: 'Lists all markers in a sequence.',
+        description: 'Lists all markers in the specified sequence. The sequence does not have to be the active one.',
         inputSchema: z.object({
-          sequenceId: z.string().describe('The ID of the sequence')
+          sequenceId: z.string().min(1).describe('The sequence ID (GUID) as returned in the "id" field by list_sequences or get_active_sequence')
         })
       },
 
@@ -755,18 +792,18 @@ export class PremiereProTools {
       },
       {
         name: 'delete_track',
-        description: 'Deletes a video or audio track from the sequence. Caption track deletion is accepted by the schema but returns an explicit unsupported result because Premiere Pro exposes no caption-track delete/read API to scripting.',
+        description: 'Deletes a video or audio track from the specified sequence. The sequence does not have to be the active one, but it does have to be open in Premiere: there is no DOM track-deletion API, so this falls through to the QE DOM, which only reaches sequences Premiere has open. A sequence QE cannot address is reported by name rather than deleted from the wrong timeline. Caption track deletion is accepted by the schema but returns an explicit unsupported result because Premiere Pro exposes no caption-track delete/read API to scripting.',
         inputSchema: z.object({
-          sequenceId: z.string().describe('The ID of the sequence'),
+          sequenceId: z.string().min(1).describe('The sequence ID (GUID) as returned in the "id" field by list_sequences or get_active_sequence'),
           trackType: z.enum(['video', 'audio', 'caption']).describe('Type of track'),
           trackIndex: z.number().describe('The index of the track to delete')
         })
       },
       {
         name: 'lock_track',
-        description: 'Locks or unlocks a track to prevent/allow editing.',
+        description: 'Locks or unlocks a track to prevent/allow editing. The sequence does not have to be the active one.',
         inputSchema: z.object({
-          sequenceId: z.string().describe('The ID of the sequence'),
+          sequenceId: z.string().min(1).describe('The sequence ID (GUID) as returned in the "id" field by list_sequences or get_active_sequence'),
           trackType: z.enum(['video', 'audio']).describe('Type of track'),
           trackIndex: z.number().describe('The index of the track'),
           locked: z.boolean().describe('Whether to lock (true) or unlock (false)')
@@ -774,9 +811,9 @@ export class PremiereProTools {
       },
       {
         name: 'toggle_track_visibility',
-        description: 'Shows or hides a video track.',
+        description: 'Shows or hides a video track by toggling its output (the eye icon) in the specified sequence. The sequence does not have to be the active one. This is track OUTPUT, not track targeting -- use set_target_track for the V1/A1 patch buttons.',
         inputSchema: z.object({
-          sequenceId: z.string().describe('The ID of the sequence'),
+          sequenceId: z.string().min(1).describe('The sequence ID (GUID) as returned in the "id" field by list_sequences or get_active_sequence'),
           trackIndex: z.number().describe('The index of the video track'),
           visible: z.boolean().describe('Whether to show (true) or hide (false)')
         })
@@ -854,14 +891,18 @@ export class PremiereProTools {
       },
       {
         name: 'set_sequence_settings',
-        description: 'Updates sequence settings.',
+        description: 'Updates sequence settings. Applies width, height, frameRate and pixelAspectRatio, reads the values back afterwards, and reports any field Premiere accepted but did not actually change. Frame size CAN be changed after creation, contrary to an earlier note in this codebase.',
         inputSchema: z.object({
           sequenceId: z.string().describe('The ID of the sequence'),
           settings: z.object({
-            width: z.number().optional().describe('Frame width'),
-            height: z.number().optional().describe('Frame height'),
-            frameRate: z.number().optional().describe('Frame rate'),
-            pixelAspectRatio: z.number().optional().describe('Pixel aspect ratio')
+            width: z.number().optional().describe('Frame width in pixels'),
+            height: z.number().optional().describe('Frame height in pixels'),
+            frameRate: z.number().optional().describe('Frames per second, e.g. 23.976, 25, 30'),
+            // Premiere stores this as an "N:M" string. A bare number is converted to the
+            // nearest exact ratio (1.5 becomes "3:2"), but the string form is accepted
+            // directly so callers can name a ratio Premiere already uses, such as "10:11".
+            pixelAspectRatio: z.union([z.number(), z.string()]).optional()
+              .describe('Pixel aspect ratio, either a number (1, 1.5, 2) or an "N:M" string ("1:1", "4:3", "10:11")')
           }).describe('Settings to update')
         })
       },
@@ -1352,9 +1393,23 @@ export class PremiereProTools {
       };
     }
 
-    // Validate input arguments
+    // Validate input arguments, and use what validation produced.
+    //
+    // The parsed value used to be discarded and the raw args passed on, which
+    // made every .transform(), .default() and z.coerce() in every schema in this
+    // file silently inert — a schema could validate correctly and then have no
+    // effect at all. No schema relies on that today, so this changes no current
+    // behaviour; it stops the next one that does from failing silently.
+    //
+    // Parsed values are merged OVER the raw args rather than replacing them.
+    // Zod object schemas strip unknown keys by default, and several handlers
+    // read alternate spellings (args.itemId || args.item_id), so replacing
+    // outright would drop arguments callers are sending today.
     try {
-      tool.inputSchema.parse(args);
+      const validated = tool.inputSchema.parse(args);
+      if (validated && typeof validated === 'object' && !Array.isArray(validated)) {
+        args = { ...args, ...(validated as Record<string, unknown>) };
+      }
     } catch (error) {
       return {
         success: false,
@@ -1438,7 +1493,7 @@ export class PremiereProTools {
         case 'remove_from_timeline':
           return await this.removeFromTimeline(args.clipId, args.sequenceId, args.deleteMode);
         case 'move_clip':
-          return await this.moveClip(args.clipId, args.newTime, args.newTrackIndex);
+          return await this.moveClip(args.clipId, args.newTime);
         case 'trim_clip':
           return await this.trimClip(args.clipId, args.inPoint, args.outPoint, args.duration);
         case 'split_clip':
@@ -1797,16 +1852,7 @@ export class PremiereProTools {
   private async listSequenceTracks(sequenceId: string): Promise<any> {
     const script = `
       try {
-        var sequence = __findSequence("${sequenceId}");
-        if (!sequence) {
-          sequence = app.project.activeSequence;
-        }
-        if (!sequence) {
-          return JSON.stringify({
-            success: false,
-            error: "Sequence not found"
-          });
-        }
+${this.buildSequenceResolver(sequenceId)}
 
         var videoTracks = [];
         var audioTracks = [];
@@ -1859,7 +1905,7 @@ export class PremiereProTools {
 
         return JSON.stringify({
           success: true,
-          sequenceId: "${sequenceId}",
+          sequenceId: sequence.sequenceID,
           sequenceName: sequence.name,
           videoTracks: videoTracks,
           audioTracks: audioTracks,
@@ -2719,7 +2765,7 @@ export class PremiereProTools {
     const script = `
       try {
         var project = app.project;
-        var newPath = "${location}/${name}.prproj";
+        var newPath = ${JSON.stringify(location)} + "/" + ${JSON.stringify(name)} + ".prproj";
         project.saveAs(newPath);
         
         return JSON.stringify({
@@ -2779,19 +2825,23 @@ export class PremiereProTools {
    */
   private async importFcpXml(filePath: string): Promise<any> {
     try {
-      const escapedPath = filePath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      // No hand-escaping here. JSON.stringify below already produces a correctly
+      // quoted literal; escaping first and then serialising doubled every backslash,
+      // so C:\\Users\\bob\\seq.xml reached the host as C:\\\\Users\\\\bob\\\\seq.xml and every
+      // Windows path failed. Introduced by the interpolation sweep, which wrapped a
+      // site that was already escaped.
       const script = `
         try {
-          var f = new File("${escapedPath}");
+          var f = new File(${JSON.stringify(filePath)});
           if (!f.exists) {
-            return JSON.stringify({ success: false, error: "File not found: ${escapedPath}" });
+            return JSON.stringify({ success: false, error: "File not found: " + ${JSON.stringify(filePath)} });
           }
           // suppressUI=true asks Premiere not to surface import warning dialogs.
-          var imported = app.project.importFiles(["${escapedPath}"], true, app.project.rootItem, false);
+          var imported = app.project.importFiles([${JSON.stringify(filePath)}], true, app.project.rootItem, false);
           if (!imported) {
-            return JSON.stringify({ success: false, imported: false, path: "${escapedPath}", method: "importFiles(suppressUI=true)", error: "Premiere rejected the FCP7 XML import" });
+            return JSON.stringify({ success: false, imported: false, path: ${JSON.stringify(filePath)}, method: "importFiles(suppressUI=true)", error: "Premiere rejected the FCP7 XML import" });
           }
-          return JSON.stringify({ success: true, imported: true, path: "${escapedPath}", method: "importFiles(suppressUI=true)" });
+          return JSON.stringify({ success: true, imported: true, path: ${JSON.stringify(filePath)}, method: "importFiles(suppressUI=true)" });
         } catch (e) {
           return JSON.stringify({ success: false, error: e.toString() });
         }
@@ -2832,7 +2882,7 @@ export class PremiereProTools {
   private async importFolder(folderPath: string, binName?: string, recursive = false): Promise<any> {
     const script = `
       try {
-        var folder = new Folder("${folderPath}");
+        var folder = new Folder(${JSON.stringify(folderPath)});
         var importedItems = [];
         var errors = [];
         
@@ -2863,7 +2913,28 @@ export class PremiereProTools {
         }
         
         var targetBin = app.project.rootItem;
-        ${binName ? `targetBin = app.project.rootItem.children["${binName}"] || app.project.rootItem;` : ''}
+        ${binName ? `
+        // Same silent reparent as create_bin: an unresolved destination bin sent the
+        // whole import to the project root instead of failing.
+        function __binByName(parent, wanted) {
+          // children[name] does not resolve: Premiere's ProjectItemCollection is
+          // index-only, so a string key returns undefined even when a child of that
+          // name exists. Verified against 26.0.2. Walk and compare instead.
+          if (!parent || !parent.children) return null;
+          for (var i = 0; i < parent.children.numItems; i++) {
+            var child = parent.children[i];
+            if (child && String(child.name) === String(wanted)) return child;
+          }
+          return null;
+        }
+        targetBin = __binByName(app.project.rootItem, ${JSON.stringify(binName)});
+        if (!targetBin) {
+          return JSON.stringify({
+            success: false,
+            error: "Destination bin not found: " + ${JSON.stringify(binName)} + ". Nothing was imported. Omit binName to import to the project root.",
+            binName: ${JSON.stringify(binName)}
+          });
+        }` : ''}
         
         importFiles(folder, targetBin);
         
@@ -2889,15 +2960,37 @@ export class PremiereProTools {
     const script = `
       try {
         var parentBin = app.project.rootItem;
-        ${parentBinName ? `parentBin = app.project.rootItem.children["${parentBinName}"] || app.project.rootItem;` : ''}
+        ${parentBinName ? `
+        // Naming a parent that does not resolve used to fall through to the project
+        // root, so the bin landed somewhere the caller never asked for while the
+        // response echoed the parent name back as though it had been used.
+        function __binByName(parent, wanted) {
+          // children[name] does not resolve: Premiere's ProjectItemCollection is
+          // index-only, so a string key returns undefined even when a child of that
+          // name exists. Verified against 26.0.2. Walk and compare instead.
+          if (!parent || !parent.children) return null;
+          for (var i = 0; i < parent.children.numItems; i++) {
+            var child = parent.children[i];
+            if (child && String(child.name) === String(wanted)) return child;
+          }
+          return null;
+        }
+        parentBin = __binByName(app.project.rootItem, ${JSON.stringify(parentBinName)});
+        if (!parentBin) {
+          return JSON.stringify({
+            success: false,
+            error: "Parent bin not found: " + ${JSON.stringify(parentBinName)} + ". Nothing was created. Omit parentBinName to create at the project root.",
+            parentBinName: ${JSON.stringify(parentBinName)}
+          });
+        }` : ''}
 
-        var newBin = parentBin.createBin("${name}");
+        var newBin = parentBin.createBin(${JSON.stringify(name)});
 
         return JSON.stringify({
           success: true,
-          binName: "${name}",
+          binName: ${JSON.stringify(name)},
           binId: newBin.nodeId,
-          parentBin: ${parentBinName ? `"${parentBinName}"` : '"Root"'}
+          parentBin: ${parentBinName ? `${JSON.stringify(parentBinName)}` : '"Root"'}
         });
       } catch (e) {
         return JSON.stringify({
@@ -2988,6 +3081,13 @@ export class PremiereProTools {
         // In current Premiere, Sequence.clone() returns the clone's ProjectItem (NOT a Sequence),
         // which has a settable .name but no .sequenceID / .videoTracks. Resolve the real Sequence
         // object via getSequence() before touching tracks; handle builds that return a Sequence too.
+        // Noted before the clone so the fallback below can tell a newly created
+        // sequence apart from the one the user already had open.
+        var priorActiveId = null;
+        try {
+          priorActiveId = app.project.activeSequence ? String(app.project.activeSequence.sequenceID) : null;
+        } catch (ePriorActive) {}
+
         var cloneResult = originalSeq.clone();
         var newItem = null, newSeqObj = null;
         if (cloneResult) {
@@ -2998,8 +3098,36 @@ export class PremiereProTools {
             newSeqObj = cloneResult;
           }
         }
-        // Fallback: a freshly cloned sequence usually becomes the active sequence.
-        if (!newSeqObj) { try { newSeqObj = app.project.activeSequence; } catch (_) {} }
+        // Fallback: a freshly cloned sequence usually becomes the active one.
+        //
+        // Only accept it once it is demonstrably new — a different sequence from
+        // both the clone source and whatever was active before the clone ran.
+        // Taken unconditionally, this clause hands back the user's own open
+        // timeline whenever clone() returns something unexpected or
+        // getSequence() throws, and everything below then renames it and, with
+        // clearContents, removes every clip from it — reported as success.
+        if (!newSeqObj) {
+          try {
+            var activeCandidate = app.project.activeSequence;
+            var activeCandidateId = activeCandidate ? String(activeCandidate.sequenceID) : null;
+            if (activeCandidateId &&
+                activeCandidateId !== String(originalSeq.sequenceID) &&
+                activeCandidateId !== priorActiveId) {
+              newSeqObj = activeCandidate;
+            }
+          } catch (eActiveFallback) {}
+        }
+
+        // Refuse rather than guess. Clearing a sequence that may not be the copy
+        // is irreversible, so an unresolved copy has to stop the operation.
+        if (${clearContents ? 'true' : 'false'} && !newSeqObj) {
+          return JSON.stringify({
+            success: false,
+            error: "The sequence was duplicated but the copy could not be identified, so clearContents was not run. Nothing was cleared. Find the new sequence with list_sequences and clear it explicitly.",
+            duplicated: true,
+            cleared: false
+          });
+        }
 
         // Rename on the ProjectItem (visible in the project panel) AND the Sequence object.
         if (newItem) { try { newItem.name = ${safeName}; } catch (_) {} }
@@ -3096,9 +3224,22 @@ export class PremiereProTools {
     const seqArg = sequenceId ? JSON.stringify(sequenceId) : 'null';
     const script = `
       try {
-        var sequence = ${seqArg} ? __findSequence(${seqArg}) : null;
-        if (!sequence) sequence = app.project.activeSequence;
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found" });
+        // A supplied ID that does not resolve must fail. Falling back to the
+        // active sequence answers a different question and reports that
+        // sequence's identity as though it were the one asked for.
+        var sequence = null;
+        if (${seqArg}) {
+          sequence = __findSequence(${seqArg});
+          if (!sequence) {
+            return JSON.stringify({
+              success: false,
+              error: "Sequence not found by id: " + ${seqArg} + ". Use list_sequences or get_active_sequence to obtain a valid sequence ID."
+            });
+          }
+        } else {
+          sequence = app.project.activeSequence;
+        }
+        if (!sequence) return JSON.stringify({ success: false, error: "No active sequence" });
 
         // Premiere caption tracks live alongside video/audio tracks. Different
         // Premiere versions expose them differently:
@@ -3196,14 +3337,14 @@ export class PremiereProTools {
   private async deleteSequence(sequenceId: string): Promise<any> {
     const script = `
       try {
-        var sequence = __findSequence("${sequenceId}");
+        var sequence = __findSequence(${JSON.stringify(sequenceId)});
         if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found" });
         var sequenceName = sequence.name;
         app.project.deleteSequence(sequence);
         return JSON.stringify({
           success: true,
           message: "Sequence deleted successfully",
-          deletedSequenceId: "${sequenceId}",
+          deletedSequenceId: ${JSON.stringify(sequenceId)},
           deletedSequenceName: sequenceName
         });
       } catch (e) {
@@ -3226,7 +3367,10 @@ export class PremiereProTools {
 
   private async addToTimeline(sequenceId: string, projectItemId: string, trackIndex: number, time: number, insertMode = 'overwrite', linkAudio: boolean = true, sourceInPoint?: number, sourceOutPoint?: number): Promise<any> {
     try {
-      const result: any = await this.bridge.addToTimeline(sequenceId, projectItemId, trackIndex, time, linkAudio, sourceInPoint, sourceOutPoint);
+      // insertMode used to stop here: it was echoed in every response below while
+      // the bridge unconditionally overwrote, so a caller asking to insert-and-shift
+      // had the footage it was moving destroyed and was told the opposite.
+      const result: any = await this.bridge.addToTimeline(sequenceId, projectItemId, trackIndex, time, linkAudio, sourceInPoint, sourceOutPoint, insertMode);
       if (!result.success) {
         return {
           ...result,
@@ -3294,10 +3438,10 @@ export class PremiereProTools {
     return await this.bridge.executeScript(script);
   }
 
-  private async moveClip(clipId: string, newTime: number, _newTrackIndex?: number): Promise<any> {
+  private async moveClip(clipId: string, newTime: number): Promise<any> {
     const script = `
       try {
-        var info = __findClip("${clipId}");
+        var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
         var clip = info.clip;
         var oldTime = clip.start.seconds;
@@ -3306,7 +3450,7 @@ export class PremiereProTools {
         return JSON.stringify({
           success: true,
           message: "Clip moved successfully",
-          clipId: "${clipId}",
+          clipId: ${JSON.stringify(clipId)},
           oldTime: oldTime,
           newTime: ${newTime},
           trackIndex: info.trackIndex
@@ -3628,11 +3772,15 @@ export class PremiereProTools {
     const script = `
       try {
         app.enableQE();
-        var info = __findClip("${clipId}");
+        var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
         var splitSeconds = info.clip.start.seconds + ${splitTime};
-        var seq = app.project.activeSequence;
-        var fps = seq.timebase ? (254016000000 / parseInt(seq.timebase, 10)) : 30;
+        // The timecode must come from the sequence the clip actually lives in, not
+        // from whatever is on screen. Taking it from the active sequence put the cut
+        // on the right timeline at the wrong frame whenever the two differed in frame
+        // rate: a 24 fps clip razored using a 30 fps timebase lands three frames out.
+        var seq = info.sequence;
+        var fps = seq && seq.timebase ? (254016000000 / parseInt(seq.timebase, 10)) : 30;
         var totalFrames = Math.round(splitSeconds * fps);
         var hours = Math.floor(totalFrames / (fps * 3600));
         var mins = Math.floor((totalFrames % (fps * 3600)) / (fps * 60));
@@ -3640,7 +3788,12 @@ export class PremiereProTools {
         var frames = Math.round(totalFrames % fps);
         function pad(n) { return n < 10 ? "0" + n : "" + n; }
         var tc = pad(hours) + ":" + pad(mins) + ":" + pad(secs) + ":" + pad(frames);
-        var qeSeq = qe.project.getActiveSequence();
+        // Addressed by id, not by whatever is on screen. __findClip() searches every
+        // sequence in the project, so a clip can be resolved out of one sequence and
+        // then, through getActiveSequence(), have the effect applied to whichever
+        // clip sits at the same track and index in a different one.
+        var qeSeq = __qeSequenceFor(info.sequence);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + info.sequenceName + "' through the QE API." });
         var qeTrack = info.trackType === 'video' ? qeSeq.getVideoTrackAt(info.trackIndex) : qeSeq.getAudioTrackAt(info.trackIndex);
         qeTrack.razor(tc);
         return JSON.stringify({ success: true, message: "Clip split at " + tc, splitTime: ${splitTime}, timecode: tc });
@@ -3661,8 +3814,9 @@ export class PremiereProTools {
       try {
         app.enableQE();
         var sequence = ${sequenceId ? `__findSequence(${JSON.stringify(sequenceId)})` : 'app.project.activeSequence'};
-        if (!sequence) return JSON.stringify({ success: false, error: ${sequenceId ? `"Sequence not found by id: ${sequenceId}"` : '"No active sequence"'} });
+        if (!sequence) return JSON.stringify({ success: false, error: ${sequenceId ? `"Sequence not found by id: " + ${JSON.stringify(sequenceId)}` : '"No active sequence"'} });
 
+        var __priorActive = app.project.activeSequence;
         if (app.project.activeSequence && app.project.activeSequence.sequenceID !== sequence.sequenceID) {
           app.project.openSequence(sequence.sequenceID);
         }
@@ -3681,7 +3835,7 @@ export class PremiereProTools {
         function pad(n) { return n < 10 ? "0" + n : "" + n; }
         var tc = pad(hours) + ":" + pad(mins) + ":" + pad(secs) + ":" + pad(frames);
 
-        var qeSeq = qe.project.getActiveSequence();
+        var qeSeq = __qeSequenceFor(sequence);
         if (!qeSeq) return JSON.stringify({ success: false, error: "QE active sequence unavailable" });
 
         function buildIndices(count, requested) {
@@ -3746,6 +3900,15 @@ export class PremiereProTools {
         });
       } catch (e) {
         return JSON.stringify({ success: false, error: "QE DOM error: " + e.toString() });
+      } finally {
+        // Leave the user where they were. ES3 has try/finally, and this runs
+        // before the return above completes.
+        try {
+          if (__priorActive && app.project.activeSequence &&
+              app.project.activeSequence.sequenceID !== __priorActive.sequenceID) {
+            app.project.activeSequence = __priorActive;
+          }
+        } catch (eRestore) {}
       }
     `;
 
@@ -3827,7 +3990,12 @@ export class PremiereProTools {
         }
         var beforeComponents = snapshotComponents(clip);
         var beforeCount = beforeComponents.length;
-        var qeSeq = qe.project.getActiveSequence();
+        // Addressed by id, not by whatever is on screen. __findClip() searches every
+        // sequence in the project, so a clip can be resolved out of one sequence and
+        // then, through getActiveSequence(), have the effect applied to whichever
+        // clip sits at the same track and index in a different one.
+        var qeSeq = __qeSequenceFor(info.sequence);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + info.sequenceName + "' through the QE API." });
         var qeTrack, effect;
         if (info.trackType === 'video') {
           qeTrack = qeSeq.getVideoTrackAt(info.trackIndex);
@@ -4078,7 +4246,11 @@ export class PremiereProTools {
 
         var effectAdded = false;
         if (!findCropComponent()) {
-          var qeSeq = qe.project.getActiveSequence();
+          // Addressed by id, not by whatever is on screen. __findClip() searches every
+          // sequence in the project, so a clip can be resolved out of one sequence and
+          // then, through getActiveSequence(), have the effect applied to whichever
+          // clip sits at the same track and index in a different one.
+          var qeSeq = __qeSequenceFor(info.sequence);
           if (!qeSeq) return JSON.stringify({ success: false, error: "QE active sequence not available" });
           var qeTrack = qeSeq.getVideoTrackAt(info.trackIndex);
           if (!qeTrack) return JSON.stringify({ success: false, error: "QE video track not found for clip" });
@@ -4217,19 +4389,19 @@ export class PremiereProTools {
   private async removeEffect(clipId: string, effectName: string): Promise<any> {
     const script = `
       try {
-        var info = __findClip("${clipId}");
+        var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
         var clip = info.clip;
         var found = false;
         for (var i = 0; i < clip.components.numItems; i++) {
-          if (clip.components[i].displayName === "${effectName}" || clip.components[i].matchName === "${effectName}") {
+          if (clip.components[i].displayName === ${JSON.stringify(effectName)} || clip.components[i].matchName === ${JSON.stringify(effectName)}) {
             found = true;
             break;
           }
         }
         return JSON.stringify({
           success: false,
-          error: "Effect removal is not supported by the ExtendScript API. The effect '${effectName}' was " + (found ? "found" : "not found") + " on this clip.",
+          error: "Effect removal is not supported by the ExtendScript API. The effect '" + ${JSON.stringify(effectName)} + "' was " + (found ? "found" : "not found") + " on this clip.",
           note: "Remove effects manually in Premiere Pro"
         });
       } catch (e) {
@@ -4244,18 +4416,25 @@ export class PremiereProTools {
     const script = `
       try {
         app.enableQE();
-        var info1 = __findClip("${clipId1}");
+        var info1 = __findClip(${JSON.stringify(clipId1)});
         if (!info1) return JSON.stringify({ success: false, error: "First clip not found" });
-        var info2 = __findClip("${clipId2}");
+        var info2 = __findClip(${JSON.stringify(clipId2)});
         var targetInfo = info2 || info1;
-        var qeSeq = qe.project.getActiveSequence();
+        // Addressed by id, not by whatever is on screen. __findClip() searches every
+        // sequence in the project, so a clip can be resolved out of one sequence and
+        // then, through getActiveSequence(), have the effect applied to whichever
+        // clip sits at the same track and index in a different one.
+        var qeSeq = __qeSequenceFor(targetInfo.sequence);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + targetInfo.sequenceName + "' through the QE API." });
         var qeTrack = qeSeq.getVideoTrackAt(targetInfo.trackIndex);
         var qeClip = __findQeClipByDomClip(qeTrack, targetInfo.clip);
         if (!qeClip) return JSON.stringify({ success: false, error: "Could not locate matching QE clip for transition" });
-        var transition = qe.project.getVideoTransitionByName("${transitionName}");
-        if (!transition) return JSON.stringify({ success: false, error: "Transition not found: ${transitionName}. Use list_available_transitions." });
-        var seq = app.project.activeSequence;
-        var fps = seq.timebase ? (254016000000 / parseInt(seq.timebase, 10)) : 30;
+        var transition = qe.project.getVideoTransitionByName(${JSON.stringify(transitionName)});
+        if (!transition) return JSON.stringify({ success: false, error: "Transition not found: " + ${JSON.stringify(transitionName)} + ". Use list_available_transitions." });
+        // The clip may live outside the active sequence, and a duration in frames
+        // computed from the wrong timebase gives the transition the wrong length.
+        var seq = targetInfo.sequence;
+        var fps = seq && seq.timebase ? (254016000000 / parseInt(seq.timebase, 10)) : 30;
         var frames = Math.round(${duration} * fps);
         ${this.transitionVerificationScript()}
         var before = __readQeTransitionState(qeClip);
@@ -4268,7 +4447,7 @@ export class PremiereProTools {
           return JSON.stringify({
             success: false,
             error: "Transition call completed but Premiere Pro did not expose a verified transition change",
-            transitionName: "${transitionName}",
+            transitionName: ${JSON.stringify(transitionName)},
             duration: ${duration},
             frames: frames,
             before: before,
@@ -4277,7 +4456,7 @@ export class PremiereProTools {
             afterXml: afterXml
           });
         }
-        return JSON.stringify({ success: true, message: "Transition added and verified", transitionName: "${transitionName}", duration: ${duration}, frames: frames, before: before, after: after, beforeXml: beforeXml, afterXml: afterXml });
+        return JSON.stringify({ success: true, message: "Transition added and verified", transitionName: ${JSON.stringify(transitionName)}, duration: ${duration}, frames: frames, before: before, after: after, beforeXml: beforeXml, afterXml: afterXml });
       } catch (e) {
         return JSON.stringify({ success: false, error: "QE DOM error: " + e.toString() });
       }
@@ -4291,18 +4470,25 @@ export class PremiereProTools {
     const script = `
       try {
         app.enableQE();
-        var info = __findClip("${clipId}");
+        var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, status: "failed", verified: false, error: "Clip not found" });
-        var qeSeq = qe.project.getActiveSequence();
+        // Addressed by id, not by whatever is on screen. __findClip() searches every
+        // sequence in the project, so a clip can be resolved out of one sequence and
+        // then, through getActiveSequence(), have the effect applied to whichever
+        // clip sits at the same track and index in a different one.
+        var qeSeq = __qeSequenceFor(info.sequence);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + info.sequenceName + "' through the QE API." });
         var qeTrack = info.trackType === 'video' ? qeSeq.getVideoTrackAt(info.trackIndex) : qeSeq.getAudioTrackAt(info.trackIndex);
         var qeClip = __findQeClipByDomClip(qeTrack, info.clip);
         if (!qeClip) return JSON.stringify({ success: false, status: "failed", verified: false, error: "Could not locate matching QE clip for transition" });
         var transition = info.trackType === 'video'
-          ? qe.project.getVideoTransitionByName("${transitionName}")
-          : qe.project.getAudioTransitionByName("${transitionName}");
-        if (!transition) return JSON.stringify({ success: false, status: "failed", verified: false, error: "Transition not found: ${transitionName}" });
-        var seq = app.project.activeSequence;
-        var fps = seq.timebase ? (254016000000 / parseInt(seq.timebase, 10)) : 30;
+          ? qe.project.getVideoTransitionByName(${JSON.stringify(transitionName)})
+          : qe.project.getAudioTransitionByName(${JSON.stringify(transitionName)});
+        if (!transition) return JSON.stringify({ success: false, status: "failed", verified: false, error: "Transition not found: " + ${JSON.stringify(transitionName)} });
+        // The clip may live outside the active sequence, and a duration in frames
+        // computed from the wrong timebase gives the transition the wrong length.
+        var seq = info.sequence;
+        var fps = seq && seq.timebase ? (254016000000 / parseInt(seq.timebase, 10)) : 30;
         var frames = Math.round(${duration} * fps);
         ${this.transitionVerificationScript()}
         var before = __readQeTransitionState(qeClip);
@@ -4345,8 +4531,8 @@ export class PremiereProTools {
               after: inspectionAvailable ? { transitionEnumeration: after, finalCutProXml: afterXml } : null
             },
             warning: "Transition command accepted; result could not be independently verified.",
-            transitionName: "${transitionName}",
-            position: "${position}",
+            transitionName: ${JSON.stringify(transitionName)},
+            position: ${JSON.stringify(position)},
             duration: ${duration},
             frames: frames
           });
@@ -4355,7 +4541,7 @@ export class PremiereProTools {
           success: true,
           status: "applied_verified",
           verified: true,
-          message: "Transition added at ${position} and verified",
+          message: "Transition added at " + ${JSON.stringify(position)} + " and verified",
           verification: {
             method: qeVerified ? "transition_enumeration" : "final_cut_pro_xml",
             available: true,
@@ -4363,8 +4549,8 @@ export class PremiereProTools {
             before: qeVerified ? before : beforeXml,
             after: qeVerified ? after : afterXml
           },
-          transitionName: "${transitionName}",
-          position: "${position}",
+          transitionName: ${JSON.stringify(transitionName)},
+          position: ${JSON.stringify(position)},
           duration: ${duration},
           frames: frames
         });
@@ -4585,7 +4771,7 @@ export class PremiereProTools {
   private async adjustAudioLevels(clipId: string, level: number): Promise<any> {
     const script = `
       try {
-        var info = __findClip("${clipId}");
+        var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
         var clip = info.clip;
 
@@ -4660,7 +4846,7 @@ export class PremiereProTools {
         return JSON.stringify({
           success: true,
           message: "Audio level adjusted (clip Volume component, locale-aware, calibrated dB scale)",
-          clipId: "${clipId}",
+          clipId: ${JSON.stringify(clipId)},
           requestedDB: dB,
           oldLinearValue: oldLinear,
           oldDB: oldDB,
@@ -4779,15 +4965,15 @@ export class PremiereProTools {
   private async muteTrack(sequenceId: string, trackIndex: number, muted: boolean): Promise<any> {
     const script = `
       try {
-        var sequence = __findSequence("${sequenceId}");
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        var sequence = __findSequence(${JSON.stringify(sequenceId)});
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         var track = sequence.audioTracks[${trackIndex}];
         if (!track) return JSON.stringify({ success: false, error: "Audio track not found" });
         track.setMute(${muted ? 1 : 0});
         return JSON.stringify({
           success: true,
           message: "Track mute status changed",
-          sequenceId: "${sequenceId}",
+          sequenceId: ${JSON.stringify(sequenceId)},
           trackIndex: ${trackIndex},
           muted: ${muted}
         });
@@ -5209,11 +5395,16 @@ export class PremiereProTools {
     const script = `
       try {
         app.enableQE();
-        var info = __findClip("${clipId}");
+        var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
-        var qeSeq = qe.project.getActiveSequence();
+        // Addressed by id, not by whatever is on screen. __findClip() searches every
+        // sequence in the project, so a clip can be resolved out of one sequence and
+        // then, through getActiveSequence(), have the effect applied to whichever
+        // clip sits at the same track and index in a different one.
+        var qeSeq = __qeSequenceFor(info.sequence);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + info.sequenceName + "' through the QE API." });
         var qeTrack = qeSeq.getVideoTrackAt(info.trackIndex);
-        var qeClip = qeTrack.getItemAt(info.clipIndex);
+        var qeClip = __findQeClipByDomClip(qeTrack, info.clip);
         var effect = qe.project.getVideoEffectByName("Lumetri Color");
         if (!effect) return JSON.stringify({ success: false, error: "Lumetri Color effect not found" });
         qeClip.addVideoEffect(effect);
@@ -5225,7 +5416,7 @@ export class PremiereProTools {
             ${paramCode}
           } catch (e2) {}
         }
-        return JSON.stringify({ success: true, message: "Color correction applied", clipId: "${clipId}" });
+        return JSON.stringify({ success: true, message: "Color correction applied", clipId: ${JSON.stringify(clipId)} });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
       }
@@ -5238,11 +5429,16 @@ export class PremiereProTools {
     const script = `
       try {
         app.enableQE();
-        var info = __findClip("${clipId}");
+        var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
-        var qeSeq = qe.project.getActiveSequence();
+        // Addressed by id, not by whatever is on screen. __findClip() searches every
+        // sequence in the project, so a clip can be resolved out of one sequence and
+        // then, through getActiveSequence(), have the effect applied to whichever
+        // clip sits at the same track and index in a different one.
+        var qeSeq = __qeSequenceFor(info.sequence);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + info.sequenceName + "' through the QE API." });
         var qeTrack = qeSeq.getVideoTrackAt(info.trackIndex);
-        var qeClip = qeTrack.getItemAt(info.clipIndex);
+        var qeClip = __findQeClipByDomClip(qeTrack, info.clip);
         var effect = qe.project.getVideoEffectByName("Lumetri Color");
         if (!effect) return JSON.stringify({ success: false, error: "Lumetri Color not found" });
         qeClip.addVideoEffect(effect);
@@ -5251,10 +5447,10 @@ export class PremiereProTools {
         for (var j = 0; j < lastComp.properties.numItems; j++) {
           var p = lastComp.properties[j];
           try {
-            if (p.displayName === "Input LUT") p.setValue("${lutPath}", true);
+            if (p.displayName === "Input LUT") p.setValue(${JSON.stringify(lutPath)}, true);
           } catch (e2) {}
         }
-        return JSON.stringify({ success: true, message: "LUT applied", clipId: "${clipId}", lutPath: "${lutPath}" });
+        return JSON.stringify({ success: true, message: "LUT applied", clipId: ${JSON.stringify(clipId)}, lutPath: ${JSON.stringify(lutPath)} });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
       }
@@ -5591,24 +5787,31 @@ export class PremiereProTools {
   private async exportFrame(sequenceId: string, time: number, outputPath: string, format = 'png'): Promise<any> {
     const script = `
       try {
-        var sequence = __findSequence("${sequenceId}");
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        var sequence = __findSequence(${JSON.stringify(sequenceId)});
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
 
         if (sequence.openInTimeline) {
           try { sequence.openInTimeline(); } catch (e0) {}
         }
 
-        app.enableQE();
-        var qeSequence = qe.project.getActiveSequence();
+        // Resolve the QE handle for the sequence the caller named. Reaching for
+        // qe.project.getActiveSequence() here exported whatever happened to be
+        // open in the timeline instead: asking for a non-active sequence
+        // returned success, echoed back the requested sequenceId, and wrote a
+        // frame of the active sequence's content.
+        var qeSequence = __qeSequenceFor(sequence);
         if (!qeSequence) {
-          return JSON.stringify({ success: false, error: "QE active sequence not available for frame export" });
+          return JSON.stringify({
+            success: false,
+            error: "Could not address sequence '" + sequence.name + "' through the QE API, which frame export requires. Open it in a timeline and retry."
+          });
         }
 
-        var methodName = "${format}" === "jpg" ? "exportFrameJPEG" : ("${format}" === "tiff" ? "exportFrameTiff" : "exportFramePNG");
+        var methodName = ${JSON.stringify(format)} === "jpg" ? "exportFrameJPEG" : (${JSON.stringify(format)} === "tiff" ? "exportFrameTiff" : "exportFramePNG");
         if (typeof qeSequence[methodName] !== "function") {
           return JSON.stringify({
             success: false,
-            error: "Frame export format '" + "${format}" + "' is not supported by the available Premiere API"
+            error: "Frame export format '" + ${JSON.stringify(format)} + "' is not supported by the available Premiere API"
           });
         }
 
@@ -5621,39 +5824,106 @@ export class PremiereProTools {
           timeTicks = exportTime.ticks;
         } catch (e1) {}
 
+        // Premiere's exportFrame* methods always append "." + format to the
+        // path they are handed, so passing the caller's "shot.png" wrote
+        // "shot.png.png" while the tool reported "shot.png" — a path with no
+        // file at it. Hand Premiere the stem and let it add the extension back,
+        // so the frame lands exactly where the caller asked.
+        var formatExtension = ${JSON.stringify(format)} === "jpg"
+          ? ".jpg"
+          : (${JSON.stringify(format)} === "tiff" ? ".tiff" : ".png");
+        var requestedPath = ${JSON.stringify(outputPath)};
+        var exportStem = requestedPath;
+        if (requestedPath.length > formatExtension.length) {
+          var tail = requestedPath.substring(requestedPath.length - formatExtension.length);
+          if (tail.toLowerCase() === formatExtension) {
+            exportStem = requestedPath.substring(0, requestedPath.length - formatExtension.length);
+          }
+        }
+
+        // Where the frame should land, and where it would land if some future
+        // version stopped appending the extension.
+        var candidatePaths = [exportStem + formatExtension, requestedPath];
+
+        // A non-throwing call is not proof that a file was written, so record
+        // what is on disk first. Comparing modification stamps rather than mere
+        // existence keeps a stale file from an earlier run from being reported
+        // as this call's output.
+        var beforeState = [];
+        for (var p = 0; p < candidatePaths.length; p++) {
+          var state = { existed: false, stamp: 0, length: -1 };
+          try {
+            var probe = new File(candidatePaths[p]);
+            if (probe.exists) {
+              state.existed = true;
+              state.stamp = probe.modified ? probe.modified.getTime() : 0;
+              state.length = probe.length;
+            }
+          } catch (eProbe) {}
+          beforeState.push(state);
+        }
+
+        // Returns the path that looks freshly written, or null. Freshness is judged
+        // on modification time first and length second, because a filesystem with
+        // one-second timestamp granularity can rewrite a file within the same second
+        // and leave the stamp unchanged.
+        function writtenPath(acceptUnchanged) {
+          for (var w = 0; w < candidatePaths.length; w++) {
+            try {
+              var file = new File(candidatePaths[w]);
+              if (!file.exists) continue;
+              if (!beforeState[w].existed) return candidatePaths[w];
+              var stamp = file.modified ? file.modified.getTime() : 0;
+              if (stamp !== beforeState[w].stamp) return candidatePaths[w];
+              if (file.length !== beforeState[w].length) return candidatePaths[w];
+              // Neither moved. The export may still have written identical bytes over
+              // an existing file, so on the final check accept it rather than report a
+              // failure for a write that did happen -- a false failure invites a retry.
+              if (acceptUnchanged) return candidatePaths[w];
+            } catch (eCheck) {}
+          }
+          return null;
+        }
+
         var exportError = null;
         function tryExport(arg1, arg2) {
           try {
             qeSequence[methodName](arg1, arg2);
-            return true;
           } catch (e2) {
             exportError = e2.toString();
             return false;
           }
+          // Some argument orders are accepted without throwing and without
+          // producing anything, so keep probing the remaining orders rather
+          // than reporting a success that left no file behind.
+          return writtenPath(false) !== null;
         }
 
         var exported =
-          tryExport(timeNumber, "${outputPath}") ||
-          tryExport("${outputPath}", timeNumber) ||
-          tryExport(timeString, "${outputPath}") ||
-          tryExport("${outputPath}", timeString) ||
-          tryExport(timeTicks, "${outputPath}") ||
-          tryExport("${outputPath}", timeTicks);
+          tryExport(timeNumber, exportStem) ||
+          tryExport(exportStem, timeNumber) ||
+          tryExport(timeString, exportStem) ||
+          tryExport(exportStem, timeString) ||
+          tryExport(timeTicks, exportStem) ||
+          tryExport(exportStem, timeTicks);
 
-        if (!exported) {
+        var actualPath = writtenPath(true);
+        if (!exported || !actualPath) {
           return JSON.stringify({
             success: false,
-            error: exportError || "Frame export failed"
+            error: exportError || "Frame export reported no error but wrote no file"
           });
         }
 
         return JSON.stringify({
           success: true,
           message: "Frame exported successfully",
-          sequenceId: "${sequenceId}",
+          sequenceId: ${JSON.stringify(sequenceId)},
+          sequenceName: sequence.name,
           time: ${time},
-          outputPath: "${outputPath}",
-          format: "${format}"
+          outputPath: actualPath,
+          requestedPath: requestedPath,
+          format: ${JSON.stringify(format)}
         });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
@@ -5668,11 +5938,16 @@ export class PremiereProTools {
     const script = `
       try {
         app.enableQE();
-        var info = __findClip("${clipId}");
+        var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
-        var qeSeq = qe.project.getActiveSequence();
+        // Addressed by id, not by whatever is on screen. __findClip() searches every
+        // sequence in the project, so a clip can be resolved out of one sequence and
+        // then, through getActiveSequence(), have the effect applied to whichever
+        // clip sits at the same track and index in a different one.
+        var qeSeq = __qeSequenceFor(info.sequence);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + info.sequenceName + "' through the QE API." });
         var qeTrack = qeSeq.getVideoTrackAt(info.trackIndex);
-        var qeClip = qeTrack.getItemAt(info.clipIndex);
+        var qeClip = __findQeClipByDomClip(qeTrack, info.clip);
         var effect = qe.project.getVideoEffectByName("Warp Stabilizer");
         if (!effect) return JSON.stringify({ success: false, error: "Warp Stabilizer effect not found" });
         qeClip.addVideoEffect(effect);
@@ -5683,7 +5958,7 @@ export class PremiereProTools {
             if (lastComp.properties[j].displayName === "Smoothness") lastComp.properties[j].setValue(${smoothness}, true);
           } catch (e2) {}
         }
-        return JSON.stringify({ success: true, message: "Warp Stabilizer applied", clipId: "${clipId}", smoothness: ${smoothness} });
+        return JSON.stringify({ success: true, message: "Warp Stabilizer applied", clipId: ${JSON.stringify(clipId)}, smoothness: ${smoothness} });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
       }
@@ -5696,12 +5971,17 @@ export class PremiereProTools {
     const script = `
       try {
         app.enableQE();
-        var info = __findClip("${clipId}");
+        var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
         var oldSpeed = info.clip.getSpeed();
-        var qeSeq = qe.project.getActiveSequence();
+        // Addressed by id, not by whatever is on screen. __findClip() searches every
+        // sequence in the project, so a clip can be resolved out of one sequence and
+        // then, through getActiveSequence(), have the effect applied to whichever
+        // clip sits at the same track and index in a different one.
+        var qeSeq = __qeSequenceFor(info.sequence);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + info.sequenceName + "' through the QE API." });
         var qeTrack = info.trackType === 'video' ? qeSeq.getVideoTrackAt(info.trackIndex) : qeSeq.getAudioTrackAt(info.trackIndex);
-        var qeClip = qeTrack.getItemAt(info.clipIndex);
+        var qeClip = __findQeClipByDomClip(qeTrack, info.clip);
         try { qeClip.setSpeed(${speed}, ${maintainAudio}); } catch(e2) {
           var currentPercent = Number(oldSpeed);
           if (currentPercent <= 10) currentPercent = currentPercent * 100;
@@ -5724,28 +6004,65 @@ export class PremiereProTools {
   // ============================================
 
   // Markers Implementation
-  private async addMarker(_sequenceId: string, time: number, name: string, comment?: string, color?: string, duration?: number): Promise<any> {
-    const script = `
-      try {
-        var sequence = app.project.activeSequence;
-        if (!sequence) {
+
+  /**
+   * Builds the ExtendScript preamble that resolves a caller-supplied sequence ID to a real
+   * sequence object.
+   *
+   * Premiere's ExtendScript DOM can read and mutate any sequence in the project, not just
+   * the one on screen, so a tool that accepts a sequenceId must act on that sequence rather
+   * than silently retargeting to `app.project.activeSequence`. When the ID matches nothing
+   * we return a truthful error instead of falling back to the active sequence, which would
+   * quietly write to the wrong timeline.
+   *
+   * The ID compared here is `sequence.sequenceID` (a GUID) — the same value surfaced as `id`
+   * by `list_sequences` and `get_active_sequence`. It is deliberately not `sequence.id` or
+   * `projectItem.nodeId`, which are different identifiers.
+   */
+  private buildSequenceResolver(sequenceId: string, varName: string = 'sequence'): string {
+    const literal = JSON.stringify(sequenceId);
+    return `        var ${varName} = __findSequence(${literal});
+        if (!${varName}) {
           return JSON.stringify({
             success: false,
-            error: "No active sequence"
+            error: "Sequence not found by id: " + ${literal} + ". Use list_sequences or get_active_sequence to obtain a valid sequence ID."
           });
-        } else {
-          var marker = sequence.markers.createMarker(${time});
-          marker.name = ${JSON.stringify(name)};
-          ${comment ? `marker.comments = ${JSON.stringify(comment)};` : ''}
-          ${color ? `marker.setColorByIndex(${color === 'red' ? '5' : color === 'green' ? '3' : color === 'blue' ? '1' : '0'});` : ''}
-          ${duration && duration > 0 ? `marker.end = ${time + duration};` : ''}
+        }`;
+  }
 
-          return JSON.stringify({
-            success: true,
-            markerId: marker.guid,
-            message: "Marker added successfully"
-          });
-        }
+  /**
+   * Map a schema-validated colour to its index. Returns null when no colour was
+   * supplied, leaving the marker at Premiere's default rather than silently
+   * recolouring it. Unrecognised values cannot reach here — MarkerColorSchema
+   * rejects them before the bridge is touched.
+   */
+  private static resolveMarkerColor(color?: string | number): number | null {
+    if (color === undefined || color === null || color === '') return null;
+    if (typeof color === 'number') return color;
+    const value = String(color).trim().toLowerCase();
+    if (/^[0-7]$/.test(value)) return Number(value);
+    const index = MARKER_COLOR_NAMES.indexOf(value as typeof MARKER_COLOR_NAMES[number]);
+    return index === -1 ? null : index;
+  }
+
+  private async addMarker(sequenceId: string, time: number, name: string, comment?: string, color?: string, duration?: number): Promise<any> {
+    const colorIndex = PremiereProTools.resolveMarkerColor(color);
+    const script = `
+      try {
+${this.buildSequenceResolver(sequenceId)}
+        var marker = sequence.markers.createMarker(${time});
+        marker.name = ${JSON.stringify(name)};
+        ${comment ? `marker.comments = ${JSON.stringify(comment)};` : ''}
+        ${colorIndex !== null ? `marker.setColorByIndex(${colorIndex});` : ''}
+        ${duration && duration > 0 ? `marker.end = ${time + duration};` : ''}
+
+        return JSON.stringify({
+          success: true,
+          markerId: marker.guid,
+          sequenceId: sequence.sequenceID,
+          sequenceName: sequence.name,
+          message: "Marker added successfully"
+        });
       } catch (e) {
         return JSON.stringify({
           success: false,
@@ -5756,38 +6073,33 @@ export class PremiereProTools {
     return await this.bridge.executeScript(script);
   }
 
-  private async deleteMarker(_sequenceId: string, markerId: string): Promise<any> {
+  private async deleteMarker(sequenceId: string, markerId: string): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
-        if (!sequence) {
-          return JSON.stringify({
-            success: false,
-            error: "No active sequence"
-          });
-        } else {
-          var deleted = false;
-          for (var i = 0; i < sequence.markers.numMarkers; i++) {
-            var marker = sequence.markers[i];
-            if (marker.guid === ${JSON.stringify(markerId)}) {
-              sequence.markers.deleteMarker(marker);
-              deleted = true;
-              break;
-            }
+${this.buildSequenceResolver(sequenceId)}
+        var deleted = false;
+        for (var i = 0; i < sequence.markers.numMarkers; i++) {
+          var marker = sequence.markers[i];
+          if (marker.guid === ${JSON.stringify(markerId)}) {
+            sequence.markers.deleteMarker(marker);
+            deleted = true;
+            break;
           }
-          var stillPresent = false;
-          for (var j = 0; j < sequence.markers.numMarkers; j++) {
-            if (sequence.markers[j].guid === ${JSON.stringify(markerId)}) {
-              stillPresent = true;
-              break;
-            }
-          }
-
-          return JSON.stringify({
-            success: deleted && !stillPresent,
-            message: deleted && !stillPresent ? "Marker deleted successfully" : (deleted ? "Premiere reported marker deletion but marker is still present" : "Marker not found")
-          });
         }
+        var stillPresent = false;
+        for (var j = 0; j < sequence.markers.numMarkers; j++) {
+          if (sequence.markers[j].guid === ${JSON.stringify(markerId)}) {
+            stillPresent = true;
+            break;
+          }
+        }
+
+        return JSON.stringify({
+          success: deleted && !stillPresent,
+          sequenceId: sequence.sequenceID,
+          sequenceName: sequence.name,
+          message: deleted && !stillPresent ? "Marker deleted successfully" : (deleted ? "Premiere reported marker deletion but marker is still present" : "Marker not found")
+        });
       } catch (e) {
         return JSON.stringify({
           success: false,
@@ -5798,33 +6110,29 @@ export class PremiereProTools {
     return await this.bridge.executeScript(script);
   }
 
-  private async updateMarker(_sequenceId: string, markerId: string, updates: any): Promise<any> {
+  private async updateMarker(sequenceId: string, markerId: string, updates: any): Promise<any> {
+    const updateColorIndex = PremiereProTools.resolveMarkerColor(updates.color);
     const script = `
       try {
-        var sequence = app.project.activeSequence;
-        if (!sequence) {
-          return JSON.stringify({
-            success: false,
-            error: "No active sequence"
-          });
-        } else {
-          var found = false;
-          for (var i = 0; i < sequence.markers.numMarkers; i++) {
-            var marker = sequence.markers[i];
-            if (marker.guid === ${JSON.stringify(markerId)}) {
-              ${updates.name ? `marker.name = ${JSON.stringify(updates.name)};` : ''}
-              ${updates.comment ? `marker.comments = ${JSON.stringify(updates.comment)};` : ''}
-              ${updates.color ? `marker.setColorByIndex(${updates.color === 'red' ? '5' : updates.color === 'green' ? '3' : updates.color === 'blue' ? '1' : '0'});` : ''}
-              found = true;
-              break;
-            }
+${this.buildSequenceResolver(sequenceId)}
+        var found = false;
+        for (var i = 0; i < sequence.markers.numMarkers; i++) {
+          var marker = sequence.markers[i];
+          if (marker.guid === ${JSON.stringify(markerId)}) {
+            ${updates.name !== undefined ? `marker.name = ${JSON.stringify(updates.name)};` : ''}
+            ${updates.comment !== undefined ? `marker.comments = ${JSON.stringify(updates.comment)};` : ''}
+            ${updateColorIndex !== null ? `marker.setColorByIndex(${updateColorIndex});` : ''}
+            found = true;
+            break;
           }
-
-          return JSON.stringify({
-            success: found,
-            message: found ? "Marker updated successfully" : "Marker not found"
-          });
         }
+
+        return JSON.stringify({
+          success: found,
+          sequenceId: sequence.sequenceID,
+          sequenceName: sequence.name,
+          message: found ? "Marker updated successfully" : "Marker not found"
+        });
       } catch (e) {
         return JSON.stringify({
           success: false,
@@ -5835,36 +6143,38 @@ export class PremiereProTools {
     return await this.bridge.executeScript(script);
   }
 
-  private async listMarkers(_sequenceId: string): Promise<any> {
+  private async listMarkers(sequenceId: string): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
-        if (!sequence) {
-          return JSON.stringify({
-            success: false,
-            error: "No active sequence"
-          });
-        } else {
-          var markers = [];
-          for (var i = 0; i < sequence.markers.numMarkers; i++) {
-            var marker = sequence.markers[i];
-            markers.push({
-              id: marker.guid,
-              name: marker.name,
-              comment: marker.comments,
-              start: marker.start.seconds,
-              end: marker.end.seconds,
-              duration: marker.end.seconds - marker.start.seconds,
-              type: marker.type
-            });
-          }
-
-          return JSON.stringify({
-            success: true,
-            markers: markers,
-            count: markers.length
+${this.buildSequenceResolver(sequenceId)}
+        // getColorByIndex() is not bounded by the write domain: a marker can hold
+        // -1, a persistent "no colour assigned" state that renders black. Guard
+        // the lookup, or an undefined value silently drops colorName from the JSON.
+        var COLOR_NAMES = ["green","red","purple","orange","yellow","white","blue","cyan"];
+        var markers = [];
+        for (var i = 0; i < sequence.markers.numMarkers; i++) {
+          var marker = sequence.markers[i];
+          var colorIndex = marker.getColorByIndex();
+          markers.push({
+            id: marker.guid,
+            name: marker.name,
+            comment: marker.comments,
+            start: marker.start.seconds,
+            end: marker.end.seconds,
+            duration: marker.end.seconds - marker.start.seconds,
+            type: marker.type,
+            color: colorIndex,
+            colorName: (colorIndex >= 0 && colorIndex < COLOR_NAMES.length) ? COLOR_NAMES[colorIndex] : null
           });
         }
+
+        return JSON.stringify({
+          success: true,
+          sequenceId: sequence.sequenceID,
+          sequenceName: sequence.name,
+          markers: markers,
+          count: markers.length
+        });
       } catch (e) {
         return JSON.stringify({
           success: false,
@@ -5898,8 +6208,10 @@ export class PremiereProTools {
         app.enableQE();
         var seq = __findSequence(${JSON.stringify(sequenceId)});
         if (!seq) return JSON.stringify({ success: false, error: "Sequence not found" });
+        var __priorActive = app.project.activeSequence;
         app.project.activeSequence = seq;
-        var qeSeq = qe.project.getActiveSequence();
+        var qeSeq = __qeSequenceFor(seq);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + seq.name + "' through the QE API." });
 
         // Calculate insertion index based on position
         var existingVideoTracks = seq.videoTracks.numTracks;
@@ -5919,7 +6231,7 @@ export class PremiereProTools {
           return JSON.stringify({
             success: false,
             error: "Premiere did not add the requested track",
-            trackType: "${trackType}",
+            trackType: ${JSON.stringify(trackType)},
             position: ${JSON.stringify(position)},
             videoTracksBefore: existingVideoTracks,
             videoTracksAfter: afterVideoTracks,
@@ -5932,8 +6244,8 @@ export class PremiereProTools {
 
         return JSON.stringify({
           success: true,
-          message: "${trackType} track added at " + ${JSON.stringify(position)},
-          trackType: "${trackType}",
+          message: ${JSON.stringify(trackType)} + " track added at " + ${JSON.stringify(position)},
+          trackType: ${JSON.stringify(trackType)},
           position: ${JSON.stringify(position)},
           videoTracksBefore: existingVideoTracks,
           videoTracksAfter: afterVideoTracks,
@@ -5944,17 +6256,26 @@ export class PremiereProTools {
         });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
+      } finally {
+        // Leave the user where they were. ES3 has try/finally, and this runs
+        // before the return above completes.
+        try {
+          if (__priorActive && app.project.activeSequence &&
+              app.project.activeSequence.sequenceID !== __priorActive.sequenceID) {
+            app.project.activeSequence = __priorActive;
+          }
+        } catch (eRestore) {}
       }
     `;
     return await this.bridge.executeScript(script);
   }
 
-  private async deleteTrack(_sequenceId: string, trackType: string, trackIndex: number): Promise<any> {
+  private async deleteTrack(sequenceId: string, trackType: string, trackIndex: number): Promise<any> {
     if (trackType === 'caption') {
       return {
         success: false,
         error: 'Caption track deletion is not supported by Premiere Pro scripting. The ExtendScript DOM exposes no sequence.captionTracks/getCaptionTracks surface, and the QE DOM exposes no caption-track accessor or delete method.',
-        sequenceId: _sequenceId,
+        sequenceId,
         trackType,
         trackIndex,
         unsupportedByPremiereApi: true,
@@ -5962,58 +6283,69 @@ export class PremiereProTools {
       };
     }
 
+    // Premiere 26 exposes no DOM trackCollection.deleteTrack, so deletion falls through to the
+    // QE DOM — and QE can only reach qe.project.getActiveSequence(). Rather than deleting a
+    // track from whatever timeline happens to be on screen, refuse the cross-sequence case with
+    // a truthful error that names the limitation.
     const script = `
       try {
-        var sequence = __findSequence(${JSON.stringify(_sequenceId)});
-        if (!sequence) sequence = app.project.activeSequence;
-        if (!sequence) {
-          return JSON.stringify({
-            success: false,
-            error: "Sequence not found"
-          });
-        } else {
-          var tracks = ${trackType === 'video' ? 'sequence.videoTracks' : 'sequence.audioTracks'};
-          if (${trackIndex} >= 0 && ${trackIndex} < tracks.numTracks) {
-            var beforeCount = tracks.numTracks;
-            var deleted = false;
-            if (tracks.deleteTrack) {
-              tracks.deleteTrack(${trackIndex});
-              deleted = true;
-            } else {
-              app.enableQE();
-              var qeSeq = qe.project.getActiveSequence();
-              if (!qeSeq) {
-                return JSON.stringify({ success: false, error: "QE active sequence unavailable for track deletion" });
-              }
-              if (${trackType === 'video' ? 'true' : 'false'} && qeSeq.removeVideoTrack) {
-                qeSeq.removeVideoTrack(${trackIndex});
-                deleted = true;
-              } else if (${trackType === 'audio' ? 'true' : 'false'} && qeSeq.removeAudioTrack) {
-                qeSeq.removeAudioTrack(${trackIndex});
-                deleted = true;
-              }
-            }
-            var afterCount = tracks.numTracks;
-            if (!deleted || afterCount >= beforeCount) {
+${this.buildSequenceResolver(sequenceId)}
+        var tracks = ${trackType === 'video' ? 'sequence.videoTracks' : 'sequence.audioTracks'};
+        if (${trackIndex} >= 0 && ${trackIndex} < tracks.numTracks) {
+          var beforeCount = tracks.numTracks;
+          var deleted = false;
+          if (tracks.deleteTrack) {
+            tracks.deleteTrack(${trackIndex});
+            deleted = true;
+          } else {
+            // QE addresses sequences by index through getSequenceAt(), not
+            // only whatever is active, so resolve by guid instead of refusing
+            // every cross-sequence request. What QE actually limits is which
+            // sequences it exposes at all — a sequence it cannot see is
+            // reported as such, naming it, rather than deleting a track from
+            // the timeline that happens to be on screen.
+            var activeSeq = app.project.activeSequence;
+            var qeSeq = __qeSequenceFor(sequence);
+            if (!qeSeq) {
               return JSON.stringify({
                 success: false,
-                error: "Premiere did not remove the requested track",
-                beforeCount: beforeCount,
-                afterCount: afterCount
+                error: "Track deletion needs the QE API, which cannot address sequence '" + sequence.name + "'. Premiere exposes no DOM track-deletion API, and QE only reaches sequences it has open. Open it in a timeline, or call set_active_sequence with " + sequence.sequenceID + ", then retry.",
+                sequenceId: sequence.sequenceID,
+                sequenceName: sequence.name,
+                activeSequenceId: activeSeq ? activeSeq.sequenceID : null,
+                requiresOpenSequence: true
               });
             }
+            if (${trackType === 'video' ? 'true' : 'false'} && qeSeq.removeVideoTrack) {
+              qeSeq.removeVideoTrack(${trackIndex});
+              deleted = true;
+            } else if (${trackType === 'audio' ? 'true' : 'false'} && qeSeq.removeAudioTrack) {
+              qeSeq.removeAudioTrack(${trackIndex});
+              deleted = true;
+            }
+          }
+          var afterCount = tracks.numTracks;
+          if (!deleted || afterCount >= beforeCount) {
             return JSON.stringify({
-              success: true,
-              message: "Track deleted successfully",
+              success: false,
+              error: "Premiere did not remove the requested track",
               beforeCount: beforeCount,
               afterCount: afterCount
             });
-          } else {
-            return JSON.stringify({
-              success: false,
-              error: "Track index out of range"
-            });
           }
+          return JSON.stringify({
+            success: true,
+            sequenceId: sequence.sequenceID,
+            sequenceName: sequence.name,
+            message: "Track deleted successfully",
+            beforeCount: beforeCount,
+            afterCount: afterCount
+          });
+        } else {
+          return JSON.stringify({
+            success: false,
+            error: "Track index out of range"
+          });
         }
       } catch (e) {
         return JSON.stringify({
@@ -6025,29 +6357,24 @@ export class PremiereProTools {
     return await this.bridge.executeScript(script);
   }
 
-  private async lockTrack(_sequenceId: string, trackType: string, trackIndex: number, locked: boolean): Promise<any> {
+  private async lockTrack(sequenceId: string, trackType: string, trackIndex: number, locked: boolean): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
-        if (!sequence) {
+${this.buildSequenceResolver(sequenceId)}
+        var tracks = ${trackType === 'video' ? 'sequence.videoTracks' : 'sequence.audioTracks'};
+        if (${trackIndex} >= 0 && ${trackIndex} < tracks.numTracks) {
+          tracks[${trackIndex}].setLocked(${locked ? 1 : 0});
           return JSON.stringify({
-            success: false,
-            error: "No active sequence"
+            success: true,
+            sequenceId: sequence.sequenceID,
+            sequenceName: sequence.name,
+            message: "Track " + (${locked} ? "locked" : "unlocked")
           });
         } else {
-          var tracks = ${trackType === 'video' ? 'sequence.videoTracks' : 'sequence.audioTracks'};
-          if (${trackIndex} >= 0 && ${trackIndex} < tracks.numTracks) {
-            tracks[${trackIndex}].setLocked(${locked ? 1 : 0});
-            return JSON.stringify({
-              success: true,
-              message: "Track " + (${locked} ? "locked" : "unlocked")
-            });
-          } else {
-            return JSON.stringify({
-              success: false,
-              error: "Track index out of range"
-            });
-          }
+          return JSON.stringify({
+            success: false,
+            error: "Track index out of range"
+          });
         }
       } catch (e) {
         return JSON.stringify({
@@ -6059,28 +6386,46 @@ export class PremiereProTools {
     return await this.bridge.executeScript(script);
   }
 
-  private async toggleTrackVisibility(_sequenceId: string, trackIndex: number, visible: boolean): Promise<any> {
+  private async toggleTrackVisibility(sequenceId: string, trackIndex: number, visible: boolean): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
-        if (!sequence) {
-          return JSON.stringify({
-            success: false,
-            error: "No active sequence"
-          });
-        } else {
-          if (${trackIndex} >= 0 && ${trackIndex} < sequence.videoTracks.numTracks) {
-            sequence.videoTracks[${trackIndex}].setTargeted(${visible}, true);
-            return JSON.stringify({
-              success: true,
-              message: "Track visibility toggled"
-            });
-          } else {
+${this.buildSequenceResolver(sequenceId)}
+        if (${trackIndex} >= 0 && ${trackIndex} < sequence.videoTracks.numTracks) {
+          // This used to call setTargeted(), which is the V1/A1 patch button, not the
+          // eye. Track output was never touched and the caller's track targeting was
+          // silently changed instead, under a response saying "Track visibility
+          // toggled". On a video track, mute IS the eye: setMute(1) disables output.
+          var visibilityTrack = sequence.videoTracks[${trackIndex}];
+          if (!visibilityTrack.setMute) {
+            return JSON.stringify({ success: false, error: "Track.setMute is unavailable on this build, so track output cannot be changed" });
+          }
+          visibilityTrack.setMute(${visible} ? 0 : 1);
+
+          // Read it back: assignment is not evidence of effect anywhere else in this API.
+          var nowMuted = null;
+          try { nowMuted = visibilityTrack.isMuted ? visibilityTrack.isMuted() : null; } catch (eMuted) {}
+          if (nowMuted !== null && nowMuted === ${visible}) {
             return JSON.stringify({
               success: false,
-              error: "Track index out of range"
+              error: "Premiere accepted the change but the track output did not move",
+              requestedVisible: ${visible},
+              muted: nowMuted
             });
           }
+
+          return JSON.stringify({
+            success: true,
+            sequenceId: sequence.sequenceID,
+            sequenceName: sequence.name,
+            trackIndex: ${trackIndex},
+            visible: nowMuted === null ? ${visible} : !nowMuted,
+            message: ${visible} ? "Track output enabled" : "Track output disabled"
+          });
+        } else {
+          return JSON.stringify({
+            success: false,
+            error: "Track index out of range"
+          });
         }
       } catch (e) {
         return JSON.stringify({
@@ -6120,13 +6465,15 @@ export class PremiereProTools {
     const script = `
       try {
         app.enableQE();
-        var seq = __findSequence("${sequenceId}");
+        var seq = __findSequence(${JSON.stringify(sequenceId)});
         if (!seq) return JSON.stringify({ success: false, error: "Sequence not found" });
         // Make target active so QE DOM can address it
+        var __priorActive = app.project.activeSequence;
         app.project.activeSequence = seq;
-        var qeSeq = qe.project.getActiveSequence();
-        var effect = qe.project.getAudioEffectByName("${effectName}");
-        if (!effect) return JSON.stringify({ success: false, error: "Audio effect not found: ${effectName}" });
+        var qeSeq = __qeSequenceFor(seq);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + seq.name + "' through the QE API." });
+        var effect = qe.project.getAudioEffectByName(${JSON.stringify(effectName)});
+        if (!effect) return JSON.stringify({ success: false, error: "Audio effect not found: " + ${JSON.stringify(effectName)} });
 
         var requestedParams = ${paramJson};
         function normalize(s) { return String(s).toLowerCase().replace(/[\\s_-]+/g, ''); }
@@ -6137,7 +6484,9 @@ export class PremiereProTools {
           var qeTrack = qeSeq.getAudioTrackAt(t);
           for (var c = 0; c < track.clips.numItems; c++) {
             var clip = track.clips[c];
-            var qeClip = qeTrack.getItemAt(c);
+            // Same gap/transition mismatch: c is the DOM clip index, which is not the
+            // QE item index once anything non-clip sits earlier on the track.
+            var qeClip = __findQeClipByDomClip(qeTrack, clip);
             try {
               qeClip.addAudioEffect(effect);
               var newCompIdx = clip.components.numItems - 1;
@@ -6182,15 +6531,24 @@ export class PremiereProTools {
 
         return JSON.stringify({
           success: true,
-          sequenceId: "${sequenceId}",
+          sequenceId: ${JSON.stringify(sequenceId)},
           sequenceName: String(seq.name),
-          effectName: "${effectName}",
+          effectName: ${JSON.stringify(effectName)},
           totalClipsProcessed: perClip.length,
           allOk: perClip.every ? perClip.every(function(r){return r.ok;}) : true,
           perClip: perClip
         });
       } catch (e) {
         return JSON.stringify({ success: false, error: "QE DOM error: " + e.toString() });
+      } finally {
+        // Leave the user where they were. ES3 has try/finally, and this runs
+        // before the return above completes.
+        try {
+          if (__priorActive && app.project.activeSequence &&
+              app.project.activeSequence.sequenceID !== __priorActive.sequenceID) {
+            app.project.activeSequence = __priorActive;
+          }
+        } catch (eRestore) {}
       }
     `;
     return await this.bridge.executeScript(script);
@@ -6328,9 +6686,14 @@ export class PremiereProTools {
           return JSON.stringify({ success: true, clipId: ${JSON.stringify(clipId)}, reversed: true, changed: false, method: "still image already visually reversible" });
         }
         app.enableQE();
-        var qeSeq = qe.project.getActiveSequence();
+        // Addressed by id, not by whatever is on screen. __findClip() searches every
+        // sequence in the project, so a clip can be resolved out of one sequence and
+        // then, through getActiveSequence(), have the effect applied to whichever
+        // clip sits at the same track and index in a different one.
+        var qeSeq = __qeSequenceFor(info.sequence);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + info.sequenceName + "' through the QE API." });
         var qeTrack = info.trackType === 'video' ? qeSeq.getVideoTrackAt(info.trackIndex) : qeSeq.getAudioTrackAt(info.trackIndex);
-        var qeClip = qeTrack.getItemAt(info.clipIndex);
+        var qeClip = __findQeClipByDomClip(qeTrack, info.clip);
         if (!qeClip || !qeClip.setReverse) return JSON.stringify({ success: false, error: "QE setReverse API unavailable" });
         try { qeClip.setReverse(true); } catch (reverseError) { return JSON.stringify({ success: false, error: "Reverse via QE DOM not available: " + reverseError.toString() }); }
         return JSON.stringify({ success: true, clipId: ${JSON.stringify(clipId)}, reversed: true, changed: true, maintainAudioPitch: ${maintainAudioPitch !== false} });
@@ -6377,14 +6740,14 @@ export class PremiereProTools {
   }
 
   // Project Settings
-  private async getSequenceSettings(_sequenceId: string): Promise<any> {
+  private async getSequenceSettings(sequenceId: string): Promise<any> {
     const script = `
       try {
-        var sequence = __findSequence(${JSON.stringify(_sequenceId)});
+        var sequence = __findSequence(${JSON.stringify(sequenceId)});
         if (!sequence) {
           return JSON.stringify({
             success: false,
-            error: "Sequence not found by id: " + ${JSON.stringify(_sequenceId)}
+            error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)}
           });
         }
         var settings = sequence.getSettings();
@@ -6415,29 +6778,112 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = __findSequence(${JSON.stringify(sequenceId)});
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
+        // This used to compare width and height, write nothing at all, and report
+        // "Requested sequence settings already match the active Premiere sequence" —
+        // two falsehoods in one line, since frameRate and pixelAspectRatio were never
+        // even looked at, and the sequence operated on is the resolved one rather than
+        // whatever is active. It also refused any frame size change on the grounds that
+        // Premiere cannot do it, which is untrue: setSettings() resizes a sequence after
+        // creation, verified live by taking one from 1920x1080 to 1280x720.
         var requested = ${JSON.stringify(settings || {})};
-        var current = {
-          width: Number(sequence.frameSizeHorizontal),
-          height: Number(sequence.frameSizeVertical)
-        };
-        var mismatches = [];
-        if (requested.width !== undefined && Number(requested.width) !== current.width) mismatches.push({ field: "width", requested: Number(requested.width), current: current.width });
-        if (requested.height !== undefined && Number(requested.height) !== current.height) mismatches.push({ field: "height", requested: Number(requested.height), current: current.height });
-        if (mismatches.length) {
+        if (!sequence.getSettings || !sequence.setSettings) {
+          return JSON.stringify({ success: false, error: "Sequence settings API unavailable on this build" });
+        }
+
+        function readSettings(seq) {
+          var g = seq.getSettings();
+          var fps = null;
+          try { fps = 254016000000 / parseInt(String(g.videoFrameRate.ticks), 10); } catch (eFps) {}
+          return {
+            width: Number(g.videoFrameWidth),
+            height: Number(g.videoFrameHeight),
+            frameRate: fps,
+            pixelAspectRatio: String(g.videoPixelAspectRatio)
+          };
+        }
+
+        var before = readSettings(sequence);
+        var settingsObject = sequence.getSettings();
+        var applied = [];
+
+        if (requested.width !== undefined) { settingsObject.videoFrameWidth = Number(requested.width); applied.push("width"); }
+        if (requested.height !== undefined) { settingsObject.videoFrameHeight = Number(requested.height); applied.push("height"); }
+
+        if (requested.frameRate !== undefined) {
+          // videoFrameRate is a Time expressed as ticks per frame, and it has to be
+          // assigned as a STRING of ticks. Assigning the number is accepted without
+          // complaint and then corrupts the value — the field reads back as 2^63 ticks,
+          // which works out to a frame rate of 2.75e-08.
+          settingsObject.videoFrameRate = String(Math.round(254016000000 / Number(requested.frameRate)));
+          applied.push("frameRate");
+        }
+
+        if (requested.pixelAspectRatio !== undefined) {
+          // Stored as an "N:M" string; a number throws "Illegal Parameter type".
+          var parValue = requested.pixelAspectRatio;
+          var parText = String(parValue);
+          if (parText.indexOf(":") === -1) {
+            var parNumber = Number(parValue);
+            if (!isFinite(parNumber) || parNumber <= 0) {
+              return JSON.stringify({ success: false, error: "pixelAspectRatio must be a positive number or an \\"N:M\\" ratio string." });
+            }
+            var denominator = 1000;
+            var numerator = Math.round(parNumber * denominator);
+            var a = numerator, b = denominator;
+            while (b) { var t = a % b; a = b; b = t; }
+            parText = (numerator / a) + ":" + (denominator / a);
+          }
+          settingsObject.videoPixelAspectRatio = parText;
+          applied.push("pixelAspectRatio");
+        }
+
+        if (!applied.length) {
           return JSON.stringify({
-            success: false,
-            error: "set_sequence_settings: Sequence frame size cannot be changed after creation in Premiere Pro",
-            mismatches: mismatches,
-            note: "Create a new sequence with desired settings instead"
+            success: true,
+            message: "No recognised settings were supplied, so nothing was changed",
+            sequenceId: sequence.sequenceID,
+            sequenceName: sequence.name,
+            settings: before,
+            supported: ["width", "height", "frameRate", "pixelAspectRatio"],
+            changed: false
           });
         }
+
+        try {
+          sequence.setSettings(settingsObject);
+        } catch (eApply) {
+          return JSON.stringify({
+            success: false,
+            error: "Premiere rejected the settings: " + eApply.toString(),
+            sequenceId: sequence.sequenceID,
+            sequenceName: sequence.name,
+            attempted: applied,
+            settings: before
+          });
+        }
+
+        // Read back rather than trusting the write: several of these fields accept an
+        // assignment and silently keep their old value.
+        var after = readSettings(sequence);
+        var unchanged = [];
+        for (var ai = 0; ai < applied.length; ai++) {
+          var field = applied[ai];
+          if (String(after[field]) === String(before[field]) && String(requested[field]) !== String(before[field])) {
+            unchanged.push(field);
+          }
+        }
+
         return JSON.stringify({
-          success: true,
-          message: "Requested sequence settings already match the active Premiere sequence",
-          sequenceId: ${JSON.stringify(sequenceId)},
-          settings: current,
-          changed: false
+          success: unchanged.length === 0,
+          error: unchanged.length ? "Premiere accepted the assignment but did not apply: " + unchanged.join(", ") : undefined,
+          message: unchanged.length ? undefined : "Sequence settings applied",
+          sequenceId: sequence.sequenceID,
+          sequenceName: sequence.name,
+          applied: applied,
+          before: before,
+          after: after,
+          changed: true
         });
       } catch (e) {
         return JSON.stringify({ success: false, error: e.toString() });
@@ -6678,7 +7124,7 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = __findSequence(${JSON.stringify(sequenceId)});
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         var pos = sequence.getPlayerPosition();
         return JSON.stringify({
           success: true,
@@ -6696,7 +7142,7 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = __findSequence(${JSON.stringify(sequenceId)});
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         var ticks = __secondsToTicks(${time});
         sequence.setPlayerPosition(ticks);
         return JSON.stringify({
@@ -6715,7 +7161,7 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = __findSequence(${JSON.stringify(sequenceId)});
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         var selection = sequence.getSelection();
         var clips = [];
         for (var i = 0; i < selection.length; i++) {
@@ -6937,7 +7383,7 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = __findSequence(${JSON.stringify(sequenceId)});
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         sequence.setWorkAreaInPoint(__secondsToTicks(${inPoint}));
         sequence.setWorkAreaOutPoint(__secondsToTicks(${outPoint}));
         return JSON.stringify({
@@ -6957,7 +7403,7 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = __findSequence(${JSON.stringify(sequenceId)});
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         var inTime = sequence.getWorkAreaInPointAsTime();
         var outTime = sequence.getWorkAreaOutPointAsTime();
         return JSON.stringify({
@@ -6978,12 +7424,13 @@ export class PremiereProTools {
       try {
         app.enableQE();
         var sequence = __findSequence(${JSON.stringify(sequenceId)});
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         var track = sequence.videoTracks[${trackIndex}];
         if (!track) return JSON.stringify({ success: false, error: "Track not found at index ${trackIndex}" });
         var clipCount = track.clips.numItems;
         if (clipCount < 2) return JSON.stringify({ success: false, error: "Need at least 2 clips to add transitions, found " + clipCount });
-        var qeSeq = qe.project.getActiveSequence();
+        var qeSeq = __qeSequenceFor(sequence);
+        if (!qeSeq) return JSON.stringify({ success: false, error: "Could not address sequence '" + sequence.name + "' through the QE API." });
         var qeTrack = qeSeq.getVideoTrackAt(${trackIndex});
         var transition = qe.project.getVideoTransitionByName(${JSON.stringify(transitionName)});
         if (!transition) return JSON.stringify({ success: false, error: "Transition not found: " + ${JSON.stringify(transitionName)} });
@@ -7154,7 +7601,7 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = __findSequence(${JSON.stringify(sequenceId)});
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         var tracks = ${JSON.stringify(trackType)} === "video" ? sequence.videoTracks : sequence.audioTracks;
         if (${trackIndex} < 0 || ${trackIndex} >= tracks.numTracks) return JSON.stringify({ success: false, error: "Track index out of range" });
         var track = tracks[${trackIndex}];
@@ -7197,7 +7644,7 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = __findSequence(${JSON.stringify(sequenceId)});
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         var reframedName = ${newName ? JSON.stringify(newName) : 'sequence.name + " Reframed"'};
         sequence.autoReframeSequence(${numerator}, ${denominator}, ${JSON.stringify(preset)}, reframedName, false);
         return JSON.stringify({
@@ -7222,7 +7669,7 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = __findSequence(${JSON.stringify(sequenceId)});
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         if (!sequence.performSceneEditDetectionOnSelection) {
           return JSON.stringify({ success: false, error: "performSceneEditDetectionOnSelection API unavailable" });
         }
@@ -7278,7 +7725,7 @@ export class PremiereProTools {
     const script = `
       try {
         var sequence = __findSequence(${JSON.stringify(sequenceId)});
-        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: ${sequenceId}" });
+        if (!sequence) return JSON.stringify({ success: false, error: "Sequence not found by id: " + ${JSON.stringify(sequenceId)} });
         var projectItem = __findProjectItem(${JSON.stringify(projectItemId)});
         if (!projectItem) return JSON.stringify({ success: false, error: "Caption project item not found" });
         var startAtTime = ${startTimeVal};

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -1,25 +1,25 @@
 /**
  * Security utilities for input validation and sanitization
+ *
+ * This module deliberately holds only what is wired up. It previously also
+ * exported sanitizeInput, validateProjectName, validateNumber, validateArray,
+ * validateColor, a RateLimiter and an AuditLogger. None of them were imported by
+ * any tool path, and none were covered by a test.
+ *
+ * sanitizeInput was the actively harmful one. It stripped control characters and
+ * backslash-escaped quotes, so a bin legitimately named 12" would have been
+ * stored as 12\", and a clip name containing a control character would have been
+ * silently altered rather than rejected. Worse, its presence beside a proven
+ * ExtendScript injection hole invited the assumption that arguments were being
+ * sanitized somewhere. They were not: nothing ever called it.
+ *
+ * Injection is prevented instead by serialising every interpolated value through
+ * JSON.stringify at the point of use, which is correct for arbitrary input
+ * rather than lossy, and control characters are handled in the bridge prelude
+ * where the response is built.
  */
 
 import { normalize, isAbsolute, resolve } from 'path';
-
-/**
- * Sanitizes string input to prevent injection attacks
- */
-export function sanitizeInput(input: string): string {
-  if (typeof input !== 'string') {
-    throw new Error('Input must be a string');
-  }
-
-  return input
-    // Remove control characters
-    .replace(/[\x00-\x1F\x7F]/g, '')
-    // Escape special characters for ExtendScript
-    .replace(/['"\\]/g, '\\$&')
-    // Limit length to prevent DoS
-    .slice(0, 10000);
-}
 
 /**
  * Validates file paths to prevent path traversal attacks
@@ -78,75 +78,6 @@ export function validateFilePath(filePath: string, allowedDirs?: string[]): { va
 }
 
 /**
- * Validates project name to prevent injection
- */
-export function validateProjectName(name: string): { valid: boolean; sanitized?: string; error?: string } {
-  if (!name || typeof name !== 'string') {
-    return { valid: false, error: 'Project name must be a non-empty string' };
-  }
-
-  const trimmed = name.trim();
-
-  // Length check
-  if (trimmed.length === 0) {
-    return { valid: false, error: 'Project name cannot be empty' };
-  }
-
-  if (trimmed.length > 255) {
-    return { valid: false, error: 'Project name too long (max 255 characters)' };
-  }
-
-  // Check for invalid characters in filenames
-  const invalidChars = /[<>:"|?*\x00-\x1F]/;
-  if (invalidChars.test(trimmed)) {
-    return { valid: false, error: 'Project name contains invalid characters' };
-  }
-
-  const sanitized = sanitizeInput(trimmed);
-  return { valid: true, sanitized };
-}
-
-/**
- * Validates numeric input (e.g., time, track index)
- */
-export function validateNumber(value: any, min?: number, max?: number): { valid: boolean; value?: number; error?: string } {
-  const num = Number(value);
-
-  if (isNaN(num)) {
-    return { valid: false, error: 'Value must be a number' };
-  }
-
-  if (!isFinite(num)) {
-    return { valid: false, error: 'Value must be finite' };
-  }
-
-  if (min !== undefined && num < min) {
-    return { valid: false, error: `Value must be >= ${min}` };
-  }
-
-  if (max !== undefined && num > max) {
-    return { valid: false, error: `Value must be <= ${max}` };
-  }
-
-  return { valid: true, value: num };
-}
-
-/**
- * Validates array input
- */
-export function validateArray(value: any, maxLength?: number): { valid: boolean; error?: string } {
-  if (!Array.isArray(value)) {
-    return { valid: false, error: 'Value must be an array' };
-  }
-
-  if (maxLength !== undefined && value.length > maxLength) {
-    return { valid: false, error: `Array too long (max ${maxLength} items)` };
-  }
-
-  return { valid: true };
-}
-
-/**
  * Creates a safe temp directory with proper permissions
  */
 export function createSecureTempDir(sessionId: string): string {
@@ -158,125 +89,4 @@ export function createSecureTempDir(sessionId: string): string {
   const secureDir = normalize(`${tempBase}/premiere-bridge-${sessionId}`);
 
   return secureDir;
-}
-
-/**
- * Validates color value
- */
-export function validateColor(color: string): { valid: boolean; error?: string } {
-  if (typeof color !== 'string') {
-    return { valid: false, error: 'Color must be a string' };
-  }
-
-  // Allow common color formats: hex, rgb, rgba, color names
-  const validColorPatterns = [
-    /^#[0-9A-Fa-f]{6}$/,           // hex
-    /^#[0-9A-Fa-f]{3}$/,            // short hex
-    /^rgb\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\)$/,   // rgb
-    /^rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*[\d.]+\s*\)$/,  // rgba
-    /^(red|green|blue|yellow|white|black|gray|grey|orange|purple|pink)$/i,  // color names
-  ];
-
-  const isValid = validColorPatterns.some(pattern => pattern.test(color));
-
-  if (!isValid) {
-    return { valid: false, error: 'Invalid color format' };
-  }
-
-  return { valid: true };
-}
-
-/**
- * Rate limiter to prevent abuse
- */
-export class RateLimiter {
-  private requests: Map<string, number[]> = new Map();
-  private limit: number;
-  private windowMs: number;
-
-  constructor(limit: number = 100, windowMs: number = 60000) {
-    this.limit = limit;
-    this.windowMs = windowMs;
-  }
-
-  check(identifier: string): boolean {
-    const now = Date.now();
-    const windowStart = now - this.windowMs;
-
-    // Get existing requests for this identifier
-    const requests = this.requests.get(identifier) || [];
-
-    // Filter out old requests outside the window
-    const recentRequests = requests.filter(timestamp => timestamp > windowStart);
-
-    // Check if limit exceeded
-    if (recentRequests.length >= this.limit) {
-      return false; // Rate limit exceeded
-    }
-
-    // Add current request
-    recentRequests.push(now);
-    this.requests.set(identifier, recentRequests);
-
-    // Cleanup old entries periodically
-    if (Math.random() < 0.01) { // 1% chance
-      this.cleanup();
-    }
-
-    return true; // Request allowed
-  }
-
-  private cleanup() {
-    const now = Date.now();
-    const windowStart = now - this.windowMs;
-
-    for (const [identifier, requests] of this.requests.entries()) {
-      const recentRequests = requests.filter(timestamp => timestamp > windowStart);
-      if (recentRequests.length === 0) {
-        this.requests.delete(identifier);
-      } else {
-        this.requests.set(identifier, recentRequests);
-      }
-    }
-  }
-
-  reset(identifier: string) {
-    this.requests.delete(identifier);
-  }
-}
-
-/**
- * Audit logger for security events
- */
-export class AuditLogger {
-  private logs: Array<{ timestamp: Date; event: string; details: any }> = [];
-  private maxLogs: number;
-
-  constructor(maxLogs: number = 1000) {
-    this.maxLogs = maxLogs;
-  }
-
-  log(event: string, details: any = {}) {
-    this.logs.push({
-      timestamp: new Date(),
-      event,
-      details
-    });
-
-    // Keep only recent logs
-    if (this.logs.length > this.maxLogs) {
-      this.logs = this.logs.slice(-this.maxLogs);
-    }
-
-    // In production, you might want to write these to a file or send to a logging service
-    console.error(`[AUDIT] ${event}`, details);
-  }
-
-  getLogs(count?: number): Array<{ timestamp: Date; event: string; details: any }> {
-    return count ? this.logs.slice(-count) : [...this.logs];
-  }
-
-  clear() {
-    this.logs = [];
-  }
 }


### PR DESCRIPTION
# Act on the object the caller named, with the value they sent

Branch: `pr/tool-correctness` · 17 files, +3390 / −655 · 484 tests

---

This is a large change and I want to be upfront about why it is not smaller.

Two problems run through these tools: they take an id — or a clip id that resolves
project-wide — and then act on whatever is open in the timeline; and caller-supplied
strings reach generated ExtendScript unquoted.

They overlap less than cleanly than "same lines" would suggest — of 77 changed hunks in
`src/tools/index.ts`, 34 are quoting-only, 13 targeting-only and 15 touch both. The reason
they are together is not that the split is impossible but that I tried it and it went
wrong: separating them left one caller value unquoted behind a test exemption that hid it,
which is the exact failure this change exists to prevent. I would rather ship it as one
reviewable unit than repeat that. If you would prefer it split, say which axis and I will
do it against a guard that no longer has that hole.

One part of this touches quoting of caller-supplied values, and it has a security
dimension I would rather not spell out in public. `SECURITY.md` says to open a security
advisory, but that is only available to someone with maintain rights unless private
vulnerability reporting is enabled, and it is currently off — so there is no route for an
outside contributor to follow that instruction. Enabling it (**Settings → Advanced Security
→ Private vulnerability reporting**) puts a "Report a vulnerability" button on the Security
tab, and I will file the full write-up there; any other private channel works just as well.

Until then this PR describes the issue only as a quoting defect and its everyday
user-visible effect, which needs no ill intent and is reason enough for the change on its
own.

Everything described below currently reports `success: true`.

---

## Breaking changes

Three behaviours change for existing callers. All are in the CHANGELOG.

- **`move_clip` now rejects `newTrackIndex`** instead of accepting and ignoring it. It
  never moved a clip between tracks, so callers passing it were getting a time-only move
  and no error. `move_clip_to_track` does the job — it stays a separate call because on
  this build it is a remove-and-reinsert, which can overwrite whatever occupies the
  destination and gives the clip a new id.
- **`add_marker` / `update_marker` now reject a `color` outside the eight-name palette**
  rather than silently storing green. A request for `magenta` previously produced a green
  marker and reported success.
- **Tools that resolve a `sequenceId` now fail when it does not resolve.** Many previously
  fell back to the active sequence and reported success. Anything relying on a stale id to
  mean "use whatever is open" should pass no id at all instead.

---

## What this fixes

### Caller-supplied values were not quoted for the generated script

Ids, names, paths and effect names were interpolated directly into double-quoted
ExtendScript string literals. A value containing a double quote ends the literal early,
so the generated script no longer means what it was written to mean.

The everyday effect needs no ill intent: **any name containing a double quote** — a bin
called `12"`, a LUT at `/Volumes/A"B/x.cube`, a clip whose filename carries one — produces
a script that does not parse, and the call fails with an opaque host error. Workflows that
take names from imported footage or a filesystem walk hit this without anyone doing
anything unusual.

The same defect has a security dimension, which is held back pending a private channel
rather than described here.

Every interpolated value now goes through `JSON.stringify`, including values embedded in
longer message strings. Booleans, numbers and already serialised values are left alone,
since quoting them would change the generated logic. `import_fcp_xml` is a special case:
it hand-escaped its path, and serialising on top of that double-escapes every backslash,
so the hand-escaping is removed rather than layered.

### Acting destructively on objects that were never confirmed

- **`add_to_timeline`** fell back to `track.clips[numItems - 1]` — whatever was already
  last on the track — when it could not find the clip it had just placed. It reported that
  clip's id and times as the placement, *and* used its start time to drive the
  `linkAudio: false` sweep. A placement that did nothing could delete an unrelated audio
  clip and return success.
- **`insertMode`** was accepted, echoed in every response, and never passed to the bridge,
  which always called `overwriteClip`. Asking to insert-and-shift destroyed the footage you
  were trying to move and told you the opposite.
- **`duplicate_sequence`** fell back to `app.project.activeSequence` when the clone could
  not be resolved, then renamed it and, with `clearContents`, removed every clip — emptying
  the user's open timeline and reporting the count it had just deleted.
- **`create_bin` / `import_folder`** resolved a named parent with `children[name]`, which
  never matches: `ProjectItemCollection` is index-only. Every bin and every import landed
  at the project root while the response echoed the requested name back.

### Acting on the wrong sequence or the wrong clip

- Six tools declared `sequenceId` and used the active sequence regardless.
- Twenty-nine sites resolved the id and silently fell back to the active sequence on a
  miss. `list_sequence_tracks` echoed the requested id beside another sequence's contents.
- Ten more never checked that the id resolved, answering a stale one with `success` and a
  null sequence — indistinguishable from a genuinely empty sequence.
- `__findClip` searches every sequence, then the change was applied through
  `qe.project.getActiveSequence()`. `color_correct` on a clip in a non-active sequence
  added Lumetri to the identically placed clip in the active one.
- QE track items include gaps, so `getItemAt(domClipIndex)` addressed the wrong item.

### Smaller, same shape

Marker colours were wrong for every supported value, with no colour returned to read back.
`export_frame` exported the active sequence and wrote to `<path>.<format>` while reporting
`<path>`. `set_sequence_settings` compared width and height, wrote nothing, and claimed a
match. `toggle_track_visibility` called `setTargeted()` — the patch button, not the eye.
`split_clip`, `add_transition` and `add_transition_to_clip` took their frame rate from the
active sequence while acting on a clip that may live elsewhere. `delete_track` refused
cross-sequence work QE can actually do. Validation was inert: `executeTool` discarded the
parse result.

---

## Reproducing against a real Premiere

Each of these takes a scratch project and a minute. They are written against the current
`main`; on this branch each fails truthfully or does the right thing instead.

**`duplicate_sequence` empties your open timeline.** Open a project with two sequences, A
and B. Make A the active sequence in the timeline panel. Call
`duplicate_sequence({sequenceId: <B>, newName: "copy", clearContents: true})`. On builds
where `clone()` does not return a resolvable `Sequence`, A is renamed to `copy` and every
clip is removed from it; the response is `success: true` with `clearedClips` set to the
count it just deleted.

**`create_bin` ignores the parent you name.** Create a bin `Footage`. Call
`create_bin({name: "B-Roll", parentBinName: "Footage"})`. `B-Roll` appears at the project
root, not inside `Footage`, and the response echoes `parentBinName: "Footage"` back.

**A quote in a name breaks the call.** `create_bin({name: '12" Cuts'})` fails with a host
scripting error rather than creating the bin.

**`color_correct` hits the wrong clip.** With sequences A and B holding clips at the same
positions, make A active, then call `color_correct` with a `clipId` taken from B. The
Lumetri effect lands on A's clip; B's clip is untouched; the response is `success: true`.

**`add_to_timeline` deletes unrelated audio.** Place a clip on V1 and a different audio
clip on A1 at 0s. Call `add_to_timeline` for a project item at a time where the placement
cannot be confirmed, with `linkAudio: false`. The response describes the pre-existing V1
clip as the one placed, and the A1 clip is removed.

---

## How to check it

```bash
npm ci && npm run build && npx jest      # 484 tests
```

Tests execute the generated ExtendScript against a mock host rather than matching source
text. That distinction matters here: a backslash escape written for the ExtendScript
string is consumed by the TypeScript template literal first, so what the source shows is
not what the host receives. Assertions are on the **emitted** script throughout — a
`not.toContain('${JSON.stringify(')` can never fail, because that text does not survive
emission.

Worth reviewing closely:

- **`src/__tests__/tools/injection-guard.test.ts`** drives every tool with a hostile value
  at every string position — 793 positions across 220 tools — parses each emitted script as
  ES3, and executes it against a sandbox with a canary. It reads no source, so it cannot be
  fooled by how a template literal is written. Revert any `JSON.stringify` in a generated
  script and it names the tool and the position.

  Arguments come from each tool's own schema, so array elements and nested object fields
  are fuzzed too, and the payloads cover single quotes, backslashes and line terminators as
  well as double quotes. **The 171 tools that declare a free-form `z.record` schema are
  driven from the arguments their own generated script reads**, since a schema with no
  declared fields yields nothing to fuzz — that alone was 60% of the catalogue sitting
  outside the sweep while every floor still passed.

  Each earlier version of this guard let a real breakout through with the suite green:
  selecting parameters by type name missed array parameters, a double-quote-only payload
  set could not see a raw interpolation into a single-quoted literal, and the free-form
  tools were never reached at all.

- **`src/__tests__/bridge/bridge-injection.test.ts`** does the same for the scripts the
  bridge builds itself. Tools are driven through a stub whose only member is
  `executeScript`, so the sixteen that delegate to a real bridge method — `importMedia`,
  `createSequence`, `renderSequence` — emit nothing through the tool sweep and were
  invisible to it. The real bridge is driven here with the filesystem stubbed, and its
  methods are enumerated from the prototype so a new one is covered without being listed.

- **`src/__tests__/helpers/schema-args.ts`** builds those arguments, and
  **`src/__tests__/tools/schema-args.test.ts`** asserts every tool's schema *accepts* what
  it builds. That check exists because the seeder is the single point of failure for three
  guards at once: when it produces a value a schema rejects, that tool emits nothing and
  drops out of all of them silently, with nothing going red. Reading zod internals caused
  exactly that three times — `_def.typeName`, `_def.values` and `_def.type` are each wrong
  in this build — so the seeder now uses public accessors and verifies its own output.
- **`src/__tests__/tools/undefined-identifiers.test.ts`** walks each emitted script's AST
  and reports any identifier read without being declared. A rename across two similar
  methods can leave one referring to a variable that exists only in its neighbour: the
  TypeScript compiles, the script parses, and the tool throws `ReferenceError` on every
  call. It tracks scopes, so a name that exists only as a nested function's parameter is
  not treated as declared at the top level.
- **`src/__tests__/bridge/prelude-helpers.test.ts`** executes the QE resolvers against a
  mock QE reproducing the host quirks listed below.

Every fix here was checked by restoring the defect and confirming its test fails.

---

## Host behaviour this depends on

Measured against Premiere Pro 26.0.2 through a live bridge, not taken from documentation.
Each is a single `evalScript` call to confirm.

- `qe.project.getSequenceAt(i)` reaches sequences other than the active one, and exposes a
  `guid` equal to the DOM's `sequenceID`.
- `qe.project.numSequences` over-reports: with two sequences open it counted 2 while only 1
  was reachable, the rest throwing or returning null. Each index needs its own guard.
- A sequence never opened in a timeline is invisible to `getSequenceAt()` even while it is
  active — `getActiveSequence()` still returns it, so that is used as a fallback once the
  guid matches. A freshly duplicated sequence is reachable by no other route.
- A QE track's items include gaps. A track holding three clips reported five items, typed
  `Clip, Clip, Empty, Clip, Empty`, so `getItemAt(domClipIndex)` addresses the wrong item.
- `ProjectItemCollection` is index-only. `rootItem.children["Name"]` returns `undefined`
  even when a child of that name exists.
- The marker palette is `0 green, 1 red, 2 purple, 3 orange, 4 yellow, 5 white, 6 blue,
  7 cyan`, read off the timeline. Indices round-trip through
  `setColorByIndex`/`getColorByIndex`; `8` and `9` are silent no-ops leaving the previous
  colour, `3.7` truncates to `3`, and `-1` is accepted and stored as `-1` — which is why a
  colour outside the palette is now refused rather than passed through.
- `videoFrameRate` must be assigned a string of ticks. Assigning the number `10160640000`
  raised no error and set the value to `9223372036854775807` ticks; the same value as a
  string set it exactly. `videoPixelAspectRatio` is an `"N:M"` string — `1.0` throws
  `Illegal Parameter type` on assignment, before `setSettings` is even reached, while
  `1:1`, `10:11`, `40:33` and `64:45` all round-trip.
- Sequence frame size can be changed after creation: 1920x1080 to 1280x720 through
  `getSettings()`/`setSettings()`, confirmed by read-back.
- On a video track `setMute()` is the eye, not `setTargeted()`. They are independent:
  toggling the target left `isMuted()` unchanged.
- `videoTracks.deleteTrack` is `undefined`, which is why track deletion falls through to
  QE. `insertClip` exists on both video and audio tracks.
- The QE frame export appends the format extension: exporting to a path ending `probe`
  wrote `probe.png`.

---

## Notes for the reviewer

`src/utils/security.ts` loses ~190 lines of exports that nothing imported and no test
covered, including a `sanitizeInput` that backslash-escaped quotes into stored values.
Escaping at the point of interpolation is correct for arbitrary input and is now in place
everywhere; a dead sanitizer sitting beside a live injection hole invites the assumption
that input is being sanitized somewhere.

A separate change covers the bridge's serialization and its file-handoff protocol. The two
are independent and merge in either order — verified in both directions.
