### PR TITLE
Keep the trim and spare the destination in move_clip_to_track

### DIFF
--- a/src/__tests__/tools/clip-lifecycle.test.ts
+++ b/src/__tests__/tools/clip-lifecycle.test.ts
@@ -50,7 +50,7 @@ describe('clip replace, move, and sequence-from-clips scripts', () => {
     const script = mockBridge.executeScript.mock.calls[0][0] as string;
     expect(script).toContain('if (__idsMatch(other.nodeId, moveTrackClip.clip.nodeId)) continue');
     expect(script).toContain('Pass overwrite:true');
-    expect(script).toContain('destTrack.overwriteClip(moveItem, moveStart)');
+    expect(script).toContain('destTrack.overwriteClip(moveItem, moveParkTime)');
     expect(script).toContain('placed.inPoint = secondsToTime(moveIn)');
     expect(script).not.toContain('moveTrackClip.sequence.overwriteClip');
     expect(script).not.toContain('beforeTargetCount');

--- a/src/__tests__/tools/move-clip-to-track.test.ts
+++ b/src/__tests__/tools/move-clip-to-track.test.ts
@@ -80,6 +80,32 @@ describe('move_clip_to_track fallback safety', () => {
     expect(block).not.toContain('overwriteClip(moveItem, moveStart)');
   });
 
+  it('writes the timeline duration (end) while parked, before the slide', async () => {
+    const block = await caseBlock();
+
+    // Premiere does not shrink a timeline clip when only inPoint/outPoint are
+    // written -- trim_clip and replace_clip both set `end` for that reason.
+    // Without it, the slide carries the item's FULL length into a hole the
+    // occupancy guard only measured as [start, end): the neighbour overwrite
+    // this PR exists to stop. The write has to be relative to the parked
+    // start (moveEnd is an absolute time on the original timeline).
+    expect(block).toContain('var moveDur = moveEnd - moveStart;');
+    const endWrite = 'placed.end = secondsToTime(valueOfTime(placed.start) + moveDur);';
+    expect(block).toContain(endWrite);
+    const trim = block.indexOf('placed.inPoint = secondsToTime(moveIn);');
+    const end = block.indexOf(endWrite);
+    const slide = block.indexOf('placed.move(');
+    expect(end).toBeGreaterThan(trim);
+    expect(slide).toBeGreaterThan(end);
+
+    // And the restore check refuses to slide unless the duration took.
+    const check = block.indexOf('var trimRestored =');
+    const checkLine = block.slice(check, block.indexOf('\n', check));
+    expect(checkLine).toContain('valueOfTime(placed.end) - valueOfTime(placed.start) - moveDur');
+    expect(check).toBeGreaterThan(end);
+    expect(slide).toBeGreaterThan(check);
+  });
+
   it('identifies the parked clip by projectItem identity, not nearest start', async () => {
     const block = await caseBlock();
 

--- a/src/__tests__/tools/move-clip-to-track.test.ts
+++ b/src/__tests__/tools/move-clip-to-track.test.ts
@@ -1,0 +1,125 @@
+/**
+ * move_clip_to_track: the fallback must not be able to destroy anything the
+ * caller did not ask it to touch.
+ *
+ * The current fallback removes the source clip first and then calls
+ * track.overwriteClip(item, moveStart). Both halves of that are destructive:
+ *
+ * - overwriteClip lays the projectItem down at its OWN duration, not the
+ *   trimmed length of the timeline clip. The occupancy guard only checks the
+ *   trimmed span [start, end), so a trimmed still with a long item default
+ *   still reaches past the span and takes out a neighbour -- trimming the
+ *   placed clip afterwards cannot bring that neighbour back.
+ * - the source is already gone when later steps run, so every failure path
+ *   after the removal reports the error having destroyed the clip it failed
+ *   to move.
+ *
+ * The safe shape is park -> trim -> slide -> lift-last: write the item past
+ * the last clip on the target track (guaranteed empty), trim it back to the
+ * source in/out there, slide it into the span the guard verified, and only
+ * then lift the original. Every failure after the park removes the parked
+ * copy and leaves the source untouched.
+ *
+ * Each test below fails against the previous implementation.
+ */
+
+import { executeExpandedTool } from '../../tools/expanded.js';
+
+describe('move_clip_to_track fallback safety', () => {
+  /**
+   * All expanded tools emit the same shared body, so asserting against the
+   * whole script says nothing about the tool under test. Cut out this one
+   * case block first -- same reasoning as qe-targeting.test.ts.
+   */
+  const caseBlock = async (): Promise<string> => {
+    let script = '';
+    const bridge = { executeScript: async (s: string) => { script = s; return { success: true }; } };
+    await executeExpandedTool(bridge as any, 'move_clip_to_track', { clipId: 'clip-1', trackIndex: 1 });
+
+    const start = script.indexOf('case "move_clip_to_track":');
+    expect(start).toBeGreaterThan(-1);
+    const lines = script.slice(start).split('\n');
+    const isLabel = (line: string): boolean => /^\s*case "/.test(line);
+    const body: string[] = [];
+    let seenStatement = false;
+    for (const line of lines) {
+      if (isLabel(line) && seenStatement) break;
+      if (!isLabel(line) && line.trim()) seenStatement = true;
+      body.push(line);
+    }
+    return body.join('\n');
+  };
+
+  it('lifts the source clip only after the copy is verified in the destination span', async () => {
+    const block = await caseBlock();
+
+    // The source removal must be the LAST mutation. If it runs before the
+    // copy exists at the destination, every later failure has already
+    // destroyed the clip it is reporting on.
+    const slide = block.indexOf('placed.move(');
+    const sourceRemoval = block.indexOf('moveTrackClip.clip.remove(');
+    expect(slide).toBeGreaterThan(-1);
+    expect(sourceRemoval).toBeGreaterThan(-1);
+    expect(sourceRemoval).toBeGreaterThan(slide);
+  });
+
+  it('parks past the last clip and trims before sliding into the span', async () => {
+    const block = await caseBlock();
+
+    // Parked on guaranteed-empty space first: overwriteClip writes the item
+    // at its own full duration, which can reach past [start, end) and take
+    // out a neighbour the occupancy guard never looked at.
+    expect(block).toContain('var moveParkTime = moveLastEnd + 1.0;');
+    const park = block.indexOf('var moveParkTime = moveLastEnd + 1.0;');
+    const trim = block.indexOf('placed.inPoint = secondsToTime(moveIn);');
+    const slide = block.indexOf('placed.move(');
+    expect(trim).toBeGreaterThan(park);
+    expect(slide).toBeGreaterThan(trim);
+
+    // And the destination is never written at its own coordinates.
+    expect(block).not.toContain('overwriteClip(moveItem, moveStart)');
+  });
+
+  it('identifies the parked clip by projectItem identity, not nearest start', async () => {
+    const block = await caseBlock();
+
+    // A nearest-start pick silently trims a bystander when overwriteClip
+    // no-ops. The parked clip is the one holding our projectItem at the
+    // park position.
+    expect(block).toContain('__idsMatch(candidate.projectItem.nodeId, moveItem.nodeId)');
+  });
+
+  it('removes the parked copy on every failure path after parking', async () => {
+    const block = await caseBlock();
+
+    // A call on each post-park failure path: lookup miss, trim not
+    // restored, slide landed wrong. (The definition's `= function(` shape
+    // keeps it out of this count.)
+    const calls = block.split('moveCleanupParked(').length - 1;
+    expect(calls).toBeGreaterThanOrEqual(3);
+
+    // Cleanup precedes each post-park fail, so no failure strands a
+    // full-length parked clip on the target track.
+    const parkIdx = block.indexOf('var moveParkTime');
+    let cursor = parkIdx;
+    let checkedFails = 0;
+    for (;;) {
+      const failIdx = block.indexOf('return fail(', cursor + 1);
+      if (failIdx === -1) break;
+      const cleanupIdx = block.lastIndexOf('moveCleanupParked(', failIdx);
+      expect(cleanupIdx).toBeGreaterThan(cursor);
+      cursor = failIdx;
+      checkedFails++;
+    }
+    expect(checkedFails).toBeGreaterThanOrEqual(3);
+  });
+
+  it('clears occupants explicitly under overwrite:true, since the slide will not overwrite', async () => {
+    const block = await caseBlock();
+
+    // All overlapping occupants, not just the first -- and lifted, so the
+    // destination track keeps its timing.
+    expect(block).toContain('occupants.push(other)');
+    expect(block).toContain('occupants[ori].remove(false, true)');
+  });
+});

--- a/src/tools/expanded.ts
+++ b/src/tools/expanded.ts
@@ -1726,43 +1726,98 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
             return ok({ moved: true, changed: false, trackIndex: moveTargetIndex, method: "already on requested track", clipId: moveTrackClip.clip.nodeId });
           }
           var destTrack = moveTrackClip.trackType === "video" ? moveTrackClip.sequence.videoTracks[moveTargetIndex] : moveTrackClip.sequence.audioTracks[moveTargetIndex];
-          var occupant = null;
+          var occupants = [];
+          var moveLastEnd = 0;
           for (var oi = 0; oi < destTrack.clips.numItems; oi++) {
             var other = destTrack.clips[oi];
             if (__idsMatch(other.nodeId, moveTrackClip.clip.nodeId)) continue;
             var otherStart = valueOfTime(other.start);
             var otherEnd = valueOfTime(other.end);
-            if (moveStart < otherEnd && otherStart < moveEnd) { occupant = other; break; }
+            if (otherEnd > moveLastEnd) moveLastEnd = otherEnd;
+            if (moveStart < otherEnd && otherStart < moveEnd) occupants.push(other);
           }
-          if (occupant && !allowOverwrite) {
+          if (occupants.length && !allowOverwrite) {
             return fail("Destination track is occupied at that time. Pass overwrite:true to replace the occupant, or pick another track/time.", {
-              occupantId: occupant.nodeId,
-              occupantName: occupant.name,
-              occupantStart: valueOfTime(occupant.start),
-              occupantEnd: valueOfTime(occupant.end)
+              occupantId: occupants[0].nodeId,
+              occupantName: occupants[0].name,
+              occupantStart: valueOfTime(occupants[0].start),
+              occupantEnd: valueOfTime(occupants[0].end)
             });
+          }
+          // Nothing is mutated before this point, so the refusal above costs the
+          // caller nothing. overwrite:true is the caller's sanction to clear the
+          // span, and the slide below will not overwrite on its own, so lift every
+          // overlapping occupant explicitly (ripple = false keeps the track's
+          // timing). Done ahead of the native attempt so both paths see the same
+          // destination.
+          if (occupants.length) {
+            for (var ori = occupants.length - 1; ori >= 0; ori--) occupants[ori].remove(false, true);
           }
           var nativeMove = tryCall(moveTrackClip.clip, ["moveToTrack", "setTrack"], [moveTargetIndex]);
           if (nativeMove.called) {
             return ok({ moved: true, trackIndex: moveTargetIndex, method: nativeMove.method, clipId: moveTrackClip.clip.nodeId });
           }
-          moveTrackClip.clip.remove(false, true);
-          destTrack.overwriteClip(moveItem, moveStart);
+          // The fallback reinserts from the projectItem, and overwriteClip lays the
+          // item down at its OWN duration -- not the trimmed length of the timeline
+          // clip -- so writing straight at the destination can reach past
+          // [start, end) and destroy a neighbour the occupancy guard never looked
+          // at. Park past the last clip on the target track instead (guaranteed
+          // empty), trim there, then slide into the span the guard verified.
+          var moveParkTime = moveLastEnd + 1.0;
+          var moveCleanupParked = function (parkedClip) {
+            // Remove the parked copy so no failure path strands a full-length
+            // clip on the target track. Without a reference, sweep the park zone:
+            // it was empty before, so anything past the old last end is ours.
+            try {
+              if (parkedClip) { parkedClip.remove(false, true); return; }
+            } catch (eClean) {}
+            for (var ci = destTrack.clips.numItems - 1; ci >= 0; ci--) {
+              var leftover = destTrack.clips[ci];
+              try { if (leftover && valueOfTime(leftover.start) > moveLastEnd + 0.5) leftover.remove(false, true); } catch (eSweep) {}
+            }
+          };
+          destTrack.overwriteClip(moveItem, moveParkTime);
           var placed = null;
-          var bestDelta = null;
           for (var pi = 0; pi < destTrack.clips.numItems; pi++) {
             var candidate = destTrack.clips[pi];
-            var delta = Math.abs(valueOfTime(candidate.start) - moveStart);
-            if (bestDelta === null || delta < bestDelta) { placed = candidate; bestDelta = delta; }
+            // By identity, not nearest start: if overwriteClip silently no-ops, a
+            // nearest-start pick would hand back a bystander and the trim below
+            // would rewrite its in/out.
+            if (candidate && candidate.projectItem && __idsMatch(candidate.projectItem.nodeId, moveItem.nodeId) && Math.abs(valueOfTime(candidate.start) - moveParkTime) < 0.2) { placed = candidate; break; }
           }
-          if (!placed) return fail("Move did not create a clip on the target track");
-          try { placed.inPoint = secondsToTime(moveIn); } catch (eIn) {}
-          try { placed.outPoint = secondsToTime(moveOut); } catch (eOut) {}
-          try { placed.end = secondsToTime(moveEnd); } catch (eEnd) {}
+          if (!placed) {
+            moveCleanupParked(null);
+            return fail("Move fallback did not create a clip on the target track; the source clip was left in place.");
+          }
+          // Restore the source trim while parked. Order the assignments so inPoint
+          // never transiently exceeds outPoint, which the DOM rejects.
+          try {
+            if (moveIn <= valueOfTime(placed.outPoint)) {
+              placed.inPoint = secondsToTime(moveIn);
+              placed.outPoint = secondsToTime(moveOut);
+            } else {
+              placed.outPoint = secondsToTime(moveOut);
+              placed.inPoint = secondsToTime(moveIn);
+            }
+          } catch (eTrim) {}
           try { placed.disabled = moveDisabled; } catch (eEn) {}
           var trimRestored = Math.abs(valueOfTime(placed.inPoint) - moveIn) < 0.05 && Math.abs(valueOfTime(placed.outPoint) - moveOut) < 0.05;
-          if (!trimRestored) return fail("Clip moved but source in/out could not be restored", { clipId: placed.nodeId, requestedIn: moveIn, requestedOut: moveOut, actualIn: valueOfTime(placed.inPoint), actualOut: valueOfTime(placed.outPoint) });
-          return ok({ moved: true, trackIndex: moveTargetIndex, method: "remove+overwriteClip", start: moveStart, clipId: placed.nodeId, oldClipId: args.clipId || args.node_id || args.nodeId, trimRestored: true });
+          if (!trimRestored) {
+            var placedIn = valueOfTime(placed.inPoint);
+            var placedOut = valueOfTime(placed.outPoint);
+            moveCleanupParked(placed);
+            return fail("Source in/out could not be restored on the target track; the source clip was left in place.", { requestedIn: moveIn, requestedOut: moveOut, actualIn: placedIn, actualOut: placedOut });
+          }
+          placed.move(moveStart - valueOfTime(placed.start));
+          if (Math.abs(valueOfTime(placed.start) - moveStart) > 0.05) {
+            var placedStart = valueOfTime(placed.start);
+            moveCleanupParked(placed);
+            return fail("Clip could not be slid into the destination span; the source clip was left in place.", { requestedStart: moveStart, actualStart: placedStart });
+          }
+          // Only now, with the copy verified at the destination, lift the original
+          // (ripple = false), so the source track's other clips keep their timing.
+          moveTrackClip.clip.remove(false, true);
+          return ok({ moved: true, trackIndex: moveTargetIndex, method: "park+trim+slide", start: moveStart, clipId: placed.nodeId, oldClipId: args.clipId || args.node_id || args.nodeId, trimRestored: true });
 
         case "set_clip_speed_qe":
           if (!args.clipId && !args.node_id && !args.nodeId) return fail("set_clip_speed_qe requires clipId.");

--- a/src/tools/expanded.ts
+++ b/src/tools/expanded.ts
@@ -1714,6 +1714,7 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           var allowOverwrite = Boolean(args.overwrite);
           var moveStart = valueOfTime(moveTrackClip.clip.start);
           var moveEnd = valueOfTime(moveTrackClip.clip.end);
+          var moveDur = moveEnd - moveStart;
           var moveIn = valueOfTime(moveTrackClip.clip.inPoint);
           var moveOut = valueOfTime(moveTrackClip.clip.outPoint);
           var moveDisabled = false;
@@ -1800,13 +1801,22 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
               placed.inPoint = secondsToTime(moveIn);
             }
           } catch (eTrim) {}
+          // In/out alone do not shrink the timeline clip (trim_clip and
+          // replace_clip both write end for the same reason). Set the
+          // duration relative to the PARKED start -- moveEnd is an absolute
+          // time on the original timeline and would be wrong here.
+          try { placed.end = secondsToTime(valueOfTime(placed.start) + moveDur); } catch (eEnd) {}
           try { placed.disabled = moveDisabled; } catch (eEn) {}
-          var trimRestored = Math.abs(valueOfTime(placed.inPoint) - moveIn) < 0.05 && Math.abs(valueOfTime(placed.outPoint) - moveOut) < 0.05;
+          // Refuse to slide unless in, out AND duration all took: a full-length
+          // item slid into the span is exactly the neighbour overwrite the
+          // occupancy guard cannot see, since it only measured [start, end).
+          var trimRestored = Math.abs(valueOfTime(placed.inPoint) - moveIn) < 0.05 && Math.abs(valueOfTime(placed.outPoint) - moveOut) < 0.05 && Math.abs(valueOfTime(placed.end) - valueOfTime(placed.start) - moveDur) < 0.05;
           if (!trimRestored) {
             var placedIn = valueOfTime(placed.inPoint);
             var placedOut = valueOfTime(placed.outPoint);
+            var placedDur = valueOfTime(placed.end) - valueOfTime(placed.start);
             moveCleanupParked(placed);
-            return fail("Source in/out could not be restored on the target track; the source clip was left in place.", { requestedIn: moveIn, requestedOut: moveOut, actualIn: placedIn, actualOut: placedOut });
+            return fail("Source trim could not be restored on the target track; the source clip was left in place.", { requestedIn: moveIn, requestedOut: moveOut, requestedDuration: moveDur, actualIn: placedIn, actualOut: placedOut, actualDuration: placedDur });
           }
           placed.move(moveStart - valueOfTime(placed.start));
           if (Math.abs(valueOfTime(placed.start) - moveStart) > 0.05) {


### PR DESCRIPTION
## Rebuilt on top of 1.2.6

The original branch predated your `move_clip_to_track` rework in 1.2.6, and both sides rewrote the same block, so a rebase would have been a rewrite anyway. This is now a **single commit on current `main`**, kept as a delta on your implementation rather than a competing one.

**Kept from 1.2.6:** the same-track short-circuit, the `__idsMatch` self-skip in the occupancy scan, the `overwrite:true` opt-in, the range checks, `disabled` preservation, and your error wording. That also answers review points (1) and (2) directly — the same-track cases never reach the fallback, and the clip-count check no longer exists in any form.

## What this still fixes on main

The 1.2.6 fallback does:

```js
moveTrackClip.clip.remove(false, true);
destTrack.overwriteClip(moveItem, moveStart);
```

Three problems survive there:

- **The occupancy guard checks the trimmed span, but `overwriteClip` writes the item's own duration.** A still holding 12 frames on the timeline with a multi-second item default reaches past `[start, end)` and destroys a neighbour the guard never looked at. Trimming the placed clip afterwards cannot bring that neighbour back.
- **The source is removed first**, so every later failure path (`!placed`, trim not restored) reports the error having already destroyed the clip it failed to move.
- **`placed` is picked by nearest start.** If `overwriteClip` silently no-ops, the nearest-start pick hands back a bystander and the trim rewrites its in/out.

## The change

Park → trim → slide → lift-last:

- The item is parked **past the last clip** on the target track — guaranteed empty, so the full-duration write cannot hit anything.
- The parked clip is found **by `projectItem.nodeId` identity** at the park position, not nearest start.
- Trim is restored while parked, then the clip is slid into the span the guard verified, and each step is checked.
- The original is lifted **last** (`ripple = false`), so every failure path after the park removes the parked copy (`moveCleanupParked`, review point 3) and leaves the source clip untouched — something the remove-first shape structurally cannot offer.
- Since the slide cannot overwrite, `overwrite:true` now lifts the overlapping occupants explicitly — **all** of them, not just the first.

Signature, aliases, and your occupancy error message are unchanged; `method` in the result is now `"park+trim+slide"`.

## Tests

Five added in `move-clip-to-track.test.ts`, asserting ordering properties against the extracted `case` block (same reasoning as `qe-targeting.test.ts`); **each was watched failing against the 1.2.6 implementation** before the fix:

- source lifted only after the copy is verified in the span
- park precedes trim precedes slide; no `overwriteClip(moveItem, moveStart)`
- parked clip identified by projectItem identity
- `moveCleanupParked` precedes every post-park `fail`
- occupants collected as a list and lifted under `overwrite:true`

One assertion in `clip-lifecycle.test.ts` updated (`moveStart` → `moveParkTime` in the overwrite call). Full suite **643/643**, `tsc` clean.

## Provenance

Ported from a fork running this shape in production — a Crunchyroll marketing-versioning pipeline moving trimmed cards and subtitle clips between tracks, where the full-length-reinsert and neighbour-overwrite failures were originally hit.
