### PR TITLE
feat: point the bridge at a chosen project so the editor can keep working

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -6,7 +6,7 @@ This file tracks current, confirmed limits. It is no longer a backlog of already
 
 The current built tool catalog exposes:
 
-- `283` tools (`112` declared in `src/tools/index.ts`, `171` in `src/tools/expanded.ts`)
+- `286` tools (`115` declared in `src/tools/index.ts`, `171` in `src/tools/expanded.ts`)
 
 Counted from the built catalog with `getAvailableTools().length`, not from this file.
 The previous figure of `104` was stale by a wide margin; check it against the build
@@ -39,6 +39,24 @@ Reason:
 - This is a detection-only tool -- it never cuts anything itself. Use the returned
   intervals with `split_clip`/`ripple_delete`/`razor_timeline_at_time` to actually remove
   silence from a sequence.
+
+### `activeSequence` is global, not a property of the project you ask
+
+Status: confirmed, and the reason `set_target_project` guards rather than retargets
+
+`app.project` is always the frontmost project, so `set_target_project` rewrites generated
+scripts to resolve the pinned project out of `app.projects` instead. Project-scoped work
+retargets cleanly that way. Two things do not:
+
+- `activeSequence` is reported globally. Verified live against 26.3.2 with two projects
+  open: resolving the non-frontmost project returned its own `name`, `path`, `rootItem`, and
+  `sequences.numSequences` of `0`, yet its `activeSequence` was the *other* project's open
+  sequence. A tool that trusted it would read the wrong timeline and report success.
+- The QE DOM is bound to the frontmost project with no documented way to redirect it.
+
+Scripts touching either are therefore checked in the host: if the target is not frontmost,
+they throw with the reason rather than acting on the wrong project. Pass an explicit
+`sequenceId` where a tool accepts one and it retargets normally.
 
 ### QE reaches sequences Premiere has open, not only the active one
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Operate local Adobe Premiere Pro projects through MCP.**
 
-283 tools, 13 context resources, and 10 guided prompts for Codex, Claude Code, Claude Desktop, and other MCP clients. CEP is the supported production bridge; UXP remains experimental.
+286 tools, 13 context resources, and 10 guided prompts for Codex, Claude Code, Claude Desktop, and other MCP clients. CEP is the supported production bridge; UXP remains experimental.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-5fd3c6.svg)](LICENSE.md)
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-339933.svg)](https://nodejs.org/)
@@ -124,13 +124,13 @@ This repository is currently validated for:
 
 Current catalog status as of August 5, 2026:
 
-- `283` MCP tools are exposed for AI-driven video editing
+- `286` MCP tools are exposed for AI-driven video editing
 - coverage spans project setup, media ingest, bins, sequences, timeline editing, transitions, effects, keyframes, captions, markers, metadata, proxies, multicam, color, audio, exports, and higher-level assembly workflows
 - the catalog includes practical agent workflows such as product-spot assembly, motion-graphics demos, timeline razoring, caption reads, audio ducking, scene edit detection, EDL import, export readiness validation, and linked audio/video operations
 
 Most recent completed local live validation:
 
-- `283` active tools are exposed; `get_capabilities` reports local installation and optional live connection state, while `verify_premiere_connection` is the canonical read-only bridge and host readiness check
+- `286` active tools are exposed; `get_capabilities` reports local installation and optional live connection state, while `verify_premiere_connection` is the canonical read-only bridge and host readiness check
 - `0` known parked or placeholder tools are advertised
 - `import_ae_comps` is intentionally not advertised because Premiere returned `false` for real `.aep` fixtures in this environment and a generic `.aep` import can wedge the CEP bridge
 
@@ -230,7 +230,7 @@ For a real-host sweep, use a disposable Premiere project and run `node scripts/l
 
 ## Tools
 
-All `283` advertised tools have an implementation. Tool schemas are available through MCP discovery; this catalog explains the editing surface in human terms. Start with `verify_premiere_connection`, then inspect the project before asking an agent to mutate it.
+All `286` advertised tools have an implementation. Tool schemas are available through MCP discovery; this catalog explains the editing surface in human terms. Start with `verify_premiere_connection`, then inspect the project before asking an agent to mutate it.
 
 ### Discovery and project inspection
 
@@ -251,6 +251,7 @@ All `283` advertised tools have an implementation. Tool schemas are available th
 | Tools | What they do |
 | :--- | :--- |
 | `create_project` / `open_project` / `save_project` / `save_project_as` / `close_project` | Project lifecycle and file operations. |
+| `list_open_projects` / `set_target_project` / `clear_target_project` | Point the bridge at one open project so it keeps working there while you use Premiere in another. Operations that depend on the QE DOM or on `activeSequence` report an error instead, because Premiere resolves both against the frontmost project. |
 | `import_media` / `import_folder` / `import_image_sequence` | Bring video, audio, stills, or image sequences into the project. |
 | `import_fcp_xml` / `import_sequences_from_project` / `import_sequences` | Import supported timeline interchange or sequences from another project. |
 | `create_bin` / `rename_bin` / `delete_bin` / `create_smart_bin` | Create and organize project-panel bins. |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adobe-premiere-pro-mcp",
   "version": "1.2.0",
-  "description": "MCP Bridge for Adobe Premiere Pro with 283 tools for AI-driven video editing.",
+  "description": "MCP Bridge for Adobe Premiere Pro with 286 tools for AI-driven video editing.",
   "main": "dist/index.js",
   "bin": {
     "premiere-pro-mcp": "dist/cli.js"

--- a/src/__tests__/bridge/project-targeting.test.ts
+++ b/src/__tests__/bridge/project-targeting.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Pointing the bridge at a project other than the frontmost one.
+ *
+ * Premiere's `app.project` is always whichever project is in front, so every
+ * generated script used to follow the operator's focus. Switching projects
+ * mid-session silently moved the target: ID-scoped calls failed with "not found",
+ * but ID-less ones — create_bin, create_sequence, import_media — would have
+ * succeeded inside the wrong project.
+ *
+ * The fix rewrites `app.project` to a resolver that looks the target up in
+ * `app.projects`. These tests hold the three properties that make that safe:
+ * unpinned behaviour is byte-identical to before, the collection lookup inside
+ * the resolver survives its own rewrite, and the two APIs that cannot be
+ * retargeted are guarded rather than silently pointed at the wrong project.
+ */
+
+import { PremiereProBridge } from '../../bridge/index.js';
+
+const TARGET = 'J:\\Bear\\Projects\\Bear_Cannabiz.prproj';
+
+/** Everything after the injected preamble, i.e. the caller's own script. */
+function scriptBody(built: string): string {
+  const marker = 'function __mcpRequireFrontmostTarget(feature) {';
+  const at = built.indexOf(marker);
+  if (at === -1) return built;
+  const after = built.slice(at + marker.length);
+  return after.slice(after.indexOf('\n}') + 2);
+}
+
+/** A guard *call*, as opposed to the guard definition that is always present. */
+const GUARD_CALL = /\n__mcpRequireFrontmostTarget\("/;
+
+describe('bridge project targeting', () => {
+  let bridge: PremiereProBridge;
+  const build = (script: string, callerAuthored = false): string =>
+    (bridge as unknown as {
+      buildExecutableScript(s: string, c: boolean): string;
+    }).buildExecutableScript(script, callerAuthored);
+
+  beforeEach(() => {
+    bridge = new PremiereProBridge();
+  });
+
+  describe('when no target is set', () => {
+    it('leaves app.project alone and injects nothing', () => {
+      const built = build('var n = app.project.name; return n;');
+      expect(built).toContain('app.project.name');
+      expect(built).not.toContain('__mcpProject');
+    });
+
+    it('reports no target', () => {
+      expect(bridge.getTargetProject()).toBeNull();
+    });
+  });
+
+  describe('when a target is set', () => {
+    beforeEach(() => {
+      bridge.setTargetProject(TARGET, 'Bear_Cannabiz.prproj');
+    });
+
+    it('reports the target back', () => {
+      expect(bridge.getTargetProject()).toEqual({
+        path: TARGET,
+        name: 'Bear_Cannabiz.prproj',
+      });
+    });
+
+    it('rewrites every app.project in the generated script', () => {
+      const built = build(
+        'var n = app.project.name; var s = app.project.sequences.numSequences; return n + s;'
+      );
+      expect(built).toContain('__mcpProject().name');
+      expect(built).toContain('__mcpProject().sequences.numSequences');
+      expect(scriptBody(built)).not.toMatch(/\bapp\.project\b/);
+    });
+
+    it('embeds the target and defines the resolver', () => {
+      const built = build('return app.project.name;');
+      expect(built).toContain('function __mcpProject()');
+      expect(built).toContain('Bear_Cannabiz.prproj');
+    });
+
+    // The rewrite is anchored on a word boundary, so `app.projects` cannot match.
+    // If it ever did, the resolver would recurse into itself and every call would
+    // fail with a stack overflow rather than a clear error.
+    it('does not rewrite the app.projects collection inside the resolver', () => {
+      const built = build('return app.project.name;');
+      expect(built).toContain('app.projects.numProjects');
+      expect(built).toContain('app.projects[i]');
+      expect(built).toContain('return app.project;');
+    });
+
+    it('guards the QE DOM, which always follows the frontmost project', () => {
+      const built = build('var s = qe.project.getActiveSequence(); return s.name;');
+      expect(built).toMatch(GUARD_CALL);
+      expect(built).toContain('QE DOM');
+    });
+
+    // activeSequence is global, not per-project: a project holding no sequences at
+    // all still reports the frontmost project's active sequence, so a tool trusting
+    // it would read from the wrong project without erroring.
+    it('guards activeSequence', () => {
+      const built = build('var s = app.project.activeSequence; return s.name;');
+      expect(built).toMatch(GUARD_CALL);
+      expect(built).toContain('global rather than per project');
+    });
+
+    it('does not guard scripts that touch neither', () => {
+      const built = build('var n = app.project.name; return n;');
+      expect(built).not.toMatch(GUARD_CALL);
+    });
+
+    // execute_extendscript is a passthrough. Rewriting it would edit code the
+    // caller wrote by hand, so it keeps its own app.project and can opt in by
+    // calling the resolver directly.
+    it('never rewrites caller-authored scripts', () => {
+      const built = build('var n = app.project.name; return n;', true);
+      expect(built).toContain('app.project.name');
+      expect(built).toContain('function __mcpProject()');
+    });
+  });
+
+  describe('clearing the target', () => {
+    it('restores the original behaviour exactly', () => {
+      bridge.setTargetProject(TARGET, 'Bear_Cannabiz.prproj');
+      bridge.setTargetProject(null, null);
+
+      expect(bridge.getTargetProject()).toBeNull();
+      const built = build('var n = app.project.name; return n;');
+      expect(built).toContain('app.project.name');
+      expect(built).not.toContain('__mcpProject');
+    });
+  });
+});

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -82,7 +82,7 @@ describe('PremiereProTools', () => {
       expect(toolNames).toContain('add_tracks');
       expect(toolNames).toContain('get_encoder_presets');
       expect(toolNames).not.toContain('import_ae_comps');
-      expect(availableTools).toHaveLength(283);
+      expect(availableTools).toHaveLength(286);
       expect(unimplementedExpandedToolNames).toEqual([]);
       for (const name of expandedToolNames) {
         expect(toolNames).toContain(name);
@@ -557,7 +557,7 @@ describe('PremiereProTools', () => {
       const result = await tools.executeTool('get_capabilities', {});
 
       expect(result.success).toBe(true);
-      expect(result.catalog).toEqual({ tools: 283, resources: 13, prompts: 10 });
+      expect(result.catalog).toEqual({ tools: 286, resources: 13, prompts: 10 });
       expect(result.liveConnection.checked).toBe(false);
       expect(mockBridge.executeScript).not.toHaveBeenCalled();
     });

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -465,6 +465,18 @@ export interface PremiereProEffect {
 }
 
 export class PremiereProBridge implements PremiereProTransport {
+  /**
+   * Which open project the generated scripts should act on.
+   *
+   * Premiere's `app.project` is always the frontmost project, so every tool used to
+   * follow whatever the user had in focus. Pinning a target here lets the operator
+   * keep working in another project while the bridge stays on the one it was pointed
+   * at. Null means "whatever is frontmost", which is the original behaviour.
+   *
+   * Stored as the project's path because two open projects can share a name.
+   */
+  private targetProjectPath: string | null = null;
+  private targetProjectName: string | null = null;
   private logger: Logger;
   private communicationMethod: 'uxp' | 'extendscript' | 'file';
   private tempDir: string;
@@ -591,6 +603,96 @@ export class PremiereProBridge implements PremiereProTransport {
     );
   }
 
+  /**
+   * Pin the bridge to one open project. Pass null to go back to following the
+   * frontmost project. The caller is responsible for having checked that the
+   * project is actually open; set_target_project does that before calling here.
+   */
+  setTargetProject(projectPath: string | null, projectName: string | null = null): void {
+    this.targetProjectPath = projectPath;
+    this.targetProjectName = projectName;
+  }
+
+  getTargetProject(): { path: string; name: string | null } | null {
+    if (!this.targetProjectPath) return null;
+    return { path: this.targetProjectPath, name: this.targetProjectName };
+  }
+
+  /**
+   * ExtendScript preamble that resolves the pinned project and guards the two
+   * APIs that cannot be retargeted.
+   *
+   * `app.projects` is a real collection of every open project, so project-scoped
+   * work (sequences, root item, project items) retargets cleanly. Two things do not:
+   *
+   *   - the QE DOM, which is bound to the frontmost project with no way to redirect it
+   *   - `activeSequence`, which is global rather than per-project. A project that holds
+   *     no sequences at all still reports the frontmost project's active sequence, so a
+   *     tool that trusted it would silently read from the wrong project.
+   *
+   * Both are checked in the host rather than in the server, because only the host
+   * knows which project is frontmost at the moment the script runs.
+   */
+  private buildTargetPreamble(script: string): string {
+    const target = this.targetProjectPath;
+    if (!target) return '';
+
+    const literal = JSON.stringify(target);
+    const lines: string[] = [
+      'var __mcpTargetPath = ' + literal + ';',
+      'function __mcpProject() {',
+      '  if (!__mcpTargetPath) { return app.project; }',
+      '  if (typeof app.projects === "undefined") { return app.project; }',
+      '  var i, candidate, candidatePath, candidateName;',
+      '  for (i = 0; i < app.projects.numProjects; i++) {',
+      '    candidate = app.projects[i];',
+      '    candidatePath = "";',
+      '    try { candidatePath = String(candidate.path); } catch (pathError) { candidatePath = ""; }',
+      '    if (candidatePath && candidatePath === __mcpTargetPath) { return candidate; }',
+      '  }',
+      '  for (i = 0; i < app.projects.numProjects; i++) {',
+      '    candidate = app.projects[i];',
+      '    candidateName = "";',
+      '    try { candidateName = String(candidate.name); } catch (nameError) { candidateName = ""; }',
+      '    if (candidateName && candidateName === __mcpTargetPath) { return candidate; }',
+      '  }',
+      '  throw new Error("The bridge is pointed at a project that is not open: " + __mcpTargetPath + ". Reopen it, or call clear_target_project.");',
+      '}',
+      'function __mcpRequireFrontmostTarget(feature) {',
+      '  if (!__mcpTargetPath) { return; }',
+      '  var frontmost = "";',
+      '  try { frontmost = String(app.project.path); } catch (frontError) { frontmost = ""; }',
+      '  if (frontmost !== __mcpTargetPath) {',
+      '    throw new Error("This operation uses " + feature + ", which always follows the frontmost project and cannot be pointed elsewhere. The bridge is targeting " + __mcpTargetPath + " but " + frontmost + " is frontmost. Bring the target forward in Premiere, or call clear_target_project.");',
+      '  }',
+      '}'
+    ];
+
+    // Only assert when the script actually touches an untargetable API, so that
+    // everything else keeps working while the operator is in another project.
+    if (/\bqe\b/.test(script)) {
+      lines.push('__mcpRequireFrontmostTarget("Premiere\'s QE DOM");');
+    }
+    if (/\bactiveSequence\b/.test(script)) {
+      lines.push('__mcpRequireFrontmostTarget("activeSequence, which is global rather than per project");');
+    }
+
+    return lines.join('\n') + '\n';
+  }
+
+  /**
+   * Point every `app.project` in a generated script at the pinned project.
+   *
+   * `\bapp\.project\b` cannot match `app.projects`, because the word boundary fails
+   * against the following "s" — so the collection lookup inside the preamble survives
+   * the rewrite. Caller-authored scripts are never rewritten: execute_extendscript is
+   * a passthrough and rewriting it would change code the caller wrote by hand.
+   */
+  private retargetGeneratedScript(script: string): string {
+    if (!this.targetProjectPath) return script;
+    return script.replace(/\bapp\.project\b/g, '__mcpProject()');
+  }
+
   private buildExecutableScript(script: string, callerAuthored = false): string {
     PremiereProBridge.assertNoNulByte(script);
 
@@ -604,12 +706,18 @@ export class PremiereProBridge implements PremiereProTransport {
       ? script
       : PremiereProBridge.repairScriptLineTerminators(script);
 
-    if (this.isSelfInvokingScript(safeScript)) {
-      return EXTENDSCRIPT_HELPERS + safeScript.trim();
+    // Retargeting runs on generated scripts only. A caller-authored script still gets
+    // the preamble, so it can call __mcpProject() deliberately, but its own app.project
+    // references are left exactly as written.
+    const targetedScript = callerAuthored ? safeScript : this.retargetGeneratedScript(safeScript);
+    const preamble = this.buildTargetPreamble(safeScript);
+
+    if (this.isSelfInvokingScript(targetedScript)) {
+      return EXTENDSCRIPT_HELPERS + preamble + targetedScript.trim();
     }
 
     // Wrap script bodies so top-level "return ..." remains valid in ExtendScript.
-    return EXTENDSCRIPT_HELPERS + '(function(){\n' + safeScript + '\n})();';
+    return EXTENDSCRIPT_HELPERS + preamble + '(function(){\n' + targetedScript + '\n})();';
   }
 
   async executeScript(script: string, timeoutMs?: number, callerAuthored = false): Promise<any> {

--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -7,6 +7,13 @@ import type {
 
 export interface PremiereProTransport {
   executeScript(script: string, timeoutMs?: number, callerAuthored?: boolean): Promise<any>;
+  /**
+   * Point the transport at one open project, or pass null to follow whichever project
+   * is frontmost in Premiere. Lets the operator work in a different project without
+   * the bridge following their focus.
+   */
+  setTargetProject(projectPath: string | null, projectName?: string | null): void;
+  getTargetProject(): { path: string; name: string | null } | null;
   createProject(name: string, location: string): Promise<PremiereProProject>;
   openProject(path: string): Promise<PremiereProProject>;
   saveProject(): Promise<void>;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -331,6 +331,23 @@ export class PremiereProTools {
         inputSchema: z.object({})
       },
       {
+        name: 'list_open_projects',
+        description: 'Lists every project currently open in Premiere Pro, with the path, sequence count, and which one is frontmost. Also reports which project the bridge is currently pointed at. Use this to find the path to pass to set_target_project.',
+        inputSchema: z.object({})
+      },
+      {
+        name: 'set_target_project',
+        description: 'Points the bridge at one open project so every later tool call acts on it, regardless of which project you have in focus in Premiere. This lets you keep working in another project while the bridge works on this one. Pass the full path (preferred, since two open projects can share a name) or the project name. Two operations cannot be retargeted and will report a clear error if the target is not frontmost: anything using the QE DOM, and anything relying on activeSequence, which Premiere reports globally rather than per project. Call clear_target_project to go back to following whatever is frontmost.',
+        inputSchema: z.object({
+          project: z.string().min(1).describe('Full path to the .prproj, or its name as shown by list_open_projects. Path is preferred and is matched first.')
+        })
+      },
+      {
+        name: 'clear_target_project',
+        description: 'Stops targeting a specific project. The bridge goes back to acting on whichever project is frontmost in Premiere, which is the default behaviour.',
+        inputSchema: z.object({})
+      },
+      {
         name: 'verify_premiere_connection',
         description: 'Read-only readiness check for the live CEP bridge and Premiere Pro host. Run this before an editing workflow to confirm the bridge responds and report the Premiere version, project, and active sequence without changing the project.',
         inputSchema: z.object({})
@@ -1482,6 +1499,12 @@ export class PremiereProTools {
           return await this.listSequenceTracks(args.sequenceId);
         case 'get_project_info':
           return await this.getProjectInfo();
+        case 'list_open_projects':
+          return await this.listOpenProjects();
+        case 'set_target_project':
+          return await this.setTargetProject(args.project);
+        case 'clear_target_project':
+          return await this.clearTargetProject();
         case 'verify_premiere_connection':
           return await this.verifyPremiereConnection();
         case 'get_capabilities':
@@ -1967,6 +1990,122 @@ ${this.buildSequenceResolver(sequenceId)}
     `;
 
     return await this.bridge.executeScript(script);
+  }
+
+  /**
+   * Enumerate every open project.
+   *
+   * Deliberately reads app.projects rather than app.project: the whole point is to see
+   * past the frontmost one. Written so it still answers on a host too old to expose the
+   * collection, where it degrades to reporting just the frontmost project.
+   */
+  private async listOpenProjects(): Promise<any> {
+    const script = `
+      var result = { projects: [], frontmost: null };
+      try { result.frontmost = String(app.project.path); } catch (frontError) { result.frontmost = null; }
+      if (typeof app.projects === 'undefined') {
+        result.collectionAvailable = false;
+        result.projects.push({
+          name: app.project.name,
+          path: result.frontmost,
+          isFrontmost: true
+        });
+      } else {
+        result.collectionAvailable = true;
+        for (var i = 0; i < app.projects.numProjects; i++) {
+          var proj = app.projects[i];
+          var entry = { index: i, name: null, path: null, sequenceCount: null, isFrontmost: false };
+          try { entry.name = String(proj.name); } catch (nameError) {}
+          try { entry.path = String(proj.path); } catch (pathError) {}
+          try { entry.sequenceCount = proj.sequences.numSequences; } catch (seqError) {}
+          entry.isFrontmost = (entry.path !== null && entry.path === result.frontmost);
+          result.projects.push(entry);
+        }
+      }
+      return JSON.stringify(result);
+    `;
+    const result = await this.bridge.executeScript(script);
+    const target = this.bridge.getTargetProject();
+    return {
+      success: true,
+      ...result,
+      targetProject: target ? target.path : null,
+      targeting: target
+        ? 'Bridge is pointed at ' + (target.name || target.path) + '. Calls act on it wherever your focus is.'
+        : 'Bridge is following whichever project is frontmost.'
+    };
+  }
+
+  /**
+   * Pin the bridge to a project, refusing anything that is not actually open — a typo'd
+   * path would otherwise fail later, once per call, from inside unrelated tools.
+   */
+  private async setTargetProject(project: string): Promise<any> {
+    const wanted = String(project);
+    const script = `
+      var wanted = ${JSON.stringify(wanted)};
+      var out = { matched: null, open: [] };
+      if (typeof app.projects === 'undefined') {
+        out.collectionAvailable = false;
+        return JSON.stringify(out);
+      }
+      out.collectionAvailable = true;
+      var i, proj, entry;
+      for (i = 0; i < app.projects.numProjects; i++) {
+        proj = app.projects[i];
+        entry = { name: null, path: null };
+        try { entry.name = String(proj.name); } catch (nameError) {}
+        try { entry.path = String(proj.path); } catch (pathError) {}
+        out.open.push(entry);
+        if (out.matched === null && entry.path === wanted) { out.matched = entry; }
+      }
+      if (out.matched === null) {
+        for (i = 0; i < out.open.length; i++) {
+          if (out.open[i].name === wanted) { out.matched = out.open[i]; break; }
+        }
+      }
+      return JSON.stringify(out);
+    `;
+    const probe = await this.bridge.executeScript(script);
+
+    if (probe && probe.collectionAvailable === false) {
+      throw new Error(
+        'This Premiere build does not expose app.projects, so the bridge cannot target a project other than the frontmost one.'
+      );
+    }
+    if (!probe || !probe.matched) {
+      const open = (probe && probe.open ? probe.open : [])
+        .map((entry: any) => entry.path || entry.name)
+        .filter(Boolean);
+      throw new Error(
+        'No open project matches "' + wanted + '". Open projects: ' +
+        (open.length ? open.join(', ') : 'none') +
+        '. Pass a full path from list_open_projects.'
+      );
+    }
+
+    this.bridge.setTargetProject(probe.matched.path || wanted, probe.matched.name || null);
+    return {
+      success: true,
+      targetProject: probe.matched,
+      message:
+        'Bridge is now pointed at ' + (probe.matched.name || probe.matched.path) +
+        '. Every tool call acts on it until you call clear_target_project, so you can work in another project meanwhile.',
+      limitations: [
+        'Tools that use the QE DOM still follow the frontmost project and will report an error rather than act on the wrong one.',
+        'Tools that rely on activeSequence do the same, because Premiere reports the active sequence globally rather than per project. Pass an explicit sequenceId where a tool accepts one.'
+      ]
+    };
+  }
+
+  private async clearTargetProject(): Promise<any> {
+    const previous = this.bridge.getTargetProject();
+    this.bridge.setTargetProject(null, null);
+    return {
+      success: true,
+      cleared: previous ? previous.path : null,
+      message: 'Bridge is following whichever project is frontmost again.'
+    };
   }
 
   private async getProjectInfo(): Promise<any> {


### PR DESCRIPTION
## What changed

Three tools that make the bridge's target project explicit instead of implicit:

| Tool | What it does |
| :--- | :--- |
| `list_open_projects` | Enumerates `app.projects` — path, sequence count, which one is frontmost — and reports what the bridge is currently pointed at. |
| `set_target_project` | Pins the bridge to one open project. Matches on path first, since two open projects can share a name. Refuses a project that is not open. |
| `clear_target_project` | Restores the default of following whichever project is frontmost. |

While a target is set, generated scripts have their `app.project` references rewritten to a resolver that finds the project in `app.projects`. `execute_extendscript` is deliberately exempt — it is a passthrough, and rewriting hand-written code would be a surprise. It still receives the preamble, so a caller can invoke the resolver on purpose.

## Why

Every generated script referenced `app.project`, which Premiere always resolves to the frontmost project. The bridge therefore followed the operator's focus: opening a second project to check something sent the next tool call into it. On a long conform that is a real hazard, and there was no way to work in Premiere while the bridge worked elsewhere.

## The part worth reviewing

Two APIs cannot be retargeted, and are checked in the host rather than in the server, because only the host knows what is frontmost at the moment the script runs:

- the QE DOM, bound to the frontmost project
- `activeSequence`, which Premiere reports globally rather than per project

The second one is the dangerous one, and it is why this guards rather than silently retargets. Verified live against **26.3.2** with two projects open: resolving the non-frontmost project returned its own `name`, `path`, `rootItem`, and a `sequences.numSequences` of `0` — yet its `activeSequence` was the *other* project's open sequence. A tool trusting that would read the wrong project's timeline and report success.

A script is guarded only if it actually mentions `qe` or `activeSequence`, so everything else keeps working while the operator is in another project. Tools that accept an explicit `sequenceId` retarget normally.

One implementation note: the rewrite pattern is `\bapp\.project\b`, whose word boundary cannot match `app.projects` — so the resolver's own collection lookup survives its own rewrite. There is a test pinning that, because it is the kind of thing a later regex tidy-up would break silently.

## How it was tested

- `npm run build`
- `npm test` — 556 pass, including 11 new cases: unpinned identity, the rewrite, the collection lookup surviving the rewrite, both guards firing, ordinary scripts *not* being guarded, caller-authored passthrough, and clearing
- Live against a Premiere Pro 26.3.2 session with two projects open on different volumes: the `list_open_projects` host script returned both with correct paths and sequence counts, and the resolver reached the non-frontmost project's `rootItem`

Not yet exercised: `scripts/live-tool-sweep.mjs`, which runs against a single scratch project.

## Tool surface

`283` → `286`. README catalog row, `KNOWN_ISSUES.md` (new confirmed-limitation entry for the global `activeSequence`), and the `package.json` description are updated to match.
