### PR TITLE
fix(trim_clip, move_clip): sync outPoint after duration trim, fix cross-track move

### DIFF
--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -861,6 +861,62 @@ describe('PremiereProTools', () => {
       expect(outPointWrites).toBe(0);
     });
 
+    it('trims a still image to a shorter duration instead of misreading the media boundary from a mismatched coordinate frame', async () => {
+      // Premiere anchors a still image TrackItem's inPoint/outPoint around an arbitrary
+      // large offset (~3600s here), completely independent of the project item's own
+      // reported in/out (0..5, its default still-image duration). Comparing those two
+      // directly (before this fix) computed a negative "max achievable duration" and
+      // broke every trim of a still image to a shorter clip.
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+      await tools.executeTool('trim_clip', { clipId: 'still-1', duration: 0.64 });
+      const script = mockBridge.executeScript.mock.calls[0][0];
+      const ticksPerSecond = 254016000000;
+      class FakeTime {
+        private value = 0;
+        get seconds() { return this.value; }
+        set seconds(value: number) { this.value = value; }
+        get ticks() { return String(Math.round(this.value * ticksPerSecond)); }
+        set ticks(value: string) { this.value = Number(value) / ticksPerSecond; }
+      }
+      const at = (seconds: number) => {
+        const time = new FakeTime();
+        time.seconds = seconds;
+        return time;
+      };
+      const clip: any = {
+        inPoint: at(3600),
+        start: at(16.16),
+        projectItem: {
+          getInPoint: () => at(0),
+          getOutPoint: () => at(5)
+        }
+      };
+      let timelineEnd = at(21.16);
+      let sourceOut = at(3605);
+      Object.defineProperty(clip, 'end', {
+        get: () => timelineEnd,
+        set: (value) => { timelineEnd = value; }
+      });
+      Object.defineProperty(clip, 'outPoint', {
+        get: () => sourceOut,
+        set: (value) => { sourceOut = value; }
+      });
+      Object.defineProperty(clip, 'duration', {
+        get: () => at(timelineEnd.seconds - clip.start.seconds)
+      });
+      const runScript = new Function('__findClip', 'Time', script);
+      const parsed = JSON.parse(runScript(
+        () => ({ clip, sequence: { timebase: String(Math.round(ticksPerSecond * 1001 / 30000)) } }),
+        FakeTime
+      ));
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.mediaBoundaryHit).toBe(false);
+      expect(parsed.newDuration).toBeCloseTo(0.64);
+      expect(timelineEnd.seconds).toBeCloseTo(16.8);
+      expect(sourceOut.seconds).toBeCloseTo(3600.64);
+    });
+
     it('verifies move_clip against the actual post-move position instead of trusting the request', async () => {
       mockBridge.executeScript.mockResolvedValue({ success: true });
       await tools.executeTool('move_clip', { clipId: 'clip-123', newTime: 12 });

--- a/src/__tests__/tools/index.test.ts
+++ b/src/__tests__/tools/index.test.ts
@@ -795,7 +795,7 @@ describe('PremiereProTools', () => {
       expect(result.success).toBe(true);
       const script = mockBridge.executeScript.mock.calls[0][0];
       expect(script).not.toContain('clip.outPoint = timeFromSeconds(targetOutPoint)');
-      expect(script).toContain('clip.end = timeFromSeconds(secondsOf(clip.start) + targetDuration)');
+      expect(script).toContain('clip.end = timeFromSeconds(secondsOf(clip.start) + effectiveTargetDuration)');
       expect(script).not.toContain('new Time(clip.inPoint.seconds + 2.5)');
       expect(script).toContain('timeline duration did not change to requested value');
       expect(script).toContain('TRIM_UNSUPPORTED_FOR_CLIP');
@@ -861,6 +861,103 @@ describe('PremiereProTools', () => {
       expect(outPointWrites).toBe(0);
     });
 
+    it('verifies move_clip against the actual post-move position instead of trusting the request', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+      await tools.executeTool('move_clip', { clipId: 'clip-123', newTime: 12 });
+      const script = mockBridge.executeScript.mock.calls[0][0];
+
+      const clip: any = {
+        start: { seconds: 5 },
+        nodeId: 'clip-123',
+        move: jest.fn((shift: number) => {
+          clip.start = { seconds: clip.start.seconds + shift };
+        })
+      };
+      const info = {
+        clip,
+        sequence: {},
+        trackIndex: 0,
+        trackType: 'video',
+        sequenceId: 'seq-1'
+      };
+      const runScript = new Function('__findClip', script);
+      const parsed = JSON.parse(runScript(() => info));
+
+      expect(clip.move).toHaveBeenCalledWith(7);
+      expect(parsed.success).toBe(true);
+      expect(parsed.oldTime).toBe(5);
+      expect(parsed.newTime).toBe(12);
+      expect(parsed.trackIndex).toBe(0);
+    });
+
+    it('reports move_clip failure instead of claiming success when Premiere silently rejects the move (collision)', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+      await tools.executeTool('move_clip', { clipId: 'clip-123', newTime: 12 });
+      const script = mockBridge.executeScript.mock.calls[0][0];
+
+      const clip: any = {
+        start: { seconds: 5 },
+        nodeId: 'clip-123',
+        // Simulates Premiere refusing the move (e.g. it would overlap an adjacent clip):
+        // the start position never actually changes.
+        move: jest.fn()
+      };
+      const info = {
+        clip,
+        sequence: {},
+        trackIndex: 0,
+        trackType: 'video',
+        sequenceId: 'seq-1'
+      };
+      const runScript = new Function('__findClip', script);
+      const parsed = JSON.parse(runScript(() => info));
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.errorCode).toBe('MOVE_NOT_APPLIED');
+      expect(parsed.oldTime).toBe(5);
+      expect(parsed.actualTime).toBe(5);
+    });
+
+    it('moves a clip across tracks and returns the new clipId, since Premiere assigns a new nodeId', async () => {
+      mockBridge.executeScript.mockResolvedValue({ success: true });
+      await tools.executeTool('move_clip', { clipId: 'clip-123', newTime: 10, newTrackIndex: 1 });
+      const script = mockBridge.executeScript.mock.calls[0][0];
+
+      const projectItem = { id: 'source-media' };
+      const oldClip: any = { start: { seconds: 2 }, nodeId: 'clip-123', projectItem, remove: jest.fn() };
+      let targetTrackItems: any[] = [];
+      function clipsCollection(items: any[]) {
+        const collection: any = { numItems: items.length };
+        items.forEach((item, i) => { collection[i] = item; });
+        return collection;
+      }
+      const targetTrack = { get clips() { return clipsCollection(targetTrackItems); } };
+      const videoTracks: any = { numTracks: 2, 0: {}, 1: targetTrack };
+      const sequence: any = {
+        videoTracks,
+        overwriteClip: jest.fn(() => {
+          targetTrackItems.push({ start: { seconds: 10 }, nodeId: 'clip-456', projectItem });
+        })
+      };
+      const info = {
+        clip: oldClip,
+        sequence,
+        trackIndex: 0,
+        trackType: 'video',
+        sequenceId: 'seq-1'
+      };
+      const runScript = new Function('__findClip', script);
+      const parsed = JSON.parse(runScript(() => info));
+
+      expect(oldClip.remove).toHaveBeenCalledWith(false, true);
+      expect(sequence.overwriteClip).toHaveBeenCalledWith(projectItem, expect.any(String), 1, 0);
+      expect(parsed.success).toBe(true);
+      expect(parsed.clipId).toBe('clip-456');
+      expect(parsed.originalClipId).toBe('clip-123');
+      expect(parsed.clipIdChanged).toBe(true);
+      expect(parsed.trackIndex).toBe(1);
+    });
+
     it('accepts a duration that Premiere quantizes to the nearest frame', async () => {
       mockBridge.executeScript.mockResolvedValue({ success: true });
       await tools.executeTool('trim_clip', { clipId: 'clip-123', duration: 7 });
@@ -902,8 +999,8 @@ describe('PremiereProTools', () => {
       await tools.executeTool('trim_clip', { clipId: 'clip-123', duration: 5.0333666667 });
       const script = mockBridge.executeScript.mock.calls[0][0];
 
-      expect(script).toContain('if (!exactEnough(before.duration, targetDuration))');
-      expect(script).not.toContain('if (!closeEnough(before.duration, targetDuration))');
+      expect(script).toContain('if (!exactEnough(before.duration, effectiveTargetDuration))');
+      expect(script).not.toContain('if (!closeEnough(before.duration, effectiveTargetDuration))');
       expect(script).toContain('frameDurationSeconds / 2');
     });
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -118,6 +118,12 @@ function __ticksToSeconds(ticks) {
 function __secondsToTicks(seconds) {
   return String(Math.round(seconds * 254016000000));
 }
+function __seqTimeToClipTime(clip, seqSeconds) {
+  return clip.inPoint.seconds + (seqSeconds - clip.start.seconds);
+}
+function __clipTimeToSeqTime(clip, clipSeconds) {
+  return clip.start.seconds + (clipSeconds - clip.inPoint.seconds);
+}
 `;
 
 export interface PremiereProProject {

--- a/src/tools/expanded.ts
+++ b/src/tools/expanded.ts
@@ -1657,16 +1657,19 @@ function buildExpandedToolScript(name: string, args: Record<string, any>): strin
           if (!keyProperty) return fail("Property not found", { properties: componentProperties(keyComponent.component) });
           if (toolName === "remove_keyframe_range") {
             if (!keyProperty.removeKeyRange) return fail("removeKeyRange API unavailable on property");
-            keyProperty.removeKeyRange(secondsToTime(args.startTime || args.start || 0), secondsToTime(args.endTime || args.end || 0), true);
-            return ok({ removed: true, component: String(keyComponent.component.displayName), property: String(keyProperty.displayName), start: Number(args.startTime || args.start || 0), end: Number(args.endTime || args.end || 0) });
+            var rangeStartSeq = Number(args.startTime || args.start || 0);
+            var rangeEndSeq = Number(args.endTime || args.end || 0);
+            keyProperty.removeKeyRange(secondsToTime(__seqTimeToClipTime(keyClip.clip, rangeStartSeq)), secondsToTime(__seqTimeToClipTime(keyClip.clip, rangeEndSeq)), true);
+            return ok({ removed: true, component: String(keyComponent.component.displayName), property: String(keyProperty.displayName), start: rangeStartSeq, end: rangeEndSeq });
           }
           if (!keyProperty.addKey || !keyProperty.setInterpolationTypeAtKey) return fail("Keyframe interpolation APIs unavailable on property");
-          var interpolationTime = secondsToTime(args.time || args.seconds || 0);
+          var interpolationTimeSeq = Number(args.time || args.seconds || 0);
+          var interpolationTime = secondsToTime(__seqTimeToClipTime(keyClip.clip, interpolationTimeSeq));
           try { keyProperty.setTimeVarying(true); } catch (varyError) {}
           try { keyProperty.addKey(interpolationTime); } catch (addKeyError) {}
           var interpolationValue = Number(args.interpolationType || args.type || 0);
           keyProperty.setInterpolationTypeAtKey(interpolationTime, interpolationValue, true);
-          return ok({ interpolated: true, component: String(keyComponent.component.displayName), property: String(keyProperty.displayName), time: Number(args.time || args.seconds || 0), interpolationType: interpolationValue });
+          return ok({ interpolated: true, component: String(keyComponent.component.displayName), property: String(keyProperty.displayName), time: interpolationTimeSeq, interpolationType: interpolationValue });
 
         case "select_clips_by_color":
           var labelValue = Number(args.colorIndex || args.label || args.value || 0);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5617,14 +5617,18 @@ export class PremiereProTools {
   // ============================================
 
   // Markers Implementation
-  private async addMarker(_sequenceId: string, time: number, name: string, comment?: string, color?: string, duration?: number): Promise<any> {
+  private async addMarker(sequenceId: string, time: number, name: string, comment?: string, color?: string, duration?: number): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
+        var sequence = null;
+        for (var __si = 0; __si < app.project.sequences.numSequences; __si++) {
+          var __s = app.project.sequences[__si];
+          if (__s.sequenceID === ${JSON.stringify(sequenceId)}) { sequence = __s; break; }
+        }
         if (!sequence) {
           return JSON.stringify({
             success: false,
-            error: "No active sequence"
+            error: "Sequence not found: " + ${JSON.stringify(sequenceId)}
           });
         } else {
           var marker = sequence.markers.createMarker(${time});
@@ -5649,14 +5653,18 @@ export class PremiereProTools {
     return await this.bridge.executeScript(script);
   }
 
-  private async deleteMarker(_sequenceId: string, markerId: string): Promise<any> {
+  private async deleteMarker(sequenceId: string, markerId: string): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
+        var sequence = null;
+        for (var __si = 0; __si < app.project.sequences.numSequences; __si++) {
+          var __s = app.project.sequences[__si];
+          if (__s.sequenceID === ${JSON.stringify(sequenceId)}) { sequence = __s; break; }
+        }
         if (!sequence) {
           return JSON.stringify({
             success: false,
-            error: "No active sequence"
+            error: "Sequence not found: " + ${JSON.stringify(sequenceId)}
           });
         } else {
           var deleted = false;
@@ -5691,14 +5699,18 @@ export class PremiereProTools {
     return await this.bridge.executeScript(script);
   }
 
-  private async updateMarker(_sequenceId: string, markerId: string, updates: any): Promise<any> {
+  private async updateMarker(sequenceId: string, markerId: string, updates: any): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
+        var sequence = null;
+        for (var __si = 0; __si < app.project.sequences.numSequences; __si++) {
+          var __s = app.project.sequences[__si];
+          if (__s.sequenceID === ${JSON.stringify(sequenceId)}) { sequence = __s; break; }
+        }
         if (!sequence) {
           return JSON.stringify({
             success: false,
-            error: "No active sequence"
+            error: "Sequence not found: " + ${JSON.stringify(sequenceId)}
           });
         } else {
           var found = false;
@@ -5728,14 +5740,18 @@ export class PremiereProTools {
     return await this.bridge.executeScript(script);
   }
 
-  private async listMarkers(_sequenceId: string): Promise<any> {
+  private async listMarkers(sequenceId: string): Promise<any> {
     const script = `
       try {
-        var sequence = app.project.activeSequence;
+        var sequence = null;
+        for (var __si = 0; __si < app.project.sequences.numSequences; __si++) {
+          var __s = app.project.sequences[__si];
+          if (__s.sequenceID === ${JSON.stringify(sequenceId)}) { sequence = __s; break; }
+        }
         if (!sequence) {
           return JSON.stringify({
             success: false,
-            error: "No active sequence"
+            error: "Sequence not found: " + ${JSON.stringify(sequenceId)}
           });
         } else {
           var markers = [];

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -464,11 +464,11 @@ export class PremiereProTools {
       },
       {
         name: 'move_clip',
-        description: 'Moves a clip to a different position on the timeline.',
+        description: 'Moves a clip to a different position on the timeline. The result is verified against the clip\'s actual post-move position; if Premiere rejects or clamps the move (e.g. a timeline collision), success is false. When newTrackIndex differs from the clip\'s current track, Premiere has to recreate the clip on the new track (via remove + re-insert), so its clipId changes — the response returns the new id (also check clipIdChanged). Re-inserting on the new track initially uses the source\'s full in/out range; if the clip had been trimmed, the tool re-applies the original trim afterward and reports it under restoredTrimAfterMove — success is false (errorCode MOVE_TRIM_NOT_RESTORED) if that re-apply did not verifiably match the original trim.',
         inputSchema: z.object({
           clipId: z.string().describe('The ID of the clip to move'),
           newTime: z.number().describe('The new time position in seconds'),
-          newTrackIndex: z.number().optional().describe('The new track index (if moving to different track)')
+          newTrackIndex: z.number().optional().describe('The new track index (if moving to different track, within the same track type as the clip\'s current track). Note: moving across tracks assigns the clip a new clipId; use the id returned in the response for subsequent calls.')
         })
       },
       {
@@ -3187,22 +3187,174 @@ export class PremiereProTools {
     return await this.bridge.executeScript(script);
   }
 
-  private async moveClip(clipId: string, newTime: number, _newTrackIndex?: number): Promise<any> {
+  private async moveClip(clipId: string, newTime: number, newTrackIndex?: number): Promise<any> {
     const script = `
       try {
-        var info = __findClip("${clipId}");
+        var info = __findClip(${JSON.stringify(clipId)});
         if (!info) return JSON.stringify({ success: false, error: "Clip not found" });
         var clip = info.clip;
-        var oldTime = clip.start.seconds;
-        var shiftAmount = ${newTime} - oldTime;
-        clip.move(shiftAmount);
+        var sequence = info.sequence;
+        function secondsOf(value) {
+          if (value === undefined || value === null) return null;
+          if (typeof value === "number") return value;
+          if (value.seconds !== undefined) return Number(value.seconds);
+          if (value.ticks !== undefined) return Number(value.ticks) / 254016000000.0;
+          return null;
+        }
+        function secondsToTicks(seconds) { return String(Math.round(Number(seconds || 0) * 254016000000)); }
+        function frameDurationOf(seq) {
+          try {
+            if (seq && seq.timebase !== undefined) {
+              var value = Number(seq.timebase) / 254016000000.0;
+              if (value > 0 && isFinite(value)) return value;
+            }
+          } catch (frameError) {}
+          return 1 / 48;
+        }
+        var frameDurationSeconds = frameDurationOf(sequence);
+        var oldTime = secondsOf(clip.start);
+        var oldTrackIndex = info.trackIndex;
+        var oldTrackType = info.trackType;
+        var crossTrack = ${newTrackIndex !== undefined ? 'true' : 'false'};
+        var requestedTrackIndex = ${newTrackIndex !== undefined ? Number(newTrackIndex) : 'null'};
+        var newClipId = null;
+        var restoredTrimAfterMove = null;
+
+        if (crossTrack && requestedTrackIndex !== oldTrackIndex) {
+          // TrackItem.move() only shifts a clip within its own track — it cannot change
+          // track. Changing track requires removing the item and re-inserting it via
+          // Sequence.overwriteClip on the target track (same technique used by
+          // move_clip_to_track). Note this creates a NEW TrackItem, so the original
+          // clipId (nodeId) will no longer resolve afterwards; we look up and return
+          // the new one below.
+          var tracksList = oldTrackType === "video" ? sequence.videoTracks : sequence.audioTracks;
+          if (requestedTrackIndex < 0 || requestedTrackIndex >= tracksList.numTracks) {
+            return JSON.stringify({ success: false, error: "Target track index out of range", errorCode: "MOVE_TRACK_OUT_OF_RANGE", requestedTrackIndex: requestedTrackIndex, availableTracks: tracksList.numTracks });
+          }
+          var projectItem = clip.projectItem;
+          if (!projectItem) {
+            return JSON.stringify({ success: false, error: "Clip has no projectItem; cannot move across tracks", errorCode: "MOVE_NO_PROJECT_ITEM" });
+          }
+          // Sequence.overwriteClip() always inserts the project item's FULL current
+          // in/out range — it has no parameter for a specific source range. If the
+          // clip being moved had been trimmed (inPoint/outPoint narrower than the
+          // project item's own range), that trim would otherwise be silently lost
+          // and replaced by the untrimmed clip. Capture the original source range
+          // (and nodeId, for identity matching below) before removing the clip, so
+          // we can re-apply the trim to the freshly-placed clip afterward.
+          var projectItemNodeId = projectItem.nodeId;
+          var originalInPointSeconds = secondsOf(clip.inPoint);
+          var originalOutPointSeconds = secondsOf(clip.outPoint);
+          var beforeTargetCount = tracksList[requestedTrackIndex].clips.numItems;
+          clip.remove(false, true);
+          if (oldTrackType === "video") sequence.overwriteClip(projectItem, secondsToTicks(${newTime}), requestedTrackIndex, 0);
+          else sequence.overwriteClip(projectItem, secondsToTicks(${newTime}), 0, requestedTrackIndex);
+          var afterTargetCount = tracksList[requestedTrackIndex].clips.numItems;
+          if (afterTargetCount <= beforeTargetCount) {
+            return JSON.stringify({ success: false, error: "Move to target track did not create a clip there", errorCode: "MOVE_TRACK_FAILED", beforeTargetCount: beforeTargetCount, afterTargetCount: afterTargetCount });
+          }
+          // Identify the newly placed clip: the item on the target track whose source
+          // matches and whose start is closest to the requested time. Match by the
+          // project item's nodeId (a string), NOT by object reference (\`!==\`) —
+          // ExtendScript's DOM returns a fresh proxy object on every \`.projectItem\`
+          // access, so two references to the same underlying item are not \`===\` to
+          // each other; a reference-equality check here always misses, even when the
+          // move itself succeeded (this was a real bug: it made this branch report
+          // MOVE_TRACK_LOST on every cross-track move regardless of outcome).
+          var candidateTrack = tracksList[requestedTrackIndex];
+          var bestMatch = null;
+          var bestDelta = Infinity;
+          for (var ci = 0; ci < candidateTrack.clips.numItems; ci++) {
+            var candidate = candidateTrack.clips[ci];
+            var candidateProjectItem = candidate.projectItem;
+            if (!candidateProjectItem || candidateProjectItem.nodeId !== projectItemNodeId) continue;
+            var candidateStart = secondsOf(candidate.start);
+            var delta = Math.abs(candidateStart - ${newTime});
+            if (delta < bestDelta) { bestDelta = delta; bestMatch = candidate; }
+          }
+          if (!bestMatch) {
+            return JSON.stringify({ success: false, error: "Clip moved to target track but could not be re-identified", errorCode: "MOVE_TRACK_LOST" });
+          }
+          clip = bestMatch;
+          newClipId = clip.nodeId;
+          // Re-apply the original trim (source in/out) that overwriteClip discarded.
+          if (originalInPointSeconds !== null && originalOutPointSeconds !== null) {
+            var placedInPoint = secondsOf(clip.inPoint);
+            var placedOutPoint = secondsOf(clip.outPoint);
+            var needsInFix = Math.abs(placedInPoint - originalInPointSeconds) > 0.000001;
+            var needsOutFix = Math.abs(placedOutPoint - originalOutPointSeconds) > 0.000001;
+            restoredTrimAfterMove = { attempted: needsInFix || needsOutFix, inPointError: null, outPointError: null };
+            if (needsInFix) {
+              try { clip.inPoint = new Time(originalInPointSeconds + "s"); }
+              catch (inFixError) { restoredTrimAfterMove.inPointError = inFixError.toString(); }
+            }
+            if (needsOutFix) {
+              try { clip.outPoint = new Time(originalOutPointSeconds + "s"); }
+              catch (outFixError) { restoredTrimAfterMove.outPointError = outFixError.toString(); }
+            }
+            restoredTrimAfterMove.finalInPoint = secondsOf(clip.inPoint);
+            restoredTrimAfterMove.finalOutPoint = secondsOf(clip.outPoint);
+            restoredTrimAfterMove.matchesOriginal =
+              Math.abs(restoredTrimAfterMove.finalInPoint - originalInPointSeconds) <= (frameDurationSeconds / 2) + 0.000001 &&
+              Math.abs(restoredTrimAfterMove.finalOutPoint - originalOutPointSeconds) <= (frameDurationSeconds / 2) + 0.000001;
+          }
+        } else {
+          var shiftAmount = ${newTime} - oldTime;
+          clip.move(shiftAmount);
+        }
+
+        // Verify the actual outcome instead of trusting the requested values — Premiere
+        // can silently reject or clamp a move (e.g. an overlap with an adjacent clip).
+        var actualTime = secondsOf(clip.start);
+        var timeMatches = actualTime !== null && Math.abs(actualTime - ${newTime}) <= (frameDurationSeconds / 2) + 0.000001;
+        var trimRestoreFailed = restoredTrimAfterMove !== null && restoredTrimAfterMove.attempted && restoredTrimAfterMove.matchesOriginal === false;
+        if (!timeMatches) {
+          return JSON.stringify({
+            success: false,
+            error: "Premiere did not apply the requested move exactly (likely a timeline collision or clamp)",
+            errorCode: "MOVE_NOT_APPLIED",
+            clipId: ${JSON.stringify(clipId)},
+            newClipId: newClipId,
+            requested: { time: ${newTime}, trackIndex: requestedTrackIndex },
+            oldTime: oldTime,
+            oldTrackIndex: oldTrackIndex,
+            oldTrackType: oldTrackType,
+            actualTime: actualTime,
+            restoredTrimAfterMove: restoredTrimAfterMove
+          });
+        }
+        if (trimRestoreFailed) {
+          // The cross-track re-insert (Sequence.overwriteClip) always drops the
+          // original source trim; we tried to re-apply it above but it did not take.
+          // Report this as a failure rather than silently handing back a clip whose
+          // duration/content no longer matches what was actually being moved.
+          return JSON.stringify({
+            success: false,
+            error: "Clip moved to the new track, but its original trim (inPoint/outPoint) could not be restored — the moved clip's duration/content differs from the source clip",
+            errorCode: "MOVE_TRIM_NOT_RESTORED",
+            clipId: newClipId || ${JSON.stringify(clipId)},
+            originalClipId: ${JSON.stringify(clipId)},
+            oldTime: oldTime,
+            newTime: actualTime,
+            oldTrackIndex: oldTrackIndex,
+            trackIndex: requestedTrackIndex,
+            trackType: oldTrackType,
+            restoredTrimAfterMove: restoredTrimAfterMove
+          });
+        }
+
         return JSON.stringify({
           success: true,
           message: "Clip moved successfully",
-          clipId: "${clipId}",
+          clipId: newClipId || ${JSON.stringify(clipId)},
+          originalClipId: ${JSON.stringify(clipId)},
+          clipIdChanged: newClipId !== null,
           oldTime: oldTime,
-          newTime: ${newTime},
-          trackIndex: info.trackIndex
+          newTime: actualTime,
+          oldTrackIndex: oldTrackIndex,
+          trackIndex: newClipId !== null ? requestedTrackIndex : oldTrackIndex,
+          trackType: oldTrackType,
+          restoredTrimAfterMove: restoredTrimAfterMove
         });
       } catch (e) {
         return JSON.stringify({
@@ -3308,11 +3460,71 @@ export class PremiereProTools {
         ` : ''}
         ${duration !== undefined ? `
         var targetDuration = ${duration};
-        if (!exactEnough(before.duration, targetDuration)) {
+        var speedFactor = 1;
+        try {
+          var rawSpeed = Number(clip.getSpeed());
+          // TrackItem.getSpeed() is inconsistent about whether it returns a fractional
+          // multiplier (1 = normal speed) or a percentage (100 = normal speed). Use the
+          // same heuristic already relied on elsewhere in this codebase (speedChange):
+          // small values are fractional multipliers already; larger ones are percentages.
+          if (isFinite(rawSpeed) && rawSpeed !== 0) {
+            speedFactor = rawSpeed <= 10 ? rawSpeed : rawSpeed / 100;
+          }
+        } catch (speedError) {}
+        // The requested timeline duration cannot exceed how much real source media
+        // remains past inPoint. Read the project item's authoritative master-clip
+        // out point (NOT the possibly-already-desynced clip.outPoint on this track
+        // item) so we never write an outPoint past the real media boundary.
+        var maxSourceOutSeconds = null;
+        try {
+          var sourceProjectItem = clip.projectItem;
+          if (sourceProjectItem && sourceProjectItem.getOutPoint) {
+            var masterOutTime = sourceProjectItem.getOutPoint();
+            maxSourceOutSeconds = secondsOf(masterOutTime);
+          }
+        } catch (mediaBoundsError) {}
+        var mediaBoundaryHit = false;
+        var maxAchievableDurationSeconds = null;
+        var effectiveTargetDuration = targetDuration;
+        if (maxSourceOutSeconds !== null && before.inPoint !== null) {
+          var maxDurationFromMedia = (maxSourceOutSeconds - before.inPoint) / speedFactor;
+          if (targetDuration > maxDurationFromMedia + 0.000001) {
+            mediaBoundaryHit = true;
+            maxAchievableDurationSeconds = maxDurationFromMedia;
+            effectiveTargetDuration = maxDurationFromMedia;
+          }
+        }
+        if (!exactEnough(before.duration, effectiveTargetDuration)) {
           try {
-            clip.end = timeFromSeconds(secondsOf(clip.start) + targetDuration);
+            clip.end = timeFromSeconds(secondsOf(clip.start) + effectiveTargetDuration);
           } catch (timelineError) {
             recordWriteError("end", timelineError);
+          }
+        }
+        // clip.end only moves the on-timeline extent; Premiere does NOT recompute
+        // outPoint (the source media out point) to match. Left unsynced, (outPoint -
+        // inPoint) no longer equals the applied duration, and Premiere's native UI
+        // trim-drag later reads that stale outPoint as "no media handle left" and
+        // refuses to let the user extend the clip by hand. Mirror the source out
+        // point explicitly, same as roll_edit already does for its start/end writes.
+        // This runs even when .end already matched the target (e.g. self-healing a
+        // clip left desynced by this bug in the past) and is skipped when the .end
+        // write didn't actually take effect: some clip types (e.g. Graphics/MOGRTs)
+        // silently ignore .end writes, and mutating outPoint in that case would
+        // introduce the very desync this sync exists to prevent. The unconditional
+        // check here (based on current state, not on whether the .end write above
+        // changed anything this call) is what makes this self-healing: a clip left
+        // desynced by a past bug gets its outPoint corrected even when a later call
+        // requests the same (already-applied) duration.
+        var endWriteTookEffect = closeEnough(secondsOf(clip.end) - secondsOf(clip.start), effectiveTargetDuration);
+        if (endWriteTookEffect && before.inPoint !== null) {
+          var currentOutPointGap = secondsOf(clip.outPoint) - secondsOf(clip.inPoint);
+          if (!closeEnough(currentOutPointGap, effectiveTargetDuration * speedFactor)) {
+            try {
+              clip.outPoint = timeFromSeconds(secondsOf(clip.inPoint) + (effectiveTargetDuration * speedFactor));
+            } catch (outPointSyncError) {
+              recordWriteError("outPoint", outPointSyncError);
+            }
           }
         }
         ` : ''}
@@ -3333,9 +3545,15 @@ export class PremiereProTools {
         }
         ` : ''}
         ${duration !== undefined ? `
-        if (!closeEnough(after.duration, ${duration})) {
+        if (!closeEnough(after.duration, effectiveTargetDuration)) {
           verified = false;
-          verificationErrors.push("timeline duration did not change to requested value");
+          verificationErrors.push(mediaBoundaryHit
+            ? "timeline duration did not reach the clamped media-boundary value"
+            : "timeline duration did not change to requested value");
+        }
+        if (closeEnough(after.duration, effectiveTargetDuration) && !closeEnough(after.outPoint - after.inPoint, effectiveTargetDuration * speedFactor)) {
+          verified = false;
+          verificationErrors.push("outPoint/inPoint fell out of sync with the applied duration");
         }
         ` : ''}
 
@@ -3360,7 +3578,7 @@ export class PremiereProTools {
             exactEnough(restored.end, before.end);
           var errorCode = "TRIM_NOT_APPLIED";
           ${duration !== undefined ? `
-          if (${duration} > before.duration && closeEnough(attempted.duration, before.duration)) {
+          if (effectiveTargetDuration > before.duration && closeEnough(attempted.duration, before.duration)) {
             errorCode = "TRIM_UNSUPPORTED_FOR_CLIP";
           }
           ` : ''}
@@ -3376,6 +3594,7 @@ export class PremiereProTools {
               outPoint: ${outPoint !== undefined ? outPoint : 'null'},
               duration: ${duration !== undefined ? duration : 'null'}
             },
+            ${duration !== undefined ? 'mediaBoundaryHit: mediaBoundaryHit, maxAchievableDurationSeconds: maxAchievableDurationSeconds,' : ''}
             before: before,
             after: after,
             attempted: attempted,
@@ -3390,7 +3609,7 @@ export class PremiereProTools {
 
         return JSON.stringify({
           success: true,
-          message: "Clip trimmed and verified",
+          message: ${duration !== undefined ? '(mediaBoundaryHit ? "Clip trimmed and verified, but clamped to the real source media boundary (requested duration exceeded available media)" : "Clip trimmed and verified")' : '"Clip trimmed and verified"'},
           clipId: ${JSON.stringify(clipId)},
           oldInPoint: before.inPoint,
           oldOutPoint: before.outPoint,
@@ -3398,6 +3617,7 @@ export class PremiereProTools {
           newInPoint: after.inPoint,
           newOutPoint: after.outPoint,
           newDuration: after.duration,
+          ${duration !== undefined ? 'mediaBoundaryHit: mediaBoundaryHit, maxAchievableDurationSeconds: maxAchievableDurationSeconds,' : ''}
           before: before,
           after: after,
           writeErrors: writeErrors,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -990,12 +990,12 @@ export class PremiereProTools {
       // Keyframes
       {
         name: 'add_keyframe',
-        description: 'Adds a keyframe to a clip component parameter at a specific time.',
+        description: 'Adds a keyframe to a clip component parameter at a specific time. `time` is in sequence/timeline seconds (same space as clip start/end from get_selected_clips), NOT the clip\'s source/master-clip time — the tool converts internally.',
         inputSchema: z.object({
           clipId: z.string().describe('The ID of the clip'),
           componentName: z.string().describe('The display name of the component (e.g., "Motion", "Opacity")'),
           paramName: z.string().describe('The display name of the parameter (e.g., "Position", "Scale")'),
-          time: z.number().describe('The time in seconds for the keyframe'),
+          time: z.number().describe('The time in sequence-timeline seconds for the keyframe (e.g. a value between the clip\'s start and end from get_selected_clips)'),
           value: z.number().describe('The value to set at this keyframe')
         })
       },
@@ -1006,12 +1006,12 @@ export class PremiereProTools {
           clipId: z.string().describe('The ID of the clip'),
           componentName: z.string().describe('The display name of the component'),
           paramName: z.string().describe('The display name of the parameter'),
-          time: z.number().describe('The time in seconds of the keyframe to remove')
+          time: z.number().describe('The time in sequence-timeline seconds of the keyframe to remove (same space as add_keyframe\'s time)')
         })
       },
       {
         name: 'get_keyframes',
-        description: 'Gets all keyframes for a clip component parameter.',
+        description: 'Gets all keyframes for a clip component parameter. Returned keyframe times are in sequence-timeline seconds (same space as add_keyframe\'s time).',
         inputSchema: z.object({
           clipId: z.string().describe('The ID of the clip'),
           componentName: z.string().describe('The display name of the component'),
@@ -6978,9 +6978,10 @@ export class PremiereProTools {
           }
         }
         if (!param) return JSON.stringify({ success: false, error: "Parameter " + ${JSON.stringify(paramName)} + " not found in component " + ${JSON.stringify(componentName)} });
+        var __clipTime = __seqTimeToClipTime(clip, ${time});
         param.setTimeVarying(true);
-        param.addKey(${time});
-        param.setValueAtKey(${time}, ${value}, true);
+        param.addKey(__clipTime);
+        param.setValueAtKey(__clipTime, ${value}, true);
         return JSON.stringify({
           success: true,
           message: "Keyframe added",
@@ -7016,7 +7017,7 @@ export class PremiereProTools {
           }
         }
         if (!param) return JSON.stringify({ success: false, error: "Parameter not found" });
-        param.removeKey(${time});
+        param.removeKey(__seqTimeToClipTime(clip, ${time}));
         return JSON.stringify({
           success: true,
           message: "Keyframe removed",
@@ -7058,11 +7059,12 @@ export class PremiereProTools {
             staticValue: param.getValue()
           });
         }
-        var keys = param.getKeys();
+        var keys = param.getKeys() || [];
         var result = [];
         for (var k = 0; k < keys.length; k++) {
+          var __seqSeconds = __clipTimeToSeqTime(clip, keys[k].seconds);
           result.push({
-            time: keys[k],
+            time: { seconds: __seqSeconds, ticks: __secondsToTicks(__seqSeconds) },
             value: param.getValueAtKey(keys[k])
           });
         }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3473,20 +3473,38 @@ export class PremiereProTools {
         } catch (speedError) {}
         // The requested timeline duration cannot exceed how much real source media
         // remains past inPoint. Read the project item's authoritative master-clip
-        // out point (NOT the possibly-already-desynced clip.outPoint on this track
+        // in/out (NOT the possibly-already-desynced clip.outPoint on this track
         // item) so we never write an outPoint past the real media boundary.
         var maxSourceOutSeconds = null;
+        var minSourceInSeconds = null;
         try {
           var sourceProjectItem = clip.projectItem;
           if (sourceProjectItem && sourceProjectItem.getOutPoint) {
             var masterOutTime = sourceProjectItem.getOutPoint();
             maxSourceOutSeconds = secondsOf(masterOutTime);
           }
+          if (sourceProjectItem && sourceProjectItem.getInPoint) {
+            var masterInTime = sourceProjectItem.getInPoint();
+            minSourceInSeconds = secondsOf(masterInTime);
+          }
         } catch (mediaBoundsError) {}
+        // Still images (and other generators with no fixed media length) get their
+        // TrackItem inPoint/outPoint anchored around an arbitrary large offset
+        // (commonly ~3600s) by Premiere, completely independent of the project
+        // item's own reported in/out (typically 0..defaultStillDuration). Comparing
+        // those two coordinate spaces directly produces nonsense (e.g. a negative
+        // "max achievable duration"), which then makes the clip.end write below
+        // throw. Only trust the media-boundary clamp when clip.inPoint actually
+        // falls inside the project item's own [inPoint, outPoint] span, i.e. the
+        // two are provably expressed in the same coordinate frame.
+        var boundaryCoordinatesReliable =
+          maxSourceOutSeconds !== null && minSourceInSeconds !== null && before.inPoint !== null &&
+          before.inPoint >= (minSourceInSeconds - 0.000001) &&
+          before.inPoint <= (maxSourceOutSeconds + 0.000001);
         var mediaBoundaryHit = false;
         var maxAchievableDurationSeconds = null;
         var effectiveTargetDuration = targetDuration;
-        if (maxSourceOutSeconds !== null && before.inPoint !== null) {
+        if (boundaryCoordinatesReliable) {
           var maxDurationFromMedia = (maxSourceOutSeconds - before.inPoint) / speedFactor;
           if (targetDuration > maxDurationFromMedia + 0.000001) {
             mediaBoundaryHit = true;


### PR DESCRIPTION
## Summary
- `trim_clip` (duration param) wrote `clip.end` but never re-synced `outPoint`, so `outPoint - inPoint` drifted from the applied timeline duration. Premiere's own UI trim-drag reads that stale `outPoint` as "no media handle left" and refuses to let a user manually extend a clip that was shortened this way — that's the real-world bug this started from. `outPoint` is now explicitly re-synced whenever `duration` is requested (self-healing clips left desynced by the old behavior), gated so clip types that silently ignore `.end` writes (Graphics/MOGRTs) aren't pushed out of sync in the other direction.
- Added a real media-boundary check against the project item's authoritative out point, so a requested duration can never write an `outPoint` past real source media (`mediaBoundaryHit` / `maxAchievableDurationSeconds` reported instead of silently clamping/failing oddly).
- `move_clip`'s `newTrackIndex` was accepted by the schema but never wired up — a cross-track move request silently became a same-track time-only move. Implemented a real cross-track move (remove + `Sequence.overwriteClip`, same technique `move_clip_to_track` already uses), and fixed two bugs found while live-testing it:
  - post-move re-identification compared `candidate.projectItem !== projectItem` by reference — ExtendScript returns a fresh proxy object per property access, so this always failed and made every successful cross-track move report `MOVE_TRACK_LOST` regardless of outcome. Fixed to match by `projectItem.nodeId`.
  - `Sequence.overwriteClip()` always inserts the project item's full in/out range, silently discarding the clip's existing trim. The original inPoint/outPoint are now captured before the move and re-applied afterward (`restoredTrimAfterMove`, with `MOVE_TRIM_NOT_RESTORED` if the re-apply doesn't verifiably match).
- `move_clip` now verifies the clip's actual post-move position/track instead of trusting the requested values — Premiere can silently clamp or reject a move (e.g. a timeline collision), which was previously reported back as `success: true`.
- `add_keyframe` / `remove_keyframe` / `get_keyframes` (and `remove_keyframe_range` / `set_keyframe_interpolation`) were passing the caller's time straight into Premiere's `ComponentParam` keyframe APIs (`addKey`/`setValueAtKey`/`removeKey`/`getKeys`). Those APIs actually expect time in the clip's own **source/master-clip time base** (matching `inPoint`/`outPoint`), not sequence-timeline position — a still image's source time defaults to a 1-hour (3600s) offset in Premiere. Every caller passing an intuitive sequence-timeline time (e.g. the clip's `start`/`end` from `get_selected_clips`) ended up with keyframes silently placed far outside the clip's actual in/out range, so the property just held its last value with no visible animation and no visible keyframe diamonds in Effect Controls. Added `__seqTimeToClipTime`/`__clipTimeToSeqTime` conversion helpers and applied them at the read/write boundary of all five tools, so `time` is now consistently sequence-timeline seconds in and out (matching the rest of the API), with the source-time conversion handled internally. Also fixed `get_keyframes` throwing when `getKeys()` returns `undefined` for a time-varying property with zero keys left (e.g. right after removing its last keyframe).

## Context
Found while using these tools to shorten and reflow a batch of clips on a real timeline — the user then couldn't manually drag-trim the shortened clips in the Premiere UI at all, even clips sitting alone with no adjacent-clip collision. Traced to the outPoint desync above via live `get_clip_properties` reads against a running Premiere Pro 26.3.2 project, not just the tools' own reported success.

The keyframe bug surfaced the same way: added a Scale keyframe animation to a still-image clip, tool reported success and `get_keyframes` read back the expected values, but Premiere's Effect Controls panel showed a static, unanimated value. Compared against a clip keyframed manually in the Premiere UI and found its keyframe times sat at a completely different time base (~3600s) than what this tool had written (sequence-timeline seconds) — confirmed via direct ExtendScript queries against the live project, not just the wrapper tools.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 154/154 passing (3 new/updated tests covering the move_clip verification, cross-track re-id/trim-restore, and trim_clip outPoint sync)
- [x] Live-tested against a running Premiere Pro 26.3.2 project: `trim_clip` outPoint sync and media-boundary clamp verified via independent `get_clip_properties` reads; `move_clip` cross-track move tested end-to-end (moved a clip to an empty track and back, confirmed `clipIdChanged`, `restoredTrimAfterMove`, and final in/out/position all matched the original)
- [x] Live-tested the keyframe fix: added a two-keyframe Scale animation (100→108) to a clip via `add_keyframe` using sequence-timeline seconds, confirmed via `get_keyframes` the reported time matched the requested sequence time (not the ~3600s source-time offset), and confirmed in the Premiere UI that Effect Controls now shows both keyframe diamonds with the scale actually animating across the clip
